### PR TITLE
feat(rtp_recv): BT.2020 matrix for RFC 9828 MAT=9 sources (HDR slice 2)

### DIFF
--- a/docs/cli_rtp_recv.md
+++ b/docs/cli_rtp_recv.md
@@ -61,7 +61,12 @@ quick local testing without a live sender.
 
 ### Color fallback (when the Main Packet declares S=0)
 
-- `--colorspace {bt709|bt601|rgb}` — Fallback colorspace.
+- `--colorspace {bt709|bt601|bt2020|rgb}` — Fallback colorspace.
+  `bt2020` selects the BT.2020 NCL matrix (ITU-T H.273 MatrixCoefficients = 9).
+  Note that this slice only switches the YCbCr→RGB matrix; a PQ / HLG
+  transfer function and gamut-mapping from BT.2020 primaries to the
+  display primaries are not yet implemented, so a BT.2020 HDR source
+  still renders with the display's native gamma curve.
 - `--range {full|narrow}` — Fallback range. Default `full`.
 
 ### Diagnostics

--- a/source/apps/rtp_recv/main_rtp_recv.cpp
+++ b/source/apps/rtp_recv/main_rtp_recv.cpp
@@ -95,7 +95,7 @@ void print_usage(const char* argv0) {
       "  --no-decode              Skip the openhtj2k decoder entirely (capture only)\n"
       "  --threading {on,off}     v2 multi-thread (default on); off = v1 single-thread\n"
       "  --dump-codestream <fmt>  printf-style path, e.g. '/tmp/f_%%05d.j2c'\n"
-      "  --colorspace <name>      S=0 fallback: bt709 | bt601 | rgb (bt2020 not yet)\n"
+      "  --colorspace <name>      S=0 fallback: bt709 | bt601 | bt2020 | rgb\n"
       "  --range <name>           S=0 fallback: full | narrow (default full)\n"
       "  --threads <N>            Decoder thread count (default 2; 0 = hardware)\n"
       "  --color-path {shader|cpu} YCbCr->RGB on GPU (default) or CPU fallback\n"
@@ -228,8 +228,8 @@ bool parse_cli(int argc, char** argv, CliOptions& opt) {
       opt.s0_fallback = range_full ? &YCBCR_BT601_FULL : &YCBCR_BT601_NARROW;
       opt.s0_label    = range_full ? "bt601-full" : "bt601-narrow";
     } else if (std::strcmp(v, "bt2020") == 0) {
-      std::fprintf(stderr, "ERROR: --colorspace bt2020 not supported in v1\n");
-      return false;
+      opt.s0_fallback = range_full ? &YCBCR_BT2020_FULL : &YCBCR_BT2020_NARROW;
+      opt.s0_label    = range_full ? "bt2020-full" : "bt2020-narrow";
     } else if (std::strcmp(v, "rgb") == 0) {
       opt.s0_fallback = nullptr;  // sentinel for "no YCbCr, components already RGB"
       opt.s0_label    = "rgb";
@@ -316,6 +316,8 @@ void log_coefficients_choice_once(const CliOptions& opts, const ycbcr_coefficien
                       : coeffs == &YCBCR_BT709_NARROW ? "bt709-narrow"
                       : coeffs == &YCBCR_BT601_FULL   ? "bt601-full"
                       : coeffs == &YCBCR_BT601_NARROW ? "bt601-narrow"
+                      : coeffs == &YCBCR_BT2020_FULL  ? "bt2020-full"
+                      : coeffs == &YCBCR_BT2020_NARROW? "bt2020-narrow"
                                                       : "?"));
 }
 
@@ -1406,6 +1408,33 @@ int smoke_test_ycbcr() {
         if (std::abs(static_cast<int>(out[3 * x + c]) - 128) > 1) return 1;
       }
     }
