### PR TITLE
    docs: update README for v0.4.0      - Document line-based streami…

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,97 +5,125 @@
 OpenHTJ2K is an open source implementation of ITU-T Rec.814 | ISO/IEC 15444-15 (a.k.a. JPEG 2000 Part 15, High-Throughput JPEG 2000; HTJ2K)
 
 # What OpenHTJ2K provides
-OpenHTJ2K provides a shared liberary and sample applications having the following functionalities:
-- Decoding of ITU-T Rec.800 | ISO/IEC 15444-1 (JPEG 2000 Part 1) or ITU-T Rec.814 | ISO/IEC 15444-15 (JPEG 2000 Part 15.) compliant codestreams
-  - fully compliant with conformance testing defined in ITU-T Rec.803 | ISO 15444-4.
-- Encoding an image into a codestream/JPH file which is compliant with HTJ2K
-  - currently supports only HTJ2K. The optional markers like COC, POC, etc. are not implemented.
-  - encoding of HT SigProp and MagRef passes are not implemented.
-  - up to **12 bit** per component sample is currently supported. 
-  - **Quality control for lossy compression with ***Qfactor*** feature** 
+OpenHTJ2K provides a shared library and sample applications with the following features:
+
+**Decoding**
+- Decodes ITU-T Rec.800 | ISO/IEC 15444-1 (JPEG 2000 Part 1) and ITU-T Rec.814 | ISO/IEC 15444-15 (HTJ2K) codestreams
+- Fully compliant with conformance testing defined in ITU-T Rec.803 | ISO 15444-4
+- Three decode APIs:
+  - `invoke()` — batch (full-image) path
+  - `invoke_line_based()` — streaming row-by-row output via callback, using per-subband ring buffers
+  - `invoke_line_based_stream()` — streaming path for multi-tile images, assembling full-width rows
+- The line-based path is the default; the batch path is available with the `-batch` flag
+
+**Encoding**
+- Encodes into HTJ2K-compliant codestreams (.jhc/.j2c) and JPH files (.jph)
+- Optional markers (COC, POC, etc.) and HT SigProp/MagRef passes are not implemented
+- Up to **16 bit** per component sample supported
+- Quality control for lossy compression via the `Qfactor` parameter
+- Two encode APIs:
+  - `invoke()` — batch (full-image) path
+  - `invoke_line_based_stream()` — streaming push-row path driven by a source callback
+
+**Performance**
+- DWT internal precision is float32 throughout (FDWT and IDWT)
+- SIMD acceleration: AVX2 (x86-64) and NEON (AArch64) for DWT and color transforms
+- Multi-threaded encode and decode via a built-in thread pool
 
 # Requirements
-cmake (version 3.14 or later) and C++11 compliant compiler.
+cmake (version 3.14 or later) and a C++17 compliant compiler.
 
 # Building
-Type the following command. `./` is a root of cloned repository and `${BUILD_DIR}` is a build directory (for example, `../build` or `./build` and so on)
+`./` is the root of the cloned repository and `${BUILD_DIR}` is a build directory (e.g. `../build` or `./build`).
 
-- You can also specify `-DCMAKE_BUILD_TYPE=Debug` or `-DCMAKE_BUILD_TYPE=RelWithDebInfo` to build with debug information.
-- You can also specify `-G "Xcode"` to create a project for Xcode.
-- You can also specify `-G "Visual Studio 17 2022"` to create a project for Visual Studio 2022. For the older versions,
-see https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html#visual-studio-generators
+- Specify `-DCMAKE_BUILD_TYPE=Debug` or `-DCMAKE_BUILD_TYPE=RelWithDebInfo` to include debug information.
+- Specify `-G "Xcode"` to generate an Xcode project.
+- Specify `-G "Visual Studio 17 2022"` for Visual Studio 2022. See
+  https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html#visual-studio-generators for other versions.
+- Specify `-DOPENHTJ2K_THREAD=ON` to enable multi-threaded encode/decode (recommended).
 
 ```
 cd ./
-cmake -G "Unix Makefiles" -B ${BUILD_DIR} -DCMAKE_BUILD_TYPE=Release
+cmake -G "Unix Makefiles" -B ${BUILD_DIR} -DCMAKE_BUILD_TYPE=Release -DOPENHTJ2K_THREAD=ON
 cd  ${BUILD_DIR}
 make
 ```
 
-Then the executables should be found in `${BUILD_DIR}/bin` directory.
+Executables are placed in `${BUILD_DIR}/bin`.
 
 # Usage
 ## Encoder
-Only Part 15 compliant encoding is supported. Both .j2c (codestream) and .jph (file format) are available. 
+Only Part 15 compliant encoding is supported. Both .j2c (codestream) and .jph (file format) are available.
 ```bash
-./open_htj2k_enc -i inputimage(in PNM/PGX/(TIFF, libtiff required) format) -o output [options...]
+./open_htj2k_enc -i input-image(s) -o output [options...]
 ```
-The encoder can take comma-separated multiple files. For example, components in YCbCr color space can be encoded by
+The encoder accepts comma-separated multiple input files. For example, to encode YCbCr components:
 ```
-./open_htj2k_enc -i inputY.pgx,inputCb.pgx,inputCr.pgx -o output 
+./open_htj2k_enc -i inputY.pgx,inputCb.pgx,inputCr.pgx -o output
 ```
 
-### options
+### Options
 - `Stiles=Size`
