### PR TITLE
Replace `__clz()` with `__builtin_clz()` for the purpose of portability within ARM architectures

### DIFF
--- a/source/core/common/utils.hpp
+++ b/source/core/common/utils.hpp
@@ -74,7 +74,7 @@ static inline uint32_t int_log2(const uint32_t x) {
   asm("bsr %1, %0" : "=r"(y) : "r"(x));
   #endif
 #elif (defined(__arm64__) || defined(__arm__)) && defined(__ARM_FEATURE_CLZ)
-  y = 31 - __clz(x);
+  y = 31 - __builtin_clz(x);
 #endif
   return y;
 }
@@ -88,7 +88,7 @@ static inline uint32_t count_leading_zeros(const uint32_t x) {
   // avoid undefined behaviour
   return (x == 0) ? 32 : __builtin_clz(x);
 #elif defined(__ARM_FEATURE_CLZ)
-  return __clz(x);
+  return __builtin_clz(x);
 #else
   return 31 - int_log2(x);
 #endif


### PR DESCRIPTION
This PR is for platforms based on ARM architecure. Using `__clz()` directly may cause a compilation error for some platforms, so replace it with a more portable built-in function defined in major compilers.