### PR TITLE
docs(README): correct CLI I/O table notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,11 @@ Full reference, kernel `rmem_max` tuning, hardware requirements for
 
 | Format | `open_htj2k_enc` input | `open_htj2k_dec` output | Notes |
 |--------|:---:|:---:|-------|
-| PGM / PPM | ✓ | ✓ | PPM supports subsampled (4:2:2, 4:2:0) components |
-| PGX | ✓ | ✓ | Encoder streaming path accepts subsampled PGX component sets |
-| TIFF (libtiff required, 8/16 bpp) | ✓ | | |
-| RAW | | ✓ | |
+| PGM (`P5`) | ✓ | ✓ | Single grayscale component. Bit depth is auto-detected from `maxval` (8-bit or 16-bit). Decoder writes one file per component with a `_NN` suffix. |
+| PPM (`P6`) | ✓ | ✓ | Packed RGB (3 equal-sized components). On decode, a subsampled YCbCr codestream is upsampled to luma resolution (nearest-neighbour for 4:2:2 / 4:2:0) before writing interleaved RGB — enable the YCbCr→RGB matrix with `-ycbcr bt601\|bt709`. |
+| PGX | ✓ | ✓ | One component per file. Multi-component input is a comma-separated file list (e.g. `Y.pgx,Cb.pgx,Cr.pgx`) and the encoder computes `XRsiz` / `YRsiz` from each file's dimensions, so 4:2:2 / 4:2:0 Y/Cb/Cr inputs encode with the right subsampling. Both batch and streaming encode paths support this. Decoder writes one file per component with a `_NN` suffix. |
+| TIFF | ✓ (batch only) | | Requires libtiff at build time. 8 or 16 bits **per sample**. TIFF input is supported on the batch (`-batch`) encode path only; the streaming encode path does not handle TIFF. Not a decoder output. |
+| RAW | | ✓ | Decoder-only output. Packed samples, no header, one file per component with a `_NN` suffix. |
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

Four notes in the CLI I/O table in the top-level README were ambiguous or incorrect. Verified against `source/apps/encoder/main_enc.cpp`, `source/apps/decoder/main_dec.cpp`, and `source/core/interface/encoder.cpp`.

## Corrections

1. **\"PPM supports subsampled (4:2:2, 4:2:0) components\"** — wrong. PPM (`P6`) is packed RGB, always 4:4:4. What actually happens: on decode, a subsampled YCbCr codestream is upsampled to luma resolution (nearest-neighbour for 4:2:2 / 4:2:0) before being written as interleaved RGB, and **only when \`-ycbcr bt601|bt709\` is set on the decoder CLI**. New note says exactly that.

2. **\"Encoder streaming path accepts subsampled PGX component sets\"** — misleading. *Both* encoder paths (batch and streaming) accept multi-file PGX input. Subsampling comes from the per-component dimensions in the individual `.pgx` files (the encoder computes `XRsiz` / `YRsiz` from them), not from the streaming-vs-batch choice. Both paths route through \`PgxStreamReader\` / the \`image\` class's PGX branch in \`encoder.cpp\`.

3. **\"TIFF (libtiff required, 8/16 bpp)\"** — ambiguous and incomplete. \`bpp\` commonly reads as bits-per-pixel (an 8-bit RGB TIFF is 24 bpp); what's actually supported is 8 or 16 bits **per sample**. Also TIFF is **batch-only** on the encoder — the streaming encode path (\`PnmStreamReader\` / \`PgxStreamReader\`) doesn't wire up libtiff, so TIFF + \`-batch\` is the only combination that works. New note says both.

4. **RAW row had no note.** The decoder writes one \`<base>_NN.raw\` file per component with packed samples and no header (confirmed in \`main_dec.cpp\`). New note says that.

Also split the PGM and PPM row (previously merged as \"PGM / PPM\") since the two formats now carry meaningfully different notes.

## No code change

Pure docs fix. No CHANGELOG entry needed.

## Test plan

- [x] Verified each claim against the actual source code paths listed above
- [x] Rendered the table manually — columns still align, no formatting regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)