### PR TITLE
make HIGHWAY deprecated

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ target_include_directories(open_htj2k
 		)
 set_target_properties(open_htj2k PROPERTIES OUTPUT_NAME $<IF:$<CONFIG:Debug>,open_htj2k_d,open_htj2k_R>)
 #target_link_libraries(open_htj2k PUBLIC ${CMAKE_THREAD_LIBS_INIT} PRIVATE hwy)
+target_link_libraries(open_htj2k PUBLIC ${CMAKE_THREAD_LIBS_INIT})
 
 #find_package(OpenMP)
 #if(OpenMP_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcolor-diagnostics")
 endif()
 
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/source/thirdparty/highway EXCLUDE_FROM_ALL)
+#add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/source/thirdparty/highway EXCLUDE_FROM_ALL)
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -90,9 +90,10 @@ target_include_directories(open_htj2k
 		source/core/transform
 		source/core/interface
 		source/core/jph
-		${CMAKE_CURRENT_SOURCE_DIR}/source/thirdparty/highway)
+		#${CMAKE_CURRENT_SOURCE_DIR}/source/thirdparty/highway
+		)
 set_target_properties(open_htj2k PROPERTIES OUTPUT_NAME $<IF:$<CONFIG:Debug>,open_htj2k_d,open_htj2k_R>)
-target_link_libraries(open_htj2k PUBLIC ${CMAKE_THREAD_LIBS_INIT} PRIVATE hwy)
+#target_link_libraries(open_htj2k PUBLIC ${CMAKE_THREAD_LIBS_INIT} PRIVATE hwy)
 
 #find_package(OpenMP)
 #if(OpenMP_FOUND)

--- a/source/core/coding/coding_units.cpp
+++ b/source/core/coding/coding_units.cpp
@@ -39,7 +39,7 @@
 ThreadPool *ThreadPool::singleton = nullptr;
 std::mutex ThreadPool::singleton_mutex;
 
-#include <hwy/highway.h>
+//#include <hwy/highway.h>
 
 float bibo_step_gains[32][5] = {{1.00000000, 4.17226868, 1.44209458, 2.10966980, 1.69807026},
                                 {1.38034954, 4.58473765, 1.83866981, 2.13405021, 1.63956779},


### PR DESCRIPTION
commented out HIGHWAY related things because vectorization is done without it, and it is no longer necessary.