### PR TITLE
feat(wasm): swap Chimera preset for Spark part 6/8 (edge-cached)

### DIFF
--- a/subprojects/rtp_demo.html
+++ b/subprojects/rtp_demo.html
@@ -331,8 +331,8 @@
           <option value="https://dgto7aaavl083.cloudfront.net/2026_04_14_osamu_rtp_file/1080p2997_10bit_150frames.rtp">
             1080p 29.97 10bit 4:2:2 — 150 frames (AWS CloudFront)
           </option>
-          <option value="https://samples.osamu620.dev/NETFLIX_Chimera_EP01_300fra_2160p_2997_0.9_10b_422.rtp">
-            4K 29.97 10bit 4:2:2 @ 0.9 bpp — Chimera EP01, 300 frames (Cloudflare R2)
+          <option value="https://samples.osamu620.dev/Spark_4K_2997_422_1.7bpp.part06of08.rtp">
+            4K 29.97 10bit 4:2:2 @ 1.7 bpp — Spark part 6/8 (Cloudflare R2, edge-cached)
           </option>
         </select>
         <div style="font-size:11px;color:var(--text-sub);margin-top:6px;">


### PR DESCRIPTION
## Summary
- Replace the Chimera preset (added in #228) with a 280 MiB Spark codestream chunk (`part06of08`) served from the same Cloudflare-fronted R2 bucket.
- The chunked file fits under Cloudflare's 512 MiB free-tier cache-object limit, so it edge-caches (verified: `cf-cache-status: MISS` → `HIT` on consecutive GETs).

## Test plan
- [ ] Open `rtp_demo.html`, select the "Spark part 6/8" preset, and confirm the clip loads and plays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)