### PR TITLE
Improvement on signalling of QCD and QCC markers + buffering for DWT

### DIFF
--- a/source/core/codestream/j2kmarkers.cpp
+++ b/source/core/codestream/j2kmarkers.cpp
@@ -500,9 +500,13 @@ QCD_marker::QCD_marker(j2c_src_memory &in) : j2k_marker_io_base(_QCD), Sqcd(0) {
 }
 
 QCD_marker::QCD_marker(uint8_t number_of_guardbits, uint8_t dwt_levels, uint8_t transformation,
-                       bool is_derived, uint8_t RI, uint8_t use_ycc, double basestep)
+                       bool is_derived, uint8_t RI, uint8_t use_ycc, double basestep, uint8_t qfactor)
     : j2k_marker_io_base(_QCD), Sqcd(0), is_reversible(transformation == 1) {
   unsigned long n;
+  if (is_derived && qfactor != 0xFF) {
+    is_derived = false;
+    // TODO: show warning??
+  }
   if (is_reversible) {
     Lmar = 4 + 3 * dwt_levels;
     n    = 3 * dwt_levels + 1;
@@ -532,6 +536,18 @@ QCD_marker::QCD_marker(uint8_t number_of_guardbits, uint8_t dwt_levels, uint8_t 
                                      1.205898036472720,  -0.533728236885750,
                                      -0.156446533057980, 0.033728236885750,
                                      0.053497514821622};  // gain is doubled(x2)
+
+  // Square roots of the visual weighting factors for 4:4:4 YCbCr content
+  const double W_b_sqrt[3][15] = {{0.0901, 0.2758, 0.2758, 0.7018, 0.8378, 0.8378, 1.0000, 1.0000, 1.0000,
+                                   1.0000, 1.0000, 1.0000, 1.0000, 1.0000, 1.0000},
+                                  {0.0263, 0.0863, 0.0863, 0.1362, 0.2564, 0.2564, 0.3346, 0.4691, 0.4691,
+                                   0.5444, 0.6523, 0.6523, 0.7078, 0.7797, 0.7797},
+                                  {0.0773, 0.1835, 0.1835, 0.2598, 0.4130, 0.4130, 0.5040, 0.6464, 0.6464,
+                                   0.7220, 0.8254, 0.8254, 0.8769, 0.9424, 0.9424}};
+
+  // The squared Euclidean norm of the multi-component synthesis operator that represents the contribution
+  // of component 𝑐 (e.g., Y, Cb or Cr) to reconstructed image samples (usually R, G and B)
+  const double G_c_sqrt[3] = {1.7321, 1.8051, 1.5734};
 
   double gain_low = 0.0, gain_high = 0.0;
 
@@ -602,27 +618,86 @@ QCD_marker::QCD_marker(uint8_t number_of_guardbits, uint8_t dwt_levels, uint8_t 
     }
   } else {
     // lossy
-    for (int i = 0; i < epsilon.size(); ++i) {
-      int32_t eps, m;
-      double fval = basestep / sqrt(wmse_or_BIBO[i]);
-      for (eps = 0; fval < 1.0; eps++) {
-        fval *= 2.0;
+    if (qfactor == 0xFF) {
+      for (int i = 0; i < epsilon.size(); ++i) {
+        int32_t exponent, mantissa;
+        double fval = basestep / sqrt(wmse_or_BIBO[i]);
+        for (exponent = 0; fval < 1.0; exponent++) {
+          fval *= 2.0;
+        }
+        mantissa = static_cast<int32_t>(floor((fval - 1.0) * static_cast<double>(1 << 11) + 0.5));
+        if (mantissa >= (1 << 11)) {
+          mantissa = 0;
+          exponent--;
+        }
+        if (exponent > 31) {
+          exponent = 31;
+          mantissa = 0;
+        }
+        if (exponent < 0) {
+          exponent = 0;
+          mantissa = (1 << 11) - 1;
+        }
+        epsilon[epsilon.size() - i - 1] = exponent;
+        mu[epsilon.size() - i - 1]      = mantissa;
       }
-      m = static_cast<int32_t>(floor((fval - 1.0) * static_cast<double>(1 << 11) + 0.5));
-      if (m >= (1 << 11)) {
-        m = 0;
-        eps--;
+    } else {
+      // lossy with qfactor: The detail of Qfactor feature is described in HTJ2K white paper at
+      // https://htj2k.com/wp-content/uploads/white-paper.pdf
+      double M_Q;
+      uint8_t t0 = 65, t1 = 97;
+      const double alpha_T0 = 0.04;
+      const double alpha_T1 = 0.10;
+      const double M_T0     = 2.0 * (1.0 - t0 / 100.0);
+      const double M_T1     = 2.0 * (1.0 - t1 / 100.0);
+      double alpha_Q        = alpha_T0;
+      double qfactor_power  = 1.0;
+
+      if (qfactor < 50) {
+        M_Q = 50.0 / qfactor;
+      } else {
+        M_Q = 2.0 * (1.0 - qfactor / 100.0);
       }
-      if (eps > 31) {
-        eps = 31;
-        m   = 0;
+      // adjust the scaling
+      if (qfactor >= t1) {
+        qfactor_power = 0.0;
+        alpha_Q       = alpha_T1;
+      } else if (qfactor > t0) {
+        qfactor_power = (log(M_T1) - log(M_Q)) / (log(M_T1) - log(M_T0));
+        alpha_Q       = alpha_T1 * pow(alpha_T0 / alpha_T1, qfactor_power);
       }
-      if (eps < 0) {
-        eps = 0;
-        m   = (1 << 11) - 1;
+
+      const double eps0 = sqrt(0.5) / static_cast<double>(1 << RI);
+      double delta_Q    = alpha_Q * M_Q + eps0;
+      double delta_ref  = delta_Q * G_c_sqrt[0];
+      double G_c        = G_c_sqrt[0];  // gain of color transform
+      for (int i = 0; i < epsilon.size(); ++i) {
+        int32_t exponent, mantissa;
+        double w_b;
+        // w_b for LL band shall be 1.0
+        w_b = (i == epsilon.size() - 1) ? 1.0 : pow(W_b_sqrt[0][i], qfactor_power);
+
+        double fval = (qfactor != 0xFF) ? delta_ref / (sqrt(wmse_or_BIBO[i]) * w_b * G_c)
+                                        : basestep / sqrt(wmse_or_BIBO[i]);
+        for (exponent = 0; fval < 1.0; exponent++) {
+          fval *= 2.0;
+        }
+        mantissa = static_cast<int32_t>(floor((fval - 1.0) * static_cast<double>(1 << 11) + 0.5));
+        if (mantissa >= (1 << 11)) {
+          mantissa = 0;
+          exponent--;
+        }
+        if (exponent > 31) {
+          exponent = 31;
+          mantissa = 0;
+        }
+        if (exponent < 0) {
+          exponent = 0;
+          mantissa = (1 << 11) - 1;
+        }
+        epsilon[epsilon.size() - i - 1] = exponent;
+        mu[epsilon.size() - i - 1]      = mantissa;
       }
-      epsilon[epsilon.size() - i - 1] = eps;
-      mu[epsilon.size() - i - 1]      = m;
     }
   }
 
@@ -1388,7 +1463,7 @@ j2k_main_header::j2k_main_header(SIZ_marker *siz, COD_marker *cod, QCD_marker *q
       printf("feature Qfactor is only available for gray-scale or color images.\n");
       exit(EXIT_FAILURE);
     }
-    for (uint16_t c = 0; c < siz->get_num_components(); ++c) {
+    for (uint16_t c = 1; c < siz->get_num_components(); ++c) {
       QCC.push_back(std::make_unique<QCC_marker>(
           siz->get_num_components(), c, qcd->get_number_of_guardbits(), cod->get_dwt_levels(),
           cod->get_transformation(), false, siz->get_bitdepth(c), cod->use_color_trafo(), qfactor));

--- a/source/core/codestream/j2kmarkers.hpp
+++ b/source/core/codestream/j2kmarkers.hpp
@@ -205,7 +205,7 @@ class QCD_marker : public j2k_marker_io_base {
  public:
   explicit QCD_marker(j2c_src_memory &in);
   QCD_marker(uint8_t number_of_guardbits, uint8_t dwt_levels, uint8_t transformation, bool is_derived,
-             uint8_t RI, uint8_t use_ycc, double basestep = 1.0 / 256.0);
+             uint8_t RI, uint8_t use_ycc, double basestep = 1.0 / 256.0, uint8_t qfactor = 0xFF);
   int write(j2c_destination_base &dst);
   uint8_t get_quantization_style() const;
   uint8_t get_exponents(uint8_t nb);

--- a/source/core/interface/encoder.cpp
+++ b/source/core/interface/encoder.cpp
@@ -85,15 +85,18 @@ size_t openhtj2k_encoder_impl::invoke() {
   }
   if (siz->Csiz != 3 && cod->use_color_trafo == 1) {
     cod->use_color_trafo = 0;
-    qfactor              = NO_QFACTOR;
     printf("WARNING: Cycc is set to 'no' because the number of components is not equal to 3.\n");
   }
   // force RGB->YCbCr when Qfactor feature is enabled
   if (qfactor != NO_QFACTOR) {
-    if (cod->use_color_trafo == 0) {
-      printf("WARNING: Color conversion is turned ON because Qfactor feature is enabled.\n");
+    if (siz->Csiz == 3) {
+      if (cod->use_color_trafo == 0) {
+        printf("WARNING: Color conversion is turned ON because Qfactor feature is enabled.\n");
+      }
+      cod->use_color_trafo = 1;
+    } else if (siz->Csiz != 1) {
+      printf("WARNING: Qfactor is designed for only gray-scale or RGB input.\n");
     }
-    cod->use_color_trafo = 1;
   }
 
   // create required marker segments
@@ -103,7 +106,7 @@ size_t openhtj2k_encoder_impl::invoke() {
                       cod->number_of_layers, cod->use_color_trafo, cod->dwt_levels, cod->blkwidth,
                       cod->blkheight, cod->codeblock_style, cod->transformation, cod->PPx, cod->PPy);
   QCD_marker main_QCD(qcd->number_of_guardbits, cod->dwt_levels, cod->transformation, qcd->is_derived,
-                      bit_depth[0], cod->use_color_trafo, qcd->base_step);
+                      bit_depth[0], cod->use_color_trafo, qcd->base_step, qfactor);
   // parameters for CAP marker
   uint16_t bits14_15 = 0;                     // 0: HTONLY, 2: HTDECLARED, 3: MIXED
   uint16_t bit13     = 0;                     // 0: SINGLEHT, 1: MULTIHT

--- a/source/core/transform/fdwt.cpp
+++ b/source/core/transform/fdwt.cpp
@@ -87,16 +87,14 @@ static fdwt_1d_filtr_func_fixed fdwt_1d_filtr_fixed[2] = {fdwt_1d_filtr_irrev97_
                                                           fdwt_1d_filtr_rev53_fixed};
 
 // 1-dimensional FDWT
-static inline void fdwt_1d_sr_fixed(int16_t *in, int16_t *out, const int32_t left, const int32_t right,
+static inline void fdwt_1d_sr_fixed(int16_t *buf, int16_t *in, int16_t *out, const int32_t left, const int32_t right,
                                     const uint32_t i0, const uint32_t i1, const uint8_t transformation) {
-  const uint32_t len = round_up(i1 - i0 + left + right, SIMD_LEN_I16);
-  auto *Xext         = static_cast<int16_t *>(aligned_mem_alloc(sizeof(int16_t) * len, 32));
-  // auto *Yext         = static_cast<int16_t *>(aligned_mem_alloc(sizeof(int16_t) * len, 32));
-  dwt_1d_extr_fixed(Xext, in, left, right, i0, i1);
-  fdwt_1d_filtr_fixed[transformation](Xext, left, right, i0, i1);
-  memcpy(out, Xext + left, sizeof(int16_t) * (i1 - i0));
-  aligned_mem_free(Xext);
-  // aligned_mem_free(Yext);
+//  const uint32_t len = round_up(i1 - i0 + left + right, SIMD_LEN_I16);
+//  auto *Xext         = static_cast<int16_t *>(aligned_mem_alloc(sizeof(int16_t) * len, 32));
+  dwt_1d_extr_fixed(buf, in, left, right, i0, i1);
+  fdwt_1d_filtr_fixed[transformation](buf, left, right, i0, i1);
+  memcpy(out, buf + left, sizeof(int16_t) * (i1 - i0));
+//  aligned_mem_free(Xext);
 }
 
 // FDWT for horizontal direction
@@ -121,10 +119,13 @@ static void fdwt_hor_sr_fixed(int16_t *out, int16_t *in, const uint32_t u0, cons
     }
   } else {
     // need to perform symmetric extension
+    const uint32_t len = round_up(u1 - u0 + left + right, SIMD_LEN_I16);
+    auto *Xext         = static_cast<int16_t *>(aligned_mem_alloc(sizeof(int16_t) * len, 32));
     //#pragma omp parallel for
     for (uint32_t row = 0; row < v1 - v0; ++row) {
-      fdwt_1d_sr_fixed(&in[row * stride], &out[row * stride], left, right, u0, u1, transformation);
+      fdwt_1d_sr_fixed(Xext, &in[row * stride], &out[row * stride], left, right, u0, u1, transformation);
     }
+    aligned_mem_free(Xext);
   }
 }
 


### PR DESCRIPTION
This PR contains:
- improvement on signalling QCD and QCC markers that reduces the length of the main header when Qfactor feature is on.
- changes on buffering method for horizontal DWT that slightly improves speed.