+  }
+
+  // BT.2020 sanity: the RFC 9828 MAT -> matrix dispatch routes correctly
+  // and a neutral-gray input produces gray output through the BT.2020
+  // matrix.  BT.2020 NCL is MAT=9 in ITU-T H.273 Table 4.
+  {
+    if (select_coefficients_from_mat(/*mat=*/9, /*full_range=*/true) != &YCBCR_BT2020_FULL)
+      return 1;
+    if (select_coefficients_from_mat(/*mat=*/9, /*full_range=*/false) != &YCBCR_BT2020_NARROW)
+      return 1;
+
+    const int32_t Y2020[] = {128}, Cb2020[] = {128}, Cr2020[] = {128};
+    uint8_t rgb2020[3] = {0};
+    ycbcr_row_to_rgb8(Y2020, Cb2020, Cr2020, rgb2020, 1, 1, 1, YCBCR_BT2020_FULL, 8, false);
+    if (std::abs(int(rgb2020[0]) - 128) > 1) return 1;
+    if (std::abs(int(rgb2020[1]) - 128) > 1) return 1;
+    if (std::abs(int(rgb2020[2]) - 128) > 1) return 1;
+
+    // Same neutral test at 10-bit depth so the bit-depth-dependent
+    // normalization constants in ycbcr_row_to_rgb8 get exercised for
+    // the BT.2020 matrix too.
+    const int32_t Y10[]  = {512}, Cb10[] = {512}, Cr10[] = {512};
+    uint8_t rgb10[3] = {0};
+    ycbcr_row_to_rgb8(Y10, Cb10, Cr10, rgb10, 1, 1, 1, YCBCR_BT2020_FULL, 10, false);
+    if (std::abs(int(rgb10[0]) - 128) > 1) return 1;
+    if (std::abs(int(rgb10[1]) - 128) > 1) return 1;
+    if (std::abs(int(rgb10[2]) - 128) > 1) return 1;
   }
 
   return 0;

--- a/source/apps/rtp_recv/ycbcr_rgb.hpp
+++ b/source/apps/rtp_recv/ycbcr_rgb.hpp
@@ -20,11 +20,18 @@
 //   - unsigned JPEG 2000 components (the broadcast case; signed is TODO)
 //   - input depths 8..16
 //   - chroma subsampling 4:4:4, 4:2:2, 4:2:0 via per-component stride ratios
-//   - full-range and narrow-range BT.601 / BT.709
+//   - full-range and narrow-range BT.601 / BT.709 / BT.2020 NCL
 //
-// NOT supported in v1:
+// NOT supported:
 //   - signed components (triggers an assert / std::abort)
-//   - BT.2020 NCL (add in v2)
+//   - BT.2020 constant-luminance (ITU-T H.273 MatrixCoefficients = 10)
+//   - ICtCp / XYZ matrices
+//
+// HDR colorimetry scope: this file covers only the YCbCr -> RGB matrix step.
+// The result is non-linear R'G'B' in the source primaries (BT.601 / BT.709 /
+// BT.2020) -- NOT linear light.  A PQ / HLG EOTF and a gamut-mapping step
+// from the source primaries to the display primaries belong in a later
+// slice of the HDR roadmap.
 
 #include <algorithm>
 #include <cassert>
@@ -80,18 +87,52 @@ constexpr ycbcr_coefficients YCBCR_BT709_NARROW = {
     /*cb_to_b*/ 2.112f,
 };
 
