### PR TITLE
fix(tests): encoder tests must require test_artifacts fixture

### DIFF
--- a/tests/encoder_test.cmake
+++ b/tests/encoder_test.cmake
@@ -19,3 +19,21 @@ add_test(NAME dec_lossless_odd COMMAND open_htj2k_dec -i kodim23odd_lossless.j2c
 set_tests_properties(dec_lossless_odd PROPERTIES DEPENDS enc_lossless_odd)
 add_test(NAME comp_lossless_odd COMMAND imgcmp kodim23odd_lossless.ppm ${ENCODER_REF_DIR}/kodim23odd.ppm 0 0)
 set_tests_properties(comp_lossless_odd PROPERTIES DEPENDS dec_lossless_odd)
+
+# Require the decoder-conformance cleanup fixture so these encoder tests are
+# guaranteed to run AFTER cleanup_artifacts, never concurrently with it.
+# Without this, ctest -j was free to schedule cleanup_artifacts (which globs
+# *.ppm in the build dir and deletes everything matching) at any time, which
+# under parallel load sometimes landed between dec_lossless writing
+# kodim23lossless.ppm and comp_lossless reading it -- producing an
+# intermittent "File kodim23lossless.ppm is not found" failure on
+# comp_lossless / comp_lossless_odd that vanished on serial reruns.
+#
+# The `test_artifacts` fixture is declared by tests/decoder_conformance.cmake,
+# which is included before this file from CMakeLists.txt, so the name is
+# already visible here.
+set_tests_properties(
+  enc_lossless dec_lossless comp_lossless
+  enc_lossy    dec_lossy    comp_lossy
+  enc_lossless_odd dec_lossless_odd comp_lossless_odd
+  PROPERTIES FIXTURES_REQUIRED test_artifacts)


### PR DESCRIPTION
## Summary

`ctest -j` is intermittently failing `comp_lossless` and `comp_lossless_odd` with `File kodim23lossless.ppm is not found`, while serial `ctest` always passes. Root cause is a parallel scheduling race between the encoder round-trip chain in `tests/encoder_test.cmake` and the `cleanup_artifacts` fixture declared in `tests/decoder_conformance.cmake`.

## Root cause

`tests/cleanup_artifacts.cmake` runs:

```cmake
foreach(_ext pgx ppm pgm)
  file(GLOB _files "*.${_ext}")
  if(_files)
    file(REMOVE ${_files})
  endif()
endforeach()
```

It's wired as `FIXTURES_SETUP test_artifacts` and every decoder conformance test declares `FIXTURES_REQUIRED test_artifacts`, which guarantees CTest runs the cleanup once before those tests. **The encoder tests did NOT require the fixture**, so CTest was free to schedule `cleanup_artifacts` at any point relative to the `enc → dec → comp` chain.

Under `-j` load, the scheduler sometimes landed `cleanup_artifacts` between `dec_lossless` writing `kodim23lossless.ppm` and `comp_lossless` reading it, wiping the file and producing the "file not found" error on `comp_lossless`. The `DEPENDS` property on the encoder chain doesn't catch this because `DEPENDS` only orders within the same dependency chain — it has nothing to say about unrelated tests like `cleanup_artifacts`.

## Fix

Declare `FIXTURES_REQUIRED test_artifacts` on all nine encoder tests (`enc_lossless`, `dec_lossless`, `comp_lossless` plus the `_lossy` and `_odd` variants). This puts them after `cleanup_artifacts` in ctest's timeline and keeps them out of any path where the cleanup can run concurrently.

The `test_artifacts` fixture is declared in `tests/decoder_conformance.cmake`, which is included from the top-level `CMakeLists.txt` immediately before `tests/encoder_test.cmake`, so the fixture name is already in scope when the encoder tests are added.

## Verification

5 consecutive `ctest --test-dir build -j32` runs on the Ryzen 9 9950X dev box:

```
run 1: 100% tests passed, 0 tests failed out of 582
run 2: 100% tests passed, 0 tests failed out of 582
run 3: 100% tests passed, 0 tests failed out of 582
run 4: 100% tests passed, 0 tests failed out of 582
run 5: 100% tests passed, 0 tests failed out of 582
```

Previously the same machine under `-j32` produced intermittent failures on `comp_lossless` and `comp_lossless_odd` — e.g. earlier this session I caught `99% tests passed, 2 tests failed out of 582` and the failing test output was `File kodim23lossless.ppm is not found`.

## Test plan

- [x] 5 consecutive `ctest -j32` runs all pass 582/582
- [ ] CI matrix: the fix is a cmake-only change, should pass on every target that runs the encoder tests. Targets that skip encoder tests (e.g. WASM) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)