-  - Size of tile "{height, width}", Default is equal to the image size
+  - Tile size in `{height,width}` format. Default is equal to the image size.
 - `Sorigin=Size`
-  - origin of the input image in the reference grid, Default is {0,0} 
+  - Offset from the reference grid origin to the image area. Default is `{0,0}`.
 - `Stile_origin=Size`
-  - origin of tiles in the reference grid, Default is {0,0}
+  - Offset from the reference grid origin to the first tile. Default is `{0,0}`.
 - `Clevels=Int`
-  - Valid range for number of DWT levels is from 0 to 32 (Default is **5**)
+  - Number of DWT decomposition levels. Valid range: 0–32. Default is **5**.
 - `Creversible=yes or no`
-  - `yes` for lossless mode, `no` for lossy mode, Default is **no**
+  - `yes` for lossless mode, `no` for lossy mode. Default is **no**.
 - `Cblk=Size`
-  - Code-block size, Default is **64x64**
+  - Code-block size. Default is **{64,64}**.
 - `Cprecincts=Size`
-  - Precinct size
+  - Precinct size. Must be a power of two.
 - `Cycc=yes or no`
-  - `yes` to use RGB->YCbCr, Default is **yes**
+  - `yes` to apply RGB→YCbCr color space conversion. Default is **yes**.
 - `Corder`
-  - Progression order: LRCP, RLCP, RPCL, PCRL, CPRL, Default is **LRCP**
+  - Progression order: `LRCP`, `RLCP`, `RPCL`, `PCRL`, `CPRL`. Default is **LRCP**.
 - `Cuse_sop=yes or no`
-  - Default is **no** 
+  - `yes` to insert SOP (Start Of Packet) marker segments. Default is **no**.
 - `Cuse_eph=yes or no`
-  - Default is **no**
+  - `yes` to insert EPH (End of Packet Header) markers. Default is **no**.
 - `Qstep=Float`
-  - 0.0 < base step size <= 2.0
+  - Base step size for quantization. Valid range: `0.0 < Qstep <= 2.0`.
 - `Qguard=Int`
-  - 0 to 7 for the number of guard bits, Default is **1** 
-- `Qderived=yes or no`
-  - `yes` switches the quantyzation style to **derived** (Default is `no`)
+  - Number of guard bits. Valid range: 0–8. Default is **1**.
 - `Qfactor=Int`
-  - 0 to 100 for the quality of the lossy compressed image
-  - for YCbCr inputs, valid chroma subsampling formats are 4:4:4, 4:2:0, and 4:2:2
+  - Quality factor for lossy compression. Valid range: 0–100 (100 = best quality).
+  - When specified, `Qstep` is ignored and `Cycc` is set to `yes`.
 - `-jph_color_space`
-  - Color space of input components: RGB, YCC
-  - if inputs are represented in YCbCr, use YCC
+  - Declare the color space of input components: `RGB` or `YCC`.
+  - Use `YCC` if the inputs are already in YCbCr.
 - `-num_threads Int`
-  - number of threads to use in encode or decode
-  - 0, which is the default, indicates usage of all threads
+  - Number of threads. `0` (default) uses all available hardware threads.
+- `-batch`
+  - Use the batch (full-image) encode path. Loads the entire image into memory before encoding.
+  - The default path is line-based (streaming).
 
 ## Decoder
-The both Part 1 and Part 15 compliant decoding are supported.
+Both Part 1 and Part 15 compliant decoding are supported.
 ```bash
-./open_htj2k_dec -i codestream -o outputimage [-reduce n: number of DWT level reduction]
+./open_htj2k_dec -i codestream -o output [options...]
 ```
-To see a help, use `-h` option.
 
-## Supported file types
-### Encoder
-- input image formats: .pgm, .ppm, .pgx, .tif (libtiff required)
-- output codestreams: .jhc (Part 15 codestream, .j2k and .j2c can be used as aliases), .jph (Part 15 file format)
-  - Note: Specifying .jph as the output triggers a JPH file creation, otherwise just a codestream will be generated.
-### Decoder
-- input codestreams : .j2k, .j2c, .jhc
-- output image formats: .raw, .ppm, .pgm, .pgx
+### Options
+- `-reduce n`
+  - Decode at a reduced resolution by skipping `n` DWT levels.
+- `-batch`
+  - Use the batch (full-image) decode path. The default path is line-based (streaming).
+
+## Supported file formats
+### Encoder input / Decoder output
+| Format | Encoder input | Decoder output |
+|--------|:---:|:---:|
+| PGM / PPM | ✓ | ✓ |
+| PGX | ✓ | ✓ |
+| TIFF (libtiff required, 8/16 bpp) | ✓ | |
+| RAW | | ✓ |
+
+### Codestream formats
+| Extension | Description |
+|-----------|-------------|
+| `.jhc`, `.j2c`, `.j2k` | HTJ2K / JPEG 2000 Part 1 codestream |
+| `.jph` | HTJ2K file format (JPH); specifying this as encoder output triggers JPH creation |


### PR DESCRIPTION
…ng decoder/encoder APIs     - Update feature list: float32 DWT, AVX2/NEON SIMD, up to 16-bit samples     - Add -batch flag, -reduce option, and -num_threads to options reference     - Replace separate Encoder/Decoder file-type lists with a unified table     - Note C++17 requirement and -DOPENHTJ2K_THREAD=ON in build instructions     - Remove stale Qderived option (not present in current CLI)

Updated README to enhance clarity and improve formatting for features, requirements, building instructions, usage examples, and supported file formats.