### PR TITLE
Fix for AVX2

### DIFF
--- a/source/core/common/utils.hpp
+++ b/source/core/common/utils.hpp
@@ -108,8 +108,10 @@ static inline uint32_t count_leading_zeros(const uint32_t x) {
   uint32_t y;
 #if defined(_MSC_VER)
   y = __lzcnt(x);
-#elif defined(OPENHTJ2K_TRY_AVX2) && defined(__AVX2__)
+#elif defined(OPENHTJ2K_TRY_AVX2) && defined(__AVX2__) && defined(_MSC_VER) && defined(_WIN32)
   y         = _lzcnt_u32(x);
+#elif defined(OPENHTJ2K_TRY_AVX2) && defined(__AVX2__) && defined(__MINGW32__)
+  y              = __builtin_ia32_lzcnt_u32(x);
 #elif defined(__MINGW32__) || defined(__MINGW64__)
   y              = __builtin_clz(x);
 #elif defined(OPENHTJ2K_ENABLE_ARM_NEON)


### PR DESCRIPTION
gcc 11.3 has to be added (-mlzcnt)