### PR TITLE
feat(wasm): add Chimera 4K preset to rtp_demo

### DIFF
--- a/subprojects/rtp_demo.html
+++ b/subprojects/rtp_demo.html
@@ -326,7 +326,7 @@
         <select id="rtp-preset">
           <option value="">— Preset (none) —</option>
           <option value="https://samples.osamu620.dev/Spark_4K_2997_422_1.7bpp.rtp" selected>
-            4K 29.97 10bit 4:2:2 @ 1.7 bpp — Spark (Cloudflare R2)
+            4K 29.97 10bit 4:2:2 @ 1.7 bpp — Spark (Cloudflare R2, origin only — not edge-cached)
           </option>
           <option value="https://dgto7aaavl083.cloudfront.net/2026_04_14_osamu_rtp_file/1080p2997_10bit_150frames.rtp">
             1080p 29.97 10bit 4:2:2 — 150 frames (AWS CloudFront)

--- a/subprojects/rtp_demo.html
+++ b/subprojects/rtp_demo.html
@@ -331,6 +331,9 @@
           <option value="https://dgto7aaavl083.cloudfront.net/2026_04_14_osamu_rtp_file/1080p2997_10bit_150frames.rtp">
             1080p 29.97 10bit 4:2:2 — 150 frames (AWS CloudFront)
           </option>
+          <option value="https://samples.osamu620.dev/NETFLIX_Chimera_EP01_300fra_2160p_2997_0.9_10b_422.rtp">
+            4K 29.97 10bit 4:2:2 @ 0.9 bpp — Chimera EP01, 300 frames (Cloudflare R2)
+          </option>
         </select>
         <div style="font-size:11px;color:var(--text-sub);margin-top:6px;">
           Or use the file picker:


### PR DESCRIPTION
## Summary
- Add the Netflix Chimera EP01 clip (4K 29.97, 10-bit 4:2:2 @ 0.9 bpp, 300 frames) as a third preset in `subprojects/rtp_demo.html`. Served from the same Cloudflare-fronted R2 bucket as the existing 4K Spark preset, with a Cloudflare Cache Rule in place for edge caching.

## Test plan
- [ ] Open `rtp_demo.html`, select the new "Chimera EP01" preset, and confirm the clip loads and plays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)