### PR TITLE
feat(wasm): switch 1080p rtp_demo URL to CloudFront

### DIFF
--- a/subprojects/rtp_demo.html
+++ b/subprojects/rtp_demo.html
@@ -329,7 +329,7 @@
             4K 29.97 10bit 4:2:2 @ 1.7 bpp — Spark (Cloudflare R2)
           </option>
           <option value="https://dgto7aaavl083.cloudfront.net/2026_04_14_osamu_rtp_file/1080p2997_10bit_150frames.rtp">
-            1080p 29.97 10bit 4:2:2 — 150 frames (AWS S3 us-west-1)
+            1080p 29.97 10bit 4:2:2 — 150 frames (AWS CloudFront)
           </option>
         </select>
         <div style="font-size:11px;color:var(--text-sub);margin-top:6px;">

--- a/subprojects/rtp_demo.html
+++ b/subprojects/rtp_demo.html
@@ -328,7 +328,7 @@
           <option value="https://samples.osamu620.dev/Spark_4K_2997_422_1.7bpp.rtp" selected>
             4K 29.97 10bit 4:2:2 @ 1.7 bpp — Spark (Cloudflare R2)
           </option>
-          <option value="https://20210305-how-cloudfront.s3.us-west-1.amazonaws.com/2026_04_14_osamu_rtp_file/1080p2997_10bit_150frames.rtp">
+          <option value="https://dgto7aaavl083.cloudfront.net/2026_04_14_osamu_rtp_file/1080p2997_10bit_150frames.rtp">
             1080p 29.97 10bit 4:2:2 — 150 frames (AWS S3 us-west-1)
           </option>
         </select>


### PR DESCRIPTION
## Summary
- Update the 1080p preset in `subprojects/rtp_demo.html` to serve from a CloudFront distribution instead of the direct S3 URL.

## Test plan
- [ ] Open `rtp_demo.html`, select the 1080p preset, and confirm the clip loads/plays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)