+// ITU-R BT.2020 NCL full-range.  Derived from Kr=0.2627, Kg=0.6780,
+// Kb=0.0593 (BT.2020 Table 4, ITU-T H.273 MatrixCoefficients = 9):
+//   cr_to_r = 2*(1 - Kr)                         = 1.4746
+//   cb_to_b = 2*(1 - Kb)                         = 1.8814
+//   cr_to_g = (2 * Kr * (1 - Kr)) / Kg           = 0.571353...
+//   cb_to_g = (2 * Kb * (1 - Kb)) / Kg           = 0.164553...
+constexpr ycbcr_coefficients YCBCR_BT2020_FULL = {
+    /*narrow_range*/ false,
+    /*cr_to_r*/ 1.4746f,
+    /*cb_to_g*/ 0.16455313f,
+    /*cr_to_g*/ 0.57135314f,
+    /*cb_to_b*/ 1.8814f,
+};
+
+// ITU-R BT.2020 NCL narrow-range.  Mirrors the existing BT.601 / BT.709
+// narrow-range entries, which scale the full-range coefficients by
+// 255/224.  Kept consistent with the pre-existing narrow-range
+// convention so the four narrow entries behave uniformly end-to-end;
+// whether that convention is itself arithmetically correct under the
+// shader's `(s - uBias) * uScale` prelude is tracked as a separate
+// investigation rather than being fixed in this slice.
+constexpr ycbcr_coefficients YCBCR_BT2020_NARROW = {
+    /*narrow_range*/ true,
+    /*cr_to_r*/ 1.67861f,    // 1.4746   * 255/224
+    /*cb_to_g*/ 0.18732f,    // 0.164553 * 255/224
+    /*cr_to_g*/ 0.65026f,    // 0.571353 * 255/224
+    /*cb_to_b*/ 2.14179f,    // 1.8814   * 255/224
+};
+
 // Select coefficients from RFC 9828 §5.3 MAT + RANGE (S=1 case).
