### PR TITLE
fix(wasm): sync rtp_demo URL input default with selected preset

### DIFF
--- a/subprojects/rtp_demo.html
+++ b/subprojects/rtp_demo.html
@@ -343,7 +343,7 @@
       <div>
         <input id="rtp-url" type="url"
                placeholder="https://example.com/clip.rtp"
-               value="https://samples.osamu620.dev/Spark_4K_2997_422_1.7bpp.rtp">
+               value="https://samples.osamu620.dev/Spark_4K_2997_422_1.7bpp.part06of08.rtp">
         <div style="font-size:11px;color:var(--text-sub);margin-top:6px;">
           Requires CORS <code>Access-Control-Allow-Origin</code> on the host.
         </div>


### PR DESCRIPTION
## Summary
- The URL `<input>` in `subprojects/rtp_demo.html` still carried the old 2 GiB Spark URL as its default `value`, while the preset dropdown's `selected` option is now the edge-cached `part06of08` chunk. Sync the two so the input matches the selected preset on page load.

## Test plan
- [ ] Open `rtp_demo.html`; confirm the URL input pre-fills with `…Spark_4K_2997_422_1.7bpp.part06of08.rtp` and clicking Play streams from the edge-cached object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)