### PR TITLE
feat(wasm): default rtp_demo URL to 4K Spark clip on custom-domain R2

### DIFF
--- a/subprojects/rtp_demo.html
+++ b/subprojects/rtp_demo.html
@@ -334,7 +334,7 @@
       <div>
         <input id="rtp-url" type="url"
                placeholder="https://example.com/clip.rtp"
-               value="https://samples.osamu620.dev/1080p2997_10bit_150frames.rtp">
+               value="https://samples.osamu620.dev/Spark_4K_2997_422_1.7bpp.rtp">
         <div style="font-size:11px;color:var(--text-sub);margin-top:6px;">
           Requires CORS <code>Access-Control-Allow-Origin</code> on the host.
         </div>


### PR DESCRIPTION
## Summary
- Changes the hardcoded default URL in rtp_demo.html to the 4K Spark clip served from the newly-bound custom-domain R2 bucket (samples.osamu620.dev).
- Paired with the previous 2GB memory cap + auto-reduce-from-1 fix, this makes 4K the default demo experience — what the LinkedIn promo wants to show off.

## Test plan
- [x] CI green (static site change only; no WASM code changes)
- [ ] After merge + deploy, https://htj2k-demo.pages.dev/rtp_demo.html shows the new URL in the input
- [ ] Press Play works end-to-end: 4K clip downloads from R2 edge, CORS preflight passes (bucket CORS rule allows pages.dev origin), WASM decodes at reduce_NL=1 (auto), playback is smooth

## Notes
- The previous `/samples/...` default only worked if the Pages `_redirects` rewrite proxied to r2.dev — but rewrites-to-external-URLs aren't supported by Pages, so the URL had been silently broken for external visitors.  Direct custom-domain URL avoids the whole proxy question.