### PR TITLE
Fix for signed input

### DIFF
--- a/source/core/codestream/j2kmarkers.cpp
+++ b/source/core/codestream/j2kmarkers.cpp
@@ -494,6 +494,9 @@ RGN_marker::RGN_marker(j2c_src_memory &in, uint16_t Csiz) : j2k_marker_io_base(_
     len++;
     len++;
   }
+  if (len != 5 && len != 6) {
+    // TODO: generate Length error (Lrgn shall be 5 or 6).
+  }
   Srgn = get_byte();
   assert(Srgn == 0);
   SPrgn  = get_byte();

--- a/source/core/coding/coding_units.cpp
+++ b/source/core/coding/coding_units.cpp
@@ -1550,6 +1550,9 @@ void j2k_tile_component::create_resolutions(uint16_t numlayers) {
 }
 
 void j2k_tile_component::perform_dc_offset(const uint8_t transformation, const bool is_signed) {
+  if (is_signed) {
+    return;
+  }
   const int32_t shiftup = (transformation) ? 0 : FRACBITS - this->bitdepth;
   if (shiftup < 0) {
     printf("WARNING: Over 13 bpp precision will be down-shifted to 12 bpp.\n");
@@ -2724,7 +2727,7 @@ void j2k_tile::finalize(j2k_main_header &hdr, uint8_t reduce_NL, std::vector<int
       printf("WARNING: sample precision over 13 bit/pixel is not supported.\n");
     }
     // tentative workaround for negative downshift value
-    // TODO: fix this
+    // TODO: expand internal precisions to fix this problem
     int16_t offset      = (downshift < 0) ? static_cast<int16_t>((1 << -downshift) >> 1)
                                           : static_cast<int16_t>((1 << downshift) >> 1);
     int32_t *const src  = tcomp[c].get_sample_address(0, 0);

--- a/source/core/interface/encoder.cpp
+++ b/source/core/interface/encoder.cpp
@@ -596,7 +596,8 @@ size_t openhtj2k_encoder_impl::invoke() {
                       static_cast<uint8_t>(cod->blkwidth), static_cast<uint8_t>(cod->blkheight),
                       cod->codeblock_style, cod->transformation, cod->PPx, cod->PPy);
   QCD_marker main_QCD(qcd->number_of_guardbits, cod->dwt_levels, cod->transformation, qcd->is_derived,
-                      static_cast<uint8_t>(Ssiz[0] + 1U), cod->use_color_trafo, qcd->base_step, qfactor);
+                      static_cast<uint8_t>((Ssiz[0] & 0x7F) + 1U), cod->use_color_trafo, qcd->base_step,
+                      qfactor);
   // parameters for CAP marker
   uint16_t bits14_15 = 0;                     // 0: HTONLY, 2: HTDECLARED, 3: MIXED
   uint16_t bit13     = 0;                     // 0: SINGLEHT, 1: MULTIHT


### PR DESCRIPTION
This PR fixes the wrong treatment of bit-depth (Ssiz) for images having signed pixel values in the creation of the QCD marker at encoding.