### PR TITLE
fix wrong upcast in case of a pgx image has signed 16bits pixels

### DIFF
--- a/source/apps/imgcmp/image_class.hpp
+++ b/source/apps/imgcmp/image_class.hpp
@@ -275,9 +275,9 @@ class image {
           for (uint_fast32_t i_in = 0, i_out = 0; i_out < num_samples; i_in += nbytes, ++i_out) {
             if (isSigned) {
               if (isBigendian) {
-                this->data[i_out] = (int_fast16_t)((buf[i_in] << 8) | buf[i_in + 1]);
+                this->data[i_out] = static_cast<int_least16_t>((static_cast<uint_least16_t>(buf[i_in]) << 8) | static_cast<uint_least16_t>(buf[i_in + 1]));
               } else {
-                this->data[i_out] = (int_fast16_t)(buf[i_in] | (buf[i_in + 1] << 8));
+                this->data[i_out] = static_cast<int_least16_t>(static_cast<uint_least16_t>(buf[i_in]) | (static_cast<uint_least16_t>(buf[i_in + 1]) << 8));
               }
             } else {
               if (isBigendian) {


### PR DESCRIPTION
The former code does not correctly work in Linux GCC environment due to this wrong upcasting.