-// Returns nullptr for unsupported MAT values (e.g. BT.2020 NCL, log, etc.);
-// the caller should log and drop the frame or fall back to CLI settings.
+// Returns nullptr for unsupported MAT values (constant-luminance BT.2020,
+// ICtCp, chroma-derived, log); the caller should log and drop the frame
+// or fall back to CLI settings.
 inline const ycbcr_coefficients* select_coefficients_from_mat(uint8_t mat, bool full_range) {
   // Values from ITU-T H.273 Table 4 (MatrixCoefficients).
-  // 1 = BT.709; 5, 6 = BT.601 (625/525 lines); 9 = BT.2020 NCL (not yet).
+  // 1 = BT.709; 5, 6 = BT.601 (625/525 lines); 9 = BT.2020 NCL.
+  // 10 (BT.2020 CL), 11 (SMPTE ST 2085), 12-14 (chroma-derived /
+  // ICtCp) are intentionally not mapped.
   switch (mat) {
     case 1:
       return full_range ? &YCBCR_BT709_FULL : &YCBCR_BT709_NARROW;
     case 5:
     case 6:
       return full_range ? &YCBCR_BT601_FULL : &YCBCR_BT601_NARROW;
+    case 9:
+      return full_range ? &YCBCR_BT2020_FULL : &YCBCR_BT2020_NARROW;
     default:
       return nullptr;
   }


### PR DESCRIPTION
## Summary

Routes RFC 9828 frames that declare `MAT = 9` (ITU-T H.273 BT.2020 NCL) through the correct YCbCr→RGB matrix instead of falling through to an unsupported-MAT error. Also unlocks `--colorspace bt2020` as a valid CLI value so operators can force a BT.2020 interpretation when a stream carries `S = 0` (no colorimetry metadata in the Main Packet).

**Scope is deliberately narrow: only the YCbCr→RGB matrix step.** The fragment shader's output is still non-linear R'G'B' in the source primaries (BT.2020 here), with no PQ or HLG EOTF decode and no gamut mapping to the display's primaries. As a result, a BT.2020 HDR source rendered through this PR preserves its bit depth (from the GL_R16 upload path in #209) and uses the correct matrix, but a PQ-encoded stream will still be displayed as if it were SDR gamma — dim / washed relative to a proper HDR display path. The transfer-function and gamut-mapping work are queued for follow-up PRs (see Follow-ups below).

## Changes

### `source/apps/rtp_recv/ycbcr_rgb.hpp`

- **New** `YCBCR_BT2020_FULL` / `YCBCR_BT2020_NARROW` constants. Full-range coefficients derived from BT.2020 `Kr = 0.2627`, `Kg = 0.6780`, `Kb = 0.0593` per ITU-R BT.2020 Table 4:

  | | Full |
  |---|---|
  | `cr_to_r` = 2·(1-Kr) | `1.4746` |
  | `cb_to_b` = 2·(1-Kb) | `1.8814` |
  | `cr_to_g` = (2·Kr·(1-Kr))/Kg | `0.57135314` |
  | `cb_to_g` = (2·Kb·(1-Kb))/Kg | `0.16455313` |

  Narrow-range values mirror the existing BT.601 / BT.709 narrow-range convention of multiplying the full-range coefficients by `255/224`. Whether that convention is itself arithmetically correct under the shader's `(s - uBias) * uScale` prelude is a separate question — see the third item in Follow-ups below.

- **`select_coefficients_from_mat()`** gains a case for `MAT = 9`. `MAT = 10` (BT.2020 CL / constant-luminance), `11` (SMPTE ST 2085), and `12-14` (chroma-derived / ICtCp) are intentionally not mapped — commented inline so the next reader isn't surprised.

### `source/apps/rtp_recv/main_rtp_recv.cpp`

- `--colorspace bt2020` is no longer an error — it maps to `YCBCR_BT2020_FULL` or `YCBCR_BT2020_NARROW` via the existing `--range` flag.
- `log_coefficients_choice_once()` learns the new `bt2020-full` / `bt2020-narrow` labels for the info-level one-time log line.
- `-h` help string updated: `--colorspace <name>    S=0 fallback: bt709 | bt601 | bt2020 | rgb`.
- `smoke_test_ycbcr()` gains a BT.2020 sub-test: verifies `select_coefficients_from_mat(9, true/false)` returns the right constants, and runs a neutral-gray round-trip through `YCBCR_BT2020_FULL` at 8-bit and 10-bit depths. Neutral gray in → neutral gray out regardless of matrix, so this catches a wiring bug without needing a BT.2020 reference fixture.

### `docs/cli_rtp_recv.md`

- Documents `--colorspace bt2020` and explicitly notes the scope limitation: the matrix is the only thing that changes today. A BT.2020 HDR source still renders with the display's native gamma until PQ/HLG decoding and gamut mapping are added in follow-up PRs.

## Validation

- [x] `main_rtp_recv --smoke-test` passes, including the new BT.2020 sub-test (`ycbcr->rgb smoke-test OK`)
- [x] `open_htj2k_rtp_recv --colorspace bt2020` and `--colorspace bt2020 --range narrow` are both accepted by argv parsing
- [x] `open_htj2k_rtp_recv -h` shows the updated help line
- [x] `ctest --test-dir build`: **582/582** pass serially
- [ ] Live-stream verification against a real BT.2020 RFC 9828 sender — not available in my test fixture set. The CPU smoke test plus the neutral-gray round-trip are the testable claims for a color-space-only change that doesn't alter any decoded pixel when the source is already SDR.

## Follow-ups (explicitly out of scope for this PR)

1. **PQ / HLG EOTF in the fragment shader.** Adds a `uniform int uTransfer` plus curve evaluation after the matrix so the shader produces linear light for display tone-mapping.
2. **Gamut mapping from the source primaries to the display primaries.** BT.2020 R'G'B' doesn't automatically render correctly on an sRGB / BT.709 display; this is its own ~3×3 matrix step. It can be folded into the YCbCr matrix for speed or kept as a second pass for clarity.
3. **Narrow-range matrix audit.** The pre-existing BT.601 / BT.709 narrow coefficients look like they may be double-scaled when `(s - uBias) * uScale` is applied on top of a matrix that already encodes `255/224`. BT.2020 narrow matches that same convention here for internal consistency; a correctness audit of all four narrow entries is a standalone task and can happen in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)