### PR TITLE
feat(rtp_recv): GL_R16 plane upload path for >8-bit sources

### DIFF
--- a/source/apps/rtp_recv/frame_pipeline.hpp
+++ b/source/apps/rtp_recv/frame_pipeline.hpp
@@ -120,14 +120,22 @@ class LatestSlot {
 //   - CPU_RGB: the decode worker ran YCbCr→RGB on the CPU and filled
 //     `rgb` with width*height*3 interleaved bytes.  Used by the
 //     --color-path=cpu fallback and by GL-incompatible environments.
-//   - PLANAR_YCBCR / PLANAR_RGB: the decode worker only shifted samples
-//     to 8-bit per plane and filled `plane_y/cb/cr`.  Luma dims are in
-//     `width/height`; chroma dims in `chroma_width/chroma_height`
-//     (which equal the luma dims for 4:4:4 / PLANAR_RGB).  The GPU
-//     shader applies the YCbCr→RGB matrix in the fragment stage.
+//   - PLANAR_YCBCR / PLANAR_RGB: the decode worker wrote per-plane
+//     samples into either the 8-bit or 16-bit plane vectors,
+//     selected by `bit_depth`.  Luma dims are in `width/height`;
+//     chroma dims in `chroma_width/chroma_height` (which equal the
+//     luma dims for 4:4:4 / PLANAR_RGB).  The GPU shader applies
+//     the YCbCr→RGB matrix in the fragment stage.
 //
-// `rgb` is left empty in the planar shapes and vice versa, so
-// std::move-ing a DecodedFrame does not copy unused buffers.
+//     - bit_depth == 8: `plane_y/cb/cr` hold uint8_t samples, the
+//       `_16` vectors are empty.  Uploaded as GL_R8 by the renderer.
+//     - bit_depth >  8: `plane_y_16/cb_16/cr_16` hold uint16_t samples
+//       (clamp-only, NOT shifted to 8-bit), the u8 vectors are empty.
+//       Uploaded as GL_R16 by the renderer.  The fragment shader
+//       renormalizes via uNormScale before bias/scale.
+//
+// The u8 and u16 vector sets are mutually exclusive per frame, so
+// std::move-ing a DecodedFrame only moves whichever set is populated.
 struct DecodedFrame {
   enum Kind : uint8_t {
     CPU_RGB      = 0,
@@ -135,14 +143,18 @@ struct DecodedFrame {
     PLANAR_RGB   = 2,
   };
 
-  std::vector<uint8_t>      rgb;       // CPU_RGB: width * height * 3 bytes
-  std::vector<uint8_t>      plane_y;   // PLANAR_*: width * height bytes
-  std::vector<uint8_t>      plane_cb;  // PLANAR_*: chroma_width * chroma_height bytes
-  std::vector<uint8_t>      plane_cr;  // PLANAR_*: chroma_width * chroma_height bytes
+  std::vector<uint8_t>      rgb;          // CPU_RGB: width * height * 3 bytes
+  std::vector<uint8_t>      plane_y;      // PLANAR_*, 8-bit source: width * height bytes
+  std::vector<uint8_t>      plane_cb;     // PLANAR_*, 8-bit source
+  std::vector<uint8_t>      plane_cr;     // PLANAR_*, 8-bit source
+  std::vector<uint16_t>     plane_y_16;   // PLANAR_*, >8-bit source: width * height shorts
+  std::vector<uint16_t>     plane_cb_16;  // PLANAR_*, >8-bit source
+  std::vector<uint16_t>     plane_cr_16;  // PLANAR_*, >8-bit source
   uint32_t                  width         = 0;  // luma width
   uint32_t                  height        = 0;  // luma height
   uint32_t                  chroma_width  = 0;  // 0 in CPU_RGB
   uint32_t                  chroma_height = 0;  // 0 in CPU_RGB
+  uint8_t                   bit_depth     = 8;  // luma bit depth; 0 in CPU_RGB
   Kind                      kind          = CPU_RGB;
   // For PLANAR_YCBCR: points at one of the static-const YCBCR_* constants
   // in ycbcr_rgb.hpp (BT601/709 × full/narrow).  Never owns.  Null in

--- a/source/apps/rtp_recv/gl_renderer.cpp
+++ b/source/apps/rtp_recv/gl_renderer.cpp
@@ -66,20 +66,26 @@ out vec4 fragColor;
 uniform sampler2D uY;
 uniform sampler2D uCb;
 uniform sampler2D uCr;
-uniform mat3      uMatrix;   // rgb = uMatrix * ((sample - uBias) * uScale)
-uniform vec3      uBias;     // per-plane bias in [0,1] (texture-normalized)
-uniform vec3      uScale;    // per-plane scale after bias subtraction
-uniform int       uRgbMode;  // 0 = YCbCr → RGB, 1 = treat planes as R/G/B
+uniform mat3      uMatrix;     // rgb = uMatrix * ((n - uBias) * uScale)
+uniform vec3      uBias;       // per-plane bias in [0,1] after renormalization
+uniform vec3      uScale;      // per-plane scale after bias subtraction
+uniform vec3      uNormScale;  // per-plane renorm factor (1.0 for R8,
+                               // 65535/((1<<depth)-1) for R16 with >8-bit src)
+uniform int       uRgbMode;    // 0 = YCbCr -> RGB, 1 = treat planes as R/G/B
 void main() {
   vec3 s;
   s.x = texture(uY,  vTexCoord).r;
   s.y = texture(uCb, vTexCoord).r;
   s.z = texture(uCr, vTexCoord).r;
+  // For R8 textures uNormScale is (1,1,1) and this is a no-op; for R16
+  // textures uNormScale restores the source's native [0,1] range before
+  // bias/scale math runs, so the rest of the shader is depth-agnostic.
+  vec3 n = s * uNormScale;
   vec3 rgb;
   if (uRgbMode == 1) {
-    rgb = s;
+    rgb = n;
   } else {
-    rgb = uMatrix * ((s - uBias) * uScale);
+    rgb = uMatrix * ((n - uBias) * uScale);
   }
   fragColor = vec4(clamp(rgb, 0.0, 1.0), 1.0);
 }
@@ -214,14 +220,15 @@ bool GlRenderer::compile_shader_programs() {
     prog_rgb_ = 0;
     return false;
   }
-  prog_ycbcr_     = prog_yc;
-  u_yc_y_tex_     = gl::GetUniformLocation(prog_ycbcr_, "uY");
-  u_yc_cb_tex_    = gl::GetUniformLocation(prog_ycbcr_, "uCb");
-  u_yc_cr_tex_    = gl::GetUniformLocation(prog_ycbcr_, "uCr");
-  u_yc_matrix_    = gl::GetUniformLocation(prog_ycbcr_, "uMatrix");
-  u_yc_bias_      = gl::GetUniformLocation(prog_ycbcr_, "uBias");
-  u_yc_scale_     = gl::GetUniformLocation(prog_ycbcr_, "uScale");
-  u_yc_rgb_mode_  = gl::GetUniformLocation(prog_ycbcr_, "uRgbMode");
+  prog_ycbcr_      = prog_yc;
+  u_yc_y_tex_      = gl::GetUniformLocation(prog_ycbcr_, "uY");
+  u_yc_cb_tex_     = gl::GetUniformLocation(prog_ycbcr_, "uCb");
+  u_yc_cr_tex_     = gl::GetUniformLocation(prog_ycbcr_, "uCr");
+  u_yc_matrix_     = gl::GetUniformLocation(prog_ycbcr_, "uMatrix");
+  u_yc_bias_       = gl::GetUniformLocation(prog_ycbcr_, "uBias");
+  u_yc_scale_      = gl::GetUniformLocation(prog_ycbcr_, "uScale");
+  u_yc_norm_scale_ = gl::GetUniformLocation(prog_ycbcr_, "uNormScale");
+  u_yc_rgb_mode_   = gl::GetUniformLocation(prog_ycbcr_, "uRgbMode");
 
   // Drain any residual error state from the compile/link sync point so
   // later per-frame glGetError checks (if added) don't see ghosts.
@@ -273,14 +280,17 @@ void GlRenderer::shutdown() {
     window_ = nullptr;
     glfwTerminate();
   }
-  tex_rgb_w_ = 0;
-  tex_rgb_h_ = 0;
-  tex_y_w_   = 0;
-  tex_y_h_   = 0;
-  tex_cb_w_  = 0;
-  tex_cb_h_  = 0;
-  tex_cr_w_  = 0;
-  tex_cr_h_  = 0;
+  tex_rgb_w_  = 0;
+  tex_rgb_h_  = 0;
+  tex_y_w_    = 0;
+  tex_y_h_    = 0;
+  tex_y_bpp_  = 0;
+  tex_cb_w_   = 0;
+  tex_cb_h_   = 0;
+  tex_cb_bpp_ = 0;
+  tex_cr_w_   = 0;
+  tex_cr_h_   = 0;
+  tex_cr_bpp_ = 0;
 }
 
 bool GlRenderer::check_gl_error(const char* context) const {
@@ -329,16 +339,21 @@ bool GlRenderer::ensure_rgb_texture(int w, int h) {
   return true;
 }
 
-bool GlRenderer::ensure_planar_textures(int w_y, int h_y, int w_c, int h_c) {
+bool GlRenderer::ensure_planar_textures(int w_y, int h_y, int w_c, int h_c, int bpp) {
   // A freshly-created texture has no backing store, so the glTexImage2D
   // step must run even when the cached (cur_w, cur_h) already match the
   // requested size.  The earlier version of this function shared Cb/Cr
   // tracking variables, which caused the Cr texture to skip allocation
   // on the first frame (Cb allocation updated the shared counters) and
   // the shader then sampled an incomplete texture — usually reading as
-  // all zeros, producing a strongly red-shifted output.
-  auto ensure_one = [this](const char* label, GLuint& tex, int& cur_w, int& cur_h,
-                           int w, int h) -> bool {
+  // all zeros, producing a strongly red-shifted output.  Each texture
+  // now owns its (w, h, bpp) triple so a depth swap on one plane cannot
+  // silently skip reallocation on the others either.
+  const GLint       internal = (bpp == 2) ? GL_R16 : GL_R8;
+  const GLenum      type     = (bpp == 2) ? GL_UNSIGNED_SHORT : GL_UNSIGNED_BYTE;
+  const char*       label_bpp = (bpp == 2) ? "R16" : "R8";
+  auto ensure_one = [&](const char* label, GLuint& tex, int& cur_w, int& cur_h,
+                        int& cur_bpp, int w, int h) -> bool {
     const bool fresh = (tex == 0);
     if (fresh) {
       glGenTextures(1, &tex);
@@ -356,18 +371,25 @@ bool GlRenderer::ensure_planar_textures(int w_y, int h_y, int w_c, int h_c) {
     } else {
       glBindTexture(GL_TEXTURE_2D, tex);
     }
-    if (fresh || w != cur_w || h != cur_h) {
-      glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-      glTexImage2D(GL_TEXTURE_2D, 0, GL_R8, w, h, 0, GL_RED, GL_UNSIGNED_BYTE, nullptr);
-      if (!check_gl_error("glTexImage2D(planar initial alloc)")) return false;
-      cur_w = w;
-      cur_h = h;
+    if (fresh || w != cur_w || h != cur_h || bpp != cur_bpp) {
+      // GL_UNPACK_ALIGNMENT matters for row padding: R8 rows are 1-byte
+      // aligned, R16 rows are naturally 2-byte aligned.
+      glPixelStorei(GL_UNPACK_ALIGNMENT, bpp);
+      glTexImage2D(GL_TEXTURE_2D, 0, internal, w, h, 0, GL_RED, type, nullptr);
+      if (!check_gl_error("glTexImage2D(planar initial alloc)")) {
+        std::fprintf(stderr, "gl_renderer: ensure_planar_textures(%s, %s) alloc failed\n",
+                     label, label_bpp);
+        return false;
+      }
+      cur_w   = w;
+      cur_h   = h;
+      cur_bpp = bpp;
     }
     return true;
   };
-  if (!ensure_one("Y",  tex_y_,  tex_y_w_,  tex_y_h_,  w_y, h_y)) return false;
-  if (!ensure_one("Cb", tex_cb_, tex_cb_w_, tex_cb_h_, w_c, h_c)) return false;
-  if (!ensure_one("Cr", tex_cr_, tex_cr_w_, tex_cr_h_, w_c, h_c)) return false;
+  if (!ensure_one("Y",  tex_y_,  tex_y_w_,  tex_y_h_,  tex_y_bpp_,  w_y, h_y)) return false;
+  if (!ensure_one("Cb", tex_cb_, tex_cb_w_, tex_cb_h_, tex_cb_bpp_, w_c, h_c)) return false;
+  if (!ensure_one("Cr", tex_cr_, tex_cr_w_, tex_cr_h_, tex_cr_bpp_, w_c, h_c)) return false;
   return true;
 }
 
@@ -424,7 +446,7 @@ void GlRenderer::upload_planar_and_draw(const uint8_t* y_plane, const uint8_t* c
                                         bool components_are_rgb) {
   if (!window_ || w_y <= 0 || h_y <= 0 || w_c <= 0 || h_c <= 0) return;
 
-  ensure_planar_textures(w_y, h_y, w_c, h_c);
+  if (!ensure_planar_textures(w_y, h_y, w_c, h_c, /*bpp=*/1)) return;
 
   // Upload Y.
   glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
@@ -437,6 +459,42 @@ void GlRenderer::upload_planar_and_draw(const uint8_t* y_plane, const uint8_t* c
   glBindTexture(GL_TEXTURE_2D, tex_cr_);
   glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w_c, h_c, GL_RED, GL_UNSIGNED_BYTE, cr_plane);
 
+  // 8-bit source: the texture value already lives in the sample's native
+  // [0, 1] range, so uNormScale is the identity.
+  const float norm_scale[3] = {1.0f, 1.0f, 1.0f};
+  draw_ycbcr_program(w_y, h_y, coeffs, components_are_rgb, norm_scale);
+}
+
+void GlRenderer::upload_planar_16_and_draw(const uint16_t* y_plane, const uint16_t* cb_plane,
+                                           const uint16_t* cr_plane, int w_y, int h_y,
+                                           int w_c, int h_c, int bit_depth,
+                                           const ycbcr_coefficients* coeffs,
+                                           bool components_are_rgb) {
+  if (!window_ || w_y <= 0 || h_y <= 0 || w_c <= 0 || h_c <= 0) return;
+  if (bit_depth < 9 || bit_depth > 16) return;  // caller routes 8-bit to the u8 path
+
+  if (!ensure_planar_textures(w_y, h_y, w_c, h_c, /*bpp=*/2)) return;
+
+  // R16 row pitch is 2-byte aligned.
+  glPixelStorei(GL_UNPACK_ALIGNMENT, 2);
+  glBindTexture(GL_TEXTURE_2D, tex_y_);
+  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w_y, h_y, GL_RED, GL_UNSIGNED_SHORT, y_plane);
+  glBindTexture(GL_TEXTURE_2D, tex_cb_);
+  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w_c, h_c, GL_RED, GL_UNSIGNED_SHORT, cb_plane);
+  glBindTexture(GL_TEXTURE_2D, tex_cr_);
+  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w_c, h_c, GL_RED, GL_UNSIGNED_SHORT, cr_plane);
+
+  // GL_R16 reads back as (sample / 65535).  Multiply by this factor in the
+  // shader to restore the sample's native [0, 1] range so the bias/scale/
+  // matrix math is depth-agnostic.
+  const float native_max    = static_cast<float>((1 << bit_depth) - 1);
+  const float k             = 65535.0f / native_max;
+  const float norm_scale[3] = {k, k, k};
+  draw_ycbcr_program(w_y, h_y, coeffs, components_are_rgb, norm_scale);
+}
+
+void GlRenderer::draw_ycbcr_program(int w_y, int h_y, const ycbcr_coefficients* coeffs,
+                                    bool components_are_rgb, const float* norm_scale) {
   gl::UseProgram(prog_ycbcr_);
   gl::ActiveTexture(GL_TEXTURE0);
   glBindTexture(GL_TEXTURE_2D, tex_y_);
@@ -448,6 +506,7 @@ void GlRenderer::upload_planar_and_draw(const uint8_t* y_plane, const uint8_t* c
   glBindTexture(GL_TEXTURE_2D, tex_cr_);
   gl::Uniform1i(u_yc_cr_tex_, 2);
 
+  gl::Uniform3fv(u_yc_norm_scale_, 1, norm_scale);
   gl::Uniform1i(u_yc_rgb_mode_, components_are_rgb ? 1 : 0);
 
   if (!components_are_rgb && coeffs != nullptr) {
@@ -466,10 +525,10 @@ void GlRenderer::upload_planar_and_draw(const uint8_t* y_plane, const uint8_t* c
     };
     gl::UniformMatrix3fv(u_yc_matrix_, 1, GL_FALSE, mat);
 
-    // Bias and scale applied as `(sample - bias) * scale` where sample
-    // is the texture value in [0,1].  The CPU uploads an 8-bit plane so
-    // we compute bias/scale for 8-bit samples regardless of the source
-    // bit depth.
+    // Bias / scale in the sample's native [0, 1] range.  uNormScale above
+    // renormalized before this step, so these constants are depth-
+    // independent -- the 8-bit narrow-range offsets read as 16/255 and
+    // 128/255 regardless of whether the wire depth is 8, 10, 12, or 16.
     float bias[3];
     float scale[3];
     if (coeffs->narrow_range) {

--- a/source/apps/rtp_recv/gl_renderer.hpp
+++ b/source/apps/rtp_recv/gl_renderer.hpp
@@ -7,20 +7,22 @@
 
 // GLFW + OpenGL 3.3 core renderer for the RFC 9828 receiver.
 //
-// Two draw paths share one GL context, one VAO, and the same vertex shader:
+// Three draw paths share one GL context, one VAO, and the same vertex shader:
 //
-//   - upload_and_draw(rgb, w, h)               → RGB8 texture + passthrough
-//                                                fragment shader.  Used by
-//                                                the CPU fallback path
-//                                                (decode_to_rgb_buffer) for
-//                                                headless / GL-limited envs.
-//   - upload_planar_and_draw(y, cb, cr, ...)  → three R8 textures + YCbCr
-//                                                matrix fragment shader.
-//                                                Used by the default shader
-//                                                path so the CPU only shifts
-//                                                samples to 8-bit and the
-//                                                color conversion happens on
-//                                                the GPU.
+//   - upload_and_draw(rgb, w, h)                     → RGB8 texture +
+//     passthrough fragment shader.  Used by the CPU fallback path
+//     (decode_to_rgb_buffer) for headless / GL-limited envs.
+//   - upload_planar_and_draw(y, cb, cr, ...)        → three R8 textures +
+//     YCbCr matrix fragment shader.  Used by the shader color path when the
+//     source is 8-bit.  CPU does a clamp+shift to u8 before upload.
+//   - upload_planar_16_and_draw(y16, cb16, cr16,    → three R16 textures +
+//     ..., bit_depth)                                 the same fragment
+//     shader.  Used when the source is 10/12/16-bit so the LSBs survive
+//     the CPU -> GPU hop.  CPU does a clamp-only pack to u16; the fragment
+//     shader renormalizes via a uNormScale uniform set from bit_depth so the
+//     bias/scale/matrix math runs in normalized [0, 1] regardless of
+//     source depth.  GL_R16 is unsigned-normalized so GL_LINEAR chroma
+//     upsampling still works (GL_R16UI would need nearest+manual bilinear).
 //
 // init() tries to create a GL 3.3 core context.  Returns false if glfwInit
 // or context creation fails; the caller should log and fall back to
@@ -64,22 +66,52 @@ class GlRenderer {
   // call.  Does NOT own the pixel buffer.
   void upload_and_draw(const uint8_t* rgb, int w, int h);
 
-  // Shader path: upload three 8-bit planar samples (Y and two chroma
-  // planes, already right-shifted to 8 bits on the CPU side) and draw
-  // them through the YCbCr→RGB fragment shader.  Cb/Cr widths/heights
-  // may be smaller than luma for 4:2:2 / 4:2:0; GL_LINEAR + clamp-to-
-  // edge handles the chroma upsample.  `coeffs` selects BT.601/709 and
-  // full/narrow range; the matrix + normalization bias/scale are baked
-  // into shader uniforms on each call.  `components_are_rgb` skips the
-  // matrix entirely and treats the three planes as R/G/B.
+  // Shader path, 8-bit source: upload three 8-bit planar samples (Y and
+  // two chroma planes, already right-shifted to 8 bits on the CPU side)
+  // and draw them through the YCbCr->RGB fragment shader.  Cb/Cr widths/
+  // heights may be smaller than luma for 4:2:2 / 4:2:0; GL_LINEAR +
+  // clamp-to-edge handles the chroma upsample.  `coeffs` selects
+  // BT.601/709 and full/narrow range; the matrix + normalization bias/
+  // scale are baked into shader uniforms on each call.
+  // `components_are_rgb` skips the matrix entirely and treats the three
+  // planes as R/G/B.
   void upload_planar_and_draw(const uint8_t* y_plane, const uint8_t* cb_plane,
                               const uint8_t* cr_plane, int w_y, int h_y, int w_c, int h_c,
                               const ycbcr_coefficients* coeffs, bool components_are_rgb);
 
+  // Shader path, >8-bit source: upload three 16-bit planar samples
+  // (unsigned, clamped to [0, (1<<bit_depth)-1], NOT right-shifted) into
+  // three GL_R16 textures and draw them through the same YCbCr->RGB
+  // fragment shader.  The shader samples each texture as a [0, 1]
+  // normalized value and then multiplies by a uNormScale of
+  // (65535 / ((1<<bit_depth)-1)) so the sample renormalizes to [0, 1]
+  // in the source's native scale before bias/scale/matrix math runs.
+  // `bit_depth` is the source luma depth (9..16); for chroma planes at a
+  // different depth, pass the luma depth and rely on the streams we've
+  // encountered which are always same-depth across planes.  The LSBs
+  // the 8-bit path would have truncated are preserved through to the
+  // fragment stage, which is the foundational slice for HDR.
+  void upload_planar_16_and_draw(const uint16_t* y_plane, const uint16_t* cb_plane,
+                                 const uint16_t* cr_plane, int w_y, int h_y, int w_c, int h_c,
+                                 int bit_depth, const ycbcr_coefficients* coeffs,
+                                 bool components_are_rgb);
+
  private:
   bool compile_shader_programs();
   bool ensure_rgb_texture(int w, int h);
-  bool ensure_planar_textures(int w_y, int h_y, int w_c, int h_c);
+  // Allocate/resize three planar textures.  `bpp` is 1 for GL_R8 or 2 for
+  // GL_R16; swapping bpp across frames forces a fresh `glTexImage2D`
+  // allocation on each texture (not just `glTexSubImage2D`).  Each
+  // texture caches its own (w, h, bpp) so swapping one bit depth doesn't
+  // silently skip reallocation on the others (same class of bug that
+  // bit us when Cb/Cr shared (w, h) tracking in the initial draft).
+  bool ensure_planar_textures(int w_y, int h_y, int w_c, int h_c, int bpp);
+  // Shared tail of upload_planar_and_draw / upload_planar_16_and_draw:
+  // binds the three planar textures to the YCbCr program, sets the matrix
+  // + bias/scale + uNormScale uniforms, draws the fullscreen triangle
+  // strip, and swaps buffers.  `norm_scale` is a pointer to three floats.
+  void draw_ycbcr_program(int w_y, int h_y, const ycbcr_coefficients* coeffs,
+                          bool components_are_rgb, const float* norm_scale);
   void draw_fullscreen_quad(int fb_w, int fb_h, int content_w, int content_h);
   // Drains the GL error queue and logs each non-zero code with the
   // given context label.  Called only at allocation / program-link
@@ -110,17 +142,25 @@ class GlRenderer {
   int          u_yc_matrix_      = -1;
   int          u_yc_bias_        = -1;
   int          u_yc_scale_       = -1;
+  int          u_yc_norm_scale_  = -1;  // per-plane renormalization factor (1.0 for R8)
   int          u_yc_rgb_mode_    = -1;  // int: 0=ycbcr, 1=passthrough RGB components
   int          u_yc_viewport_    = -1;
   unsigned int tex_y_            = 0;
   unsigned int tex_cb_           = 0;
   unsigned int tex_cr_           = 0;
+  // Per-texture (width, height, bytes-per-pixel) so we can detect resize or
+  // format swaps on any of the three planes independently.  Sharing any of
+  // these across textures is a bug class -- see the comment above
+  // ensure_planar_textures in gl_renderer.cpp.
   int          tex_y_w_          = 0;
   int          tex_y_h_          = 0;
+  int          tex_y_bpp_        = 0;
   int          tex_cb_w_         = 0;
   int          tex_cb_h_         = 0;
+  int          tex_cb_bpp_       = 0;
   int          tex_cr_w_         = 0;
   int          tex_cr_h_         = 0;
+  int          tex_cr_bpp_       = 0;
 };
 
 }  // namespace open_htj2k::rtp_recv

--- a/source/apps/rtp_recv/main_rtp_recv.cpp
+++ b/source/apps/rtp_recv/main_rtp_recv.cpp
@@ -408,10 +408,14 @@ bool decode_to_planar_buffers(open_htj2k::openhtj2k_decoder& decoder, bool compo
   df.plane_y.clear();
   df.plane_cb.clear();
   df.plane_cr.clear();
+  df.plane_y_16.clear();
+  df.plane_cb_16.clear();
+  df.plane_cr_16.clear();
   df.width         = 0;
   df.height        = 0;
   df.chroma_width  = 0;
   df.chroma_height = 0;
+  df.bit_depth     = 0;
   df.kind          = components_are_rgb ? DecodedFrame::PLANAR_RGB : DecodedFrame::PLANAR_YCBCR;
 
   bool     dims_ok    = true;
@@ -421,6 +425,7 @@ bool decode_to_planar_buffers(open_htj2k::openhtj2k_decoder& decoder, bool compo
   uint32_t chroma_h_0 = 0;
   uint8_t  depth_y    = 0;
   uint8_t  depth_c    = 0;
+  bool     use_16     = false;  // true when depth_y > 8 -> take the GL_R16 path
 
   try {
     std::vector<uint32_t> widths;
@@ -462,43 +467,80 @@ bool decode_to_planar_buffers(open_htj2k::openhtj2k_decoder& decoder, bool compo
             df.height        = luma_h;
             df.chroma_width  = chroma_w_0;
             df.chroma_height = chroma_h_0;
-            df.plane_y.assign(static_cast<size_t>(luma_w) * luma_h, 0);
-            df.plane_cb.assign(static_cast<size_t>(chroma_w_0) * chroma_h_0,
-                               components_are_rgb ? 0 : 128);
-            df.plane_cr.assign(static_cast<size_t>(chroma_w_0) * chroma_h_0,
-                               components_are_rgb ? 0 : 128);
+            df.bit_depth     = depth_y;
+            use_16           = (depth_y > 8);
+            if (use_16) {
+              // 16-bit plane path.  Neutral chroma in the u16 space is the
+              // midpoint of the source's [0, (1<<depth)-1] range.
+              const uint16_t neutral_c = components_are_rgb
+                                             ? 0
+                                             : static_cast<uint16_t>(1u << (depth_c - 1));
+              df.plane_y_16.assign(static_cast<size_t>(luma_w) * luma_h, 0);
+              df.plane_cb_16.assign(static_cast<size_t>(chroma_w_0) * chroma_h_0, neutral_c);
+              df.plane_cr_16.assign(static_cast<size_t>(chroma_w_0) * chroma_h_0, neutral_c);
+            } else {
+              df.plane_y.assign(static_cast<size_t>(luma_w) * luma_h, 0);
+              df.plane_cb.assign(static_cast<size_t>(chroma_w_0) * chroma_h_0,
+                                 components_are_rgb ? 0 : 128);
+              df.plane_cr.assign(static_cast<size_t>(chroma_w_0) * chroma_h_0,
+                                 components_are_rgb ? 0 : 128);
+            }
           }
           if (!dims_ok) return;
 
-          const int32_t shift_y  = static_cast<int32_t>(depth_y) - 8;
           const int32_t maxval_y = (1 << depth_y) - 1;
 
-          // Luma row — every call has a Y row at the current y.
-          shift_i32_plane_to_u8(rows[0], df.plane_y.data() + static_cast<size_t>(y) * luma_w,
-                                luma_w, shift_y, maxval_y);
+          // Luma row -- every call has a Y row at the current y.
+          if (use_16) {
+            clamp_i32_plane_to_u16(
+                rows[0], df.plane_y_16.data() + static_cast<size_t>(y) * luma_w, luma_w,
+                maxval_y);
+          } else {
+            const int32_t shift_y = static_cast<int32_t>(depth_y) - 8;
+            shift_i32_plane_to_u8(rows[0],
+                                  df.plane_y.data() + static_cast<size_t>(y) * luma_w,
+                                  luma_w, shift_y, maxval_y);
+          }
 
           // Chroma (or G/B for PLANAR_RGB).  Written only for rows that
           // land on the chroma grid.  For 4:2:2 the chroma height equals
           // luma height and every luma row contributes.  For 4:2:0 the
           // luma height is 2x chroma; rows[] pointers may be nullptr on
-          // the "skip" luma rows — guard with the callback nc check.
+          // the "skip" luma rows -- guard with the callback nc check.
           if (nc >= 3) {
-            const int32_t shift_c  = static_cast<int32_t>(depth_c) - 8;
             const int32_t maxval_c = (1 << depth_c) - 1;
             const uint32_t yc      = (luma_h > 0)
                                          ? static_cast<uint32_t>(
                                                static_cast<uint64_t>(y) * chroma_h_0 / luma_h)
                                          : 0;
             if (yc < chroma_h_0) {
-              if (rows[1] != nullptr) {
-                shift_i32_plane_to_u8(rows[1],
-                                      df.plane_cb.data() + static_cast<size_t>(yc) * chroma_w_0,
-                                      chroma_w_0, shift_c, maxval_c);
-              }
-              if (rows[2] != nullptr) {
-                shift_i32_plane_to_u8(rows[2],
-                                      df.plane_cr.data() + static_cast<size_t>(yc) * chroma_w_0,
-                                      chroma_w_0, shift_c, maxval_c);
+              if (use_16) {
+                if (rows[1] != nullptr) {
+                  clamp_i32_plane_to_u16(
+                      rows[1],
+                      df.plane_cb_16.data() + static_cast<size_t>(yc) * chroma_w_0,
+                      chroma_w_0, maxval_c);
+                }
+                if (rows[2] != nullptr) {
+                  clamp_i32_plane_to_u16(
+                      rows[2],
+                      df.plane_cr_16.data() + static_cast<size_t>(yc) * chroma_w_0,
+                      chroma_w_0, maxval_c);
+                }
+              } else {
+                const int32_t shift_c = static_cast<int32_t>(depth_c) - 8;
+                if (rows[1] != nullptr) {
+                  shift_i32_plane_to_u8(
+                      rows[1],
+                      df.plane_cb.data() + static_cast<size_t>(yc) * chroma_w_0,
+                      chroma_w_0, shift_c, maxval_c);
+                }
+                if (rows[2] != nullptr) {
+                  shift_i32_plane_to_u8(
+                      rows[2],
+                      df.plane_cr.data() + static_cast<size_t>(yc) * chroma_w_0,
+                      chroma_w_0, shift_c, maxval_c);
+                }
               }
             }
           }
@@ -540,12 +582,22 @@ bool decode_and_present(const AssembledFrame& frame, const CliOptions& opts, boo
       return false;
     }
     if (renderer != nullptr) {
-      renderer->upload_planar_and_draw(
-          planar_scratch.plane_y.data(), planar_scratch.plane_cb.data(),
-          planar_scratch.plane_cr.data(), static_cast<int>(planar_scratch.width),
-          static_cast<int>(planar_scratch.height),
-          static_cast<int>(planar_scratch.chroma_width),
-          static_cast<int>(planar_scratch.chroma_height), coeffs, components_are_rgb);
+      if (planar_scratch.bit_depth > 8) {
+        renderer->upload_planar_16_and_draw(
+            planar_scratch.plane_y_16.data(), planar_scratch.plane_cb_16.data(),
+            planar_scratch.plane_cr_16.data(), static_cast<int>(planar_scratch.width),
+            static_cast<int>(planar_scratch.height),
+            static_cast<int>(planar_scratch.chroma_width),
+            static_cast<int>(planar_scratch.chroma_height),
+            static_cast<int>(planar_scratch.bit_depth), coeffs, components_are_rgb);
+      } else {
+        renderer->upload_planar_and_draw(
+            planar_scratch.plane_y.data(), planar_scratch.plane_cb.data(),
+            planar_scratch.plane_cr.data(), static_cast<int>(planar_scratch.width),
+            static_cast<int>(planar_scratch.height),
+            static_cast<int>(planar_scratch.chroma_width),
+            static_cast<int>(planar_scratch.chroma_height), coeffs, components_are_rgb);
+      }
     }
   } else {
     uint32_t out_w = 0;
@@ -1141,6 +1193,13 @@ int run_receiver_threaded(const CliOptions& opts) {
       if (df->kind == DecodedFrame::CPU_RGB) {
         renderer_ptr->upload_and_draw(df->rgb.data(), static_cast<int>(df->width),
                                       static_cast<int>(df->height));
+      } else if (df->bit_depth > 8) {
+        renderer_ptr->upload_planar_16_and_draw(
+            df->plane_y_16.data(), df->plane_cb_16.data(), df->plane_cr_16.data(),
+            static_cast<int>(df->width), static_cast<int>(df->height),
+            static_cast<int>(df->chroma_width), static_cast<int>(df->chroma_height),
+            static_cast<int>(df->bit_depth), df->shader_coeffs,
+            df->components_are_rgb);
       } else {
         renderer_ptr->upload_planar_and_draw(
             df->plane_y.data(), df->plane_cb.data(), df->plane_cr.data(),

--- a/source/apps/rtp_recv/planar_shift.hpp
+++ b/source/apps/rtp_recv/planar_shift.hpp
@@ -94,6 +94,66 @@ inline void shift_i32_plane_to_u8(const int32_t* in, uint8_t* out, uint32_t widt
   }
 }
 
+// ── 16-bit variant ──────────────────────────────────────────────────────────
+// Clamp int32 samples to [0, maxval] and pack into the top `depth` bits of a
+// uint16_t, where `depth` is the source bit depth.  Used by the shader path
+// when the source is >8 bit: the GL_R16 texture is unsigned-normalized, so
+// writing the sample value directly produces a texture that reads back as
+// (sample / 65535) in the shader; the fragment program then renormalizes
+// via a uNormScale uniform set to (65535.0 / ((1<<depth)-1)) to restore the
+// sample's original [0, 1] range before bias/scale/matrix math.  No right
+// shift: the whole point of the 16-bit path is to preserve the LSBs the u8
+// path truncated.
+inline void clamp_i32_plane_to_u16_scalar(const int32_t* in, uint16_t* out, uint32_t width,
+                                          int32_t maxval) {
+  for (uint32_t x = 0; x < width; ++x) {
+    int32_t v = in[x];
+    if (v < 0) v = 0;
+    if (v > maxval) v = maxval;
+    out[x] = static_cast<uint16_t>(v);
+  }
+}
+
+inline void clamp_i32_plane_to_u16(const int32_t* in, uint16_t* out, uint32_t width,
+                                   int32_t maxval) {
+  uint32_t x = 0;
+
+#if defined(__AVX2__)
+  // AVX2: 8 int32 per iteration.  Clamp to [0, maxval], pack down to 8 u16
+  // via packus_epi32, reassemble the two lanes into a single __m128i, and
+  // store the eight u16 values.
+  //
+  // packus_epi32 is lane-local: the low 64 bits of each 128-bit lane hold
+  // four u16 values, and the high 64 bits duplicate them.  We
+  // unpacklo_epi64 the two lanes to get eight contiguous u16s.
+  //
+  // No srai here: the u16 preserves the source's full dynamic range, and
+  // the fragment shader renormalizes via uNormScale at sample time.
+  const __m256i vzero   = _mm256_setzero_si256();
+  const __m256i vmaxval = _mm256_set1_epi32(maxval);
+  for (; x + 8 <= width; x += 8) {
+    __m256i v = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(in + x));
+    v         = _mm256_max_epi32(v, vzero);
+    v         = _mm256_min_epi32(v, vmaxval);
+
+    const __m256i p16      = _mm256_packus_epi32(v, v);
+    const __m128i lane0    = _mm256_castsi256_si128(p16);
+    const __m128i lane1    = _mm256_extracti128_si256(p16, 1);
+    const __m128i merged16 = _mm_unpacklo_epi64(lane0, lane1);
+
+    _mm_storeu_si128(reinterpret_cast<__m128i*>(out + x), merged16);
+  }
+#endif
+
+  // Tail (and the whole row on non-AVX2 builds).
+  for (; x < width; ++x) {
+    int32_t v = in[x];
+    if (v < 0) v = 0;
+    if (v > maxval) v = maxval;
+    out[x] = static_cast<uint16_t>(v);
+  }
+}
+
 // Byte-equality smoke test used from main_rtp_recv --smoke-test.  Drives
 // the AVX2 and scalar paths with a hand-crafted input that exercises the
 // clamp low/high edges, every residue of width % 8, and the shift == 0
@@ -103,6 +163,8 @@ inline bool plane_shift_smoke_test() {
   alignas(32) int32_t input[kMax];
   alignas(32) uint8_t  out_simd[kMax];
   alignas(32) uint8_t  out_ref[kMax];
+  alignas(32) uint16_t out16_simd[kMax];
+  alignas(32) uint16_t out16_ref[kMax];
 
   // Mix: negatives, zeros, small positives, near-max, over-max.
   for (uint32_t i = 0; i < kMax; ++i) {
@@ -147,6 +209,26 @@ inline bool plane_shift_smoke_test() {
       }
     }
   }
+
+  // Same matrix against the u16 clamp helper.
+  const int32_t u16_cases[] = {255, 1023, 4095, 65535};
+  for (int32_t maxval : u16_cases) {
+    for (uint32_t w = 1; w <= kMax; ++w) {
+      for (uint32_t i = 0; i < kMax; ++i) out16_simd[i] = 0xABCD;
+      for (uint32_t i = 0; i < kMax; ++i) out16_ref[i]  = 0xABCD;
+
+      clamp_i32_plane_to_u16(input, out16_simd, w, maxval);
+      clamp_i32_plane_to_u16_scalar(input, out16_ref, w, maxval);
+
+      for (uint32_t i = 0; i < w; ++i) {
+        if (out16_simd[i] != out16_ref[i]) return false;
+      }
+      for (uint32_t i = w; i < kMax; ++i) {
+        if (out16_simd[i] != 0xABCD) return false;
+      }
+    }
+  }
+
   return true;
 }
 


### PR DESCRIPTION
## Summary

For 10 / 12 / 16-bit HTJ2K sources, the RTP receiver's shader color path now preserves the full source bit depth end-to-end instead of right-shifting to `GL_R8` at plane upload time. **No colorimetric change** in this PR: the output still goes through the same BT.601 / BT.709 matrix, so the visible difference on an SDR display is LSB preservation (no 2- or 4-bit truncation), not any new display behavior. The follow-up work for actually decoding HDR transfer functions (PQ, HLG) and for the BT.2020 colour space sits on top of this groundwork and is tracked in separate PRs; this PR is deliberately a narrow texture-format + pipeline change so the correctness surface is small and the 8-bit path can be proved bit-identical to 0.11.1.

## What this PR changes

- **`planar_shift.hpp`** — new `clamp_i32_plane_to_u16` / `_scalar` helper beside the existing `shift_i32_plane_to_u8`. AVX2 path: 8 int32 per iteration, clamp to `[0, maxval]`, `packus_epi32` pack to u16, `unpacklo_epi64` lane reassembly. No arithmetic shift — the u16 path preserves the LSBs the u8 path truncated. Smoke test extended to byte-compare it against the scalar reference for every `(maxval, width)` residue used by the u8 test.

- **`frame_pipeline.hpp`** — `DecodedFrame` gains `plane_y_16` / `plane_cb_16` / `plane_cr_16` vectors and a `bit_depth` field. u8 and u16 plane sets are mutually exclusive per frame so `std::move` never allocates for the unused set.

- **`gl_renderer.{hpp,cpp}`** —
  - `ensure_planar_textures` gains a `bpp` parameter (1 → `GL_R8`, 2 → `GL_R16`). Each texture now owns its own `(w, h, bpp)` triple so a format swap on one plane cannot silently skip reallocation on the others (same class of bug we hit before with shared Cb/Cr tracking).
  - New `upload_planar_16_and_draw(y16, cb16, cr16, ..., bit_depth, coeffs, components_are_rgb)`.
  - Shared per-draw tail factored out as `draw_ycbcr_program()` so the u8 and u16 variants use identical matrix / bias / scale / viewport / swap logic.
  - Fragment shader gains `uNormScale` (vec3). For u8 callers it is the identity `(1, 1, 1)`; for u16 callers it is `65535 / ((1<<bit_depth)-1)`, restoring the sample's native `[0, 1]` range before the existing bias/scale/matrix math runs. Multiplication by exact `1.0` in IEEE 754 is identity, so the 8-bit path is bit-identical to before.

- **`main_rtp_recv.cpp`** — `decode_to_planar_buffers` branches on `depth_y > 8`. 8-bit sources keep the unchanged u8 path; >8-bit sources fill the new u16 vectors via `clamp_i32_plane_to_u16`. Both the single-threaded v1 path and the threaded render loop dispatch to `upload_planar_16_and_draw` when `DecodedFrame::bit_depth > 8`.

## What this PR does NOT change

- **BT.2020 matrix.** The shader still reads `coeffs->cb_to_g` etc. from `ycbcr_coefficients`; only BT.601 and BT.709 are populated. A BT.2020 PQ source rendered through this PR still goes through a BT.709 matrix and looks wrong colorimetrically — but it preserves its LSBs.
- **PQ / HLG EOTF.** The shader output is still linear in the source's gamma, which for SDR is gamma-2.2-ish and for HDR is the PQ or HLG curve the encoder applied. No EOTF decode or tone-map.
- **CPU color path.** `decode_to_rgb_buffer → ycbcr_row_to_rgb8` still ships 8-bit preview. HDR on the CPU is out of scope.

## Format choice rationale

`GL_R16`, not `GL_R16UI`:

- **Linear filtering.** `R16` is unsigned-normalized so `GL_LINEAR` magnification filtering works — critical for the 4:2:2 / 4:2:0 chroma upsample. `R16UI` would force `GL_NEAREST` and require a manual bilinear fetch in the shader (four `texelFetch`es + mix); the quality loss on chroma edges would be visible on text and fine detail.
- **Same CPU cost as u8.** The AVX2 clamp-to-u16 path does one fewer op than `shift_i32_plane_to_u8` (no right shift) and uses the same 8-sample loop structure, so the per-row callback cost is basically identical.

Not `GL_R16F`: works for linear filtering but needs a CPU int32→half conversion per sample, which is strictly more expensive than the pack-to-u16 the new helper already does.

## Measurements

**Ryzen 9 9950X dev box, `--threads 2`.**

| Fixture | Path | Frames | Wall | Steady fps | decode avg | evicts |
|---|---|---|---|---|---|---|
| 10-bit camera 4K 4:2:2 1.7 bpp (existing, kept as regression baseline) | u8 | 2000 | 36.9 s | 60.01 ± 0.31 | 13.13 ms | 0/2000 |
| **12-bit Spark 4K 4:2:2** (new, exercises GL_R16 path) | **u16** | **500** | **19.4 s** | **29.95-30.00** | **17.09 ms** | **0/500** |

The 12-bit number is higher per frame because the source has more entropy and a slightly higher wire bitrate at the same coding settings, not because the new code path is more expensive — CPU cost of `clamp_i32_plane_to_u16` is ~identical to `shift_i32_plane_to_u8`, and the R16 upload bandwidth fits trivially in PCIe 4.0.

## Validation

- [x] `ctest --test-dir build` → **582/582 pass** (core decoder untouched)
- [x] `main_rtp_recv --smoke-test` → all existing smoke tests pass, including the newly-extended `plane_shift_smoke_test` which byte-compares `clamp_i32_plane_to_u16` against its scalar reference across `maxval ∈ {255, 1023, 4095, 65535}` and `w ∈ [1, 96]`
- [x] Live 500-frame soak, 12-bit 4K 4:2:2 fixture, real sender over `kdu_stream_send`: 0 failures, 0 evictions, no GL errors logged, frame rate locked to source cadence
- [x] 8-bit path byte-equality by code review: `decode_to_planar_buffers` diff is purely additive (the `use_16=true` branch); `upload_planar_and_draw` passes `bpp=1`; shader `uNormScale=(1,1,1)` is the identity

## Test plan

- [ ] CI: 9-job matrix (ubuntu ×2, ubuntu-arm ×2, macos ×2, windows ×1, windows-arm ×1, wasm) — `GL_R16` is GL 2.1 spec, supported on every driver that passes `GL 3.3 core`, so all desktop targets should pass. WASM does not build the `OPENHTJ2K_RTP` target, so the new code is not exercised there.
- [ ] Visual spot-check on the 12-bit Spark fixture vs the old u8-truncated path — LSB preservation is the testable claim

🤖 Generated with [Claude Code](https://claude.com/claude-code)