### PR TITLE
set library and runtime output bin directory inside root binary directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,8 +54,8 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Intel")
 	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -Ofast -parallel -qopenmp -ipo -liomp5")
 endif()
 
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/../bin)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/../bin)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 #### Source files settings "libopen_htj2k" shared library target
 add_library(open_htj2k ${SOURCES})


### PR DESCRIPTION
When OpenHTJ2K is one of many binary directories for different cmake
projects, it makes it easier to manage the binary outputs from the
different projects if each project stores its outputs inside its own
root cmake binary directory. Currently, the project stores outputs one level
above root binary directory.