### PR TITLE
fix(wasm): parseRtpStream background pump — fix paced-mode stall on slow decoders

### DIFF
--- a/subprojects/rtp_parser.js
+++ b/subprojects/rtp_parser.js
@@ -59,32 +59,77 @@ function quickParseRtp(pkt) {
  * Async generator over RTP packets in a .rtp file.
  * @param {string | Uint8Array | ReadableStream<Uint8Array>} source
  *     URL to fetch, a Uint8Array containing the file bytes, or a ReadableStream.
+ * @param {object} [opts]
+ * @param {(n: number) => void} [opts.onChunk]
+ *     Fires per chunk received from the underlying stream.  Used by the
+ *     caller to measure network-delivery rate vs. packet-consumption rate.
+ * @param {number} [opts.highWaterMark=128*1024*1024]
+ *     Maximum in-memory buffer size (bytes).  The background pump pauses
+ *     reading once the buffer grows past this; it resumes as the consumer
+ *     drains.  Higher values protect against decoder-rate ↔ network-rate
+ *     mismatches at the cost of JS heap.
  * @yields {{bytes: Uint8Array, seq: number, timestamp: number, marker: boolean}}
  *     `bytes` is valid only until the next `next()` call — copy it if you need
  *     to retain the data.
  */
 export async function* parseRtpStream(source, opts = {}) {
-  const reader = await sourceToReader(source);
-  const buf    = new RollingBuffer();
-  let   eof    = false;
-  // Optional callback invoked once per chunk received from the underlying
-  // stream — lets the caller measure disk-read rate vs. packet-consumption rate.
+  const reader  = await sourceToReader(source);
+  const buf     = new RollingBuffer();
   const onChunk = typeof opts.onChunk === 'function' ? opts.onChunk : null;
+  // 128 MiB default — absorbs large producer/consumer rate mismatches so
+  // the fetch reader never sits idle long enough to trip Cloudflare/NAT
+  // connection timeouts we've seen with on-demand reads on slow decoders.
+  const HIGH_WATER_MARK = opts.highWaterMark ?? (128 * 1024 * 1024);
 
-  async function fillAtLeast(nBytes) {
-    while (buf.length < nBytes && !eof) {
-      const { value, done } = await reader.read();
-      if (done) { eof = true; break; }
-      if (value && value.length) {
-        buf.append(value);
-        if (onChunk) onChunk(value.length);
+  let eof       = false;   // reader exhausted (or consumer finished)
+  let readError = null;    // deferred error from the pump — rethrown in waitForBytes
+
+  // Background pump: drain the reader into `buf` as fast as the network
+  // delivers bytes, independent of the consumer's packet-yield rate.
+  // When `buf` exceeds HIGH_WATER_MARK, the pump sleeps briefly before
+  // checking again (backpressure to the network via reader.read()).  The
+  // consumer path below calls buf.consume() as it yields packets, which
+  // naturally lets the buffer drain and unblocks the pump.
+  //
+  // Why a pump at all: the previous on-demand design called reader.read()
+  // only when the for-await body asked for more bytes.  A slow decoder
+  // starved those reads, which made the fetch socket idle for seconds
+  // and triggered Cloudflare- or NAT-side stream cancellation (observed
+  // as a hard stall after ~60 MB, see rtp_demo PR history).
+  const pumpDone = (async () => {
+    try {
+      while (!eof) {
+        if (buf.length > HIGH_WATER_MARK) {
+          await new Promise(r => setTimeout(r, 10));
+          continue;
+        }
+        const { value, done } = await reader.read();
+        if (done) break;
+        if (value && value.length) {
+          buf.append(value);
+          if (onChunk) onChunk(value.length);
+        }
       }
+    } catch (e) {
+      readError = e;
+    } finally {
+      eof = true;
     }
+  })();
+
+  // Wait until at least `nBytes` are in the buffer (or the pump finishes).
+  // 1 ms polling is cheap and fine for this workload; we're not trying to
+  // meet sub-millisecond latency — the decoder takes tens of ms per frame.
+  async function waitForBytes(nBytes) {
+    while (buf.length < nBytes && !eof) {
+      await new Promise(r => setTimeout(r, 1));
+    }
+    if (readError) throw readError;
   }
 
   try {
     while (true) {
-      await fillAtLeast(4);
+      await waitForBytes(4);
       if (buf.length < 4) return;          // clean EOF
       const hdr    = buf.bytes(0, 4);
       const marker = (hdr[0] << 8) | hdr[1];
@@ -92,7 +137,7 @@ export async function* parseRtpStream(source, opts = {}) {
         throw new Error(`parseRtpStream: bad marker 0x${marker.toString(16)} at stream offset`);
       }
       const length = (hdr[2] << 8) | hdr[3];
-      await fillAtLeast(4 + length);
+      await waitForBytes(4 + length);
       if (buf.length < 4 + length) {
         throw new Error(`parseRtpStream: truncated packet (need ${length} bytes)`);
       }
@@ -102,11 +147,13 @@ export async function* parseRtpStream(source, opts = {}) {
       buf.consume(4 + length);
     }
   } finally {
-    // Called on normal completion, exception, or when the consumer calls
-    // iterator.return() (for-await `break`).  Cancel the underlying stream
-    // so the Blob's file reader / fetch network socket closes and nothing
-    // leaks across play→stop→play cycles.
+    // Called on normal completion, exception, or iterator.return() (for-await
+    // `break`).  Flag eof so the pump's HIGH_WATER_MARK sleep loop exits,
+    // then cancel the underlying reader to close the fetch socket / Blob
+    // reader so nothing leaks across play→stop→play cycles.
+    eof = true;
     try { await reader.cancel(); } catch (e) { /* ignore */ }
+    try { await pumpDone; }        catch (e) { /* ignore */ }
     try { reader.releaseLock(); }  catch (e) { /* ignore */ }
   }
 }


### PR DESCRIPTION
## Summary
- Runs network reads in a background async pump that continuously drains the fetch ReadableStream into the existing RollingBuffer, up to a 128 MiB high-water mark.
- Replaces the old on-demand \`fillAtLeast()\` (which only called \`reader.read()\` when the consumer needed bytes) with a polling \`waitForBytes()\` against the pump-filled buffer.
- Pure \`subprojects/rtp_parser.js\` change; \`rtp_demo.html\` is unchanged.

## Why
Pierre (US West) consistently hit a hard stall in paced mode on the Spark 4K preset: after ~55k packets / ~60 MB, \`Network: 0 in / 0 parsed Mbps\` for 20+ seconds, with \`chunk=0 parsed=0 dec=7 paceDrops=35 ring=0\`. ASAP mode on the same machine played all 164 frames fine, just slower — so the network itself was capable, but something about paced mode's pacing knocked the fetch stream offline.

Root cause: under paced-mode pre-decode drop, the packet loop alternates between **bursting** through packets (drop + \`continue\`, no decode) and **blocking** the main thread for ~91 ms inside \`decodeFrame()\`. With reads driven by the for-await body, \`reader.read()\` was called at that same bursty-then-silent cadence. After ~60 MB of bursts and long gaps, the fetch socket is dropped silently (Cloudflare HTTP/2 stream timeout and/or the stateful NAT on the viewer's side), and the browser never surfaces the fact.

ASAP mode avoids the pattern because every completed frame triggers a ~91 ms decode on the main thread, which naturally spaces out \`reader.read()\` calls to a steady ~11/sec — the socket never idles long enough to be dropped.

## Fix architecture
```
[network]  →  reader.read()  ──┐
                               ↓   (async pump, continuous)
                          RollingBuffer  ≤ 128 MiB
                               ↓   (waitForBytes poll)
           for-await consumer ─┘
```

- Pump runs as soon as the generator starts; sleeps 10 ms when buffer > \`highWaterMark\`.
- Consumer yield polls the buffer at 1 ms granularity (fine — decoder takes 10s of ms per frame).
- Errors from \`reader.read()\` are stashed and rethrown in the next \`waitForBytes()\` call.
- \`finally\` still cancels the reader + releases the lock on clean exit, early break, or exception.

## Trade-offs
- **Heap**: up to 128 MiB for the in-flight buffer. Configurable via \`opts.highWaterMark\`; 128 MiB absorbs the 280 MiB Spark preset's producer/consumer mismatch completely at typical US West throughput.
- **Very large files** (e.g., the 2 GiB full-Spark preset): pump pauses on high-water and resumes on drain; if a slow decoder holds the buffer near full for minutes the same mystery-timeout *could* recur, but that preset is already labelled "origin only — not edge-cached" and is not the default.
- **Consumer-visible API**: unchanged.

## Test plan
- [ ] Pierre (original reporter) confirms paced-mode playback of the Spark preset no longer stalls
- [ ] Fast-decoder path (Tokyo) still smooth in paced mode — no regression in \`Display FPS / Decode FPS / Pace drops\`
- [ ] ASAP mode (\`?pacing=max\`) still plays end-to-end; no behavioural change expected
- [ ] Pause / resume mid-stream: pump sleeps while ring+buffer hold bytes; resume doesn't sprint
- [ ] Stop mid-stream: clean teardown, no leaked socket (DevTools Network tab shows request cancelled)
- [ ] Local File blob source (\`File.stream()\`) still works (same ReadableStream API internally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)