### PR TITLE
chore(wasm): default rtp_demo to As-fast-as-possible; pace-drop opt-in

### DIFF
--- a/subprojects/rtp_demo.html
+++ b/subprojects/rtp_demo.html
@@ -373,9 +373,14 @@
             <option value="bt709">BT.709</option>
           </select>
         </label>
-        <label><input type="radio" name="pacing" value="paced" checked> Paced (RTP clock)</label>
-        <label><input type="radio" name="pacing" value="max"> As-fast-as-possible</label>
+        <label><input type="radio" name="pacing" value="paced"> Paced (RTP clock)</label>
+        <label><input type="radio" name="pacing" value="max" checked> As-fast-as-possible</label>
       </div>
+    </div>
+    <div style="font-size:11px; color:var(--text-sub); margin-top:10px;">
+      Default is <b>As-fast-as-possible</b>. Paced playback requires a
+      high-performance CPU (decoder must sustain source frame rate);
+      on slower machines the Paced mode may stutter or stall.
     </div>
   </div>
 
@@ -619,13 +624,11 @@ let ycbcrMode = 'auto';
 // Network-pacing frame drop: when wall-clock is past a frame's target by
 // more than PACE_DROP_PERIODS frame periods we skip decoding it and discard
 // the WASM reassembler's ready slot, keeping playback loosely aligned with
-// the RTP clock.  The threshold is generous because a decoder that runs
-// just below real-time (e.g. 28 fps on a 30 fps source) will accumulate
-// sub-period lag every frame and otherwise trigger a burst of drops —
-// whereas letting it run freely produces visibly smoother playback at a
-// marginally lower display FPS.  Override via ?drop_periods=N; disable
-// entirely with ?nodrop=1.
-const PACE_DROP_ENABLED = !(new URLSearchParams(location.search).has('nodrop'));
+// the RTP clock.  Off by default — slow decoders otherwise get stuck in a
+// burst-then-stall pattern that trips Cloudflare/NAT timeouts.  Opt in
+// with ?drop=1; tune the threshold via ?drop_periods=N.  ?nodrop=1 is
+// kept as a legacy synonym for the default (no-op).
+const PACE_DROP_ENABLED = new URLSearchParams(location.search).has('drop');
 const PACE_DROP_PERIODS = Math.max(1,
     Number(new URLSearchParams(location.search).get('drop_periods')) || 8);
 

--- a/subprojects/rtp_demo.html
+++ b/subprojects/rtp_demo.html
@@ -272,6 +272,41 @@
       color: var(--accent); text-decoration: none;
       display: inline-flex; align-items: center; gap: 6px;
     }
+
+    /* Collapsible URL-parameters reference. */
+    .url-params {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: var(--radius); padding: 14px 20px; margin-bottom: 20px;
+      font-size: 13px;
+    }
+    .url-params > summary {
+      cursor: pointer; font-weight: 600; color: var(--text-sub);
+      font-size: 12px; text-transform: uppercase; letter-spacing: 0.6px;
+      list-style: none;          /* hide default marker */
+      user-select: none;
+    }
+    .url-params > summary::before {
+      content: "▸ "; color: var(--accent); display: inline-block;
+      transition: transform 0.15s;
+    }
+    .url-params[open] > summary::before { content: "▾ "; }
+    .url-params table {
+      width: 100%; border-collapse: collapse; margin-top: 12px;
+    }
+    .url-params th, .url-params td {
+      text-align: left; padding: 6px 10px;
+      border-bottom: 1px solid var(--border);
+      vertical-align: top;
+    }
+    .url-params th {
+      color: var(--text-sub); font-weight: 600; font-size: 11px;
+      text-transform: uppercase; letter-spacing: 0.5px;
+    }
+    .url-params td code {
+      background: var(--bg); padding: 1px 5px; border-radius: 3px;
+      font-size: 12px; color: var(--accent);
+    }
+    .url-params tr:last-child td { border-bottom: none; }
   </style>
 </head>
 
@@ -470,6 +505,60 @@
       <span id="statMbps">—</span>
     </div>
   </section>
+
+  <!-- URL-parameters reference (collapsed by default). -->
+  <details class="url-params">
+    <summary>URL parameters</summary>
+    <table>
+      <thead>
+        <tr><th>Parameter</th><th>Default</th><th>Values</th><th>Effect</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>?variant=</code></td>
+          <td><code>auto</code></td>
+          <td><code>auto</code> · <code>mt_simd</code> · <code>simd</code> · <code>mt</code> · <code>scalar</code></td>
+          <td>Force a specific WASM build. <code>auto</code> picks the best available for the browser.</td>
+        </tr>
+        <tr>
+          <td><code>?renderer=</code></td>
+          <td><code>auto</code></td>
+          <td><code>auto</code> · <code>webgl</code> · <code>2d</code></td>
+          <td>Force the renderer. <code>auto</code> prefers WebGL2 and falls back to Canvas 2D.</td>
+        </tr>
+        <tr>
+          <td><code>?drop=1</code></td>
+          <td>off</td>
+          <td>presence toggle</td>
+          <td>Enable paced-mode frame dropping (skip frames whose RTP-clock target is too far past). Off by default — slow decoders play slow-motion rather than stall.</td>
+        </tr>
+        <tr>
+          <td><code>?drop_periods=</code></td>
+          <td><code>8</code></td>
+          <td>integer ≥ 1</td>
+          <td>Number of frame periods of slack before a frame is dropped (only when <code>?drop=1</code>). At 29.97 fps the default is ≈ 267 ms.</td>
+        </tr>
+        <tr>
+          <td><code>?nodrop=1</code></td>
+          <td>—</td>
+          <td>presence toggle</td>
+          <td>Legacy synonym for the current default (no dropping). Kept for URL compatibility; has no additional effect.</td>
+        </tr>
+        <tr>
+          <td><code>?preroll=</code></td>
+          <td><code>3</code></td>
+          <td>integer ≥ 0</td>
+          <td>Frames decoded back-to-back before the paced wall clock anchors. Absorbs cold-start decode spikes (SIMD warmup, WASM JIT).</td>
+        </tr>
+        <tr>
+          <td><code>?verbose=1</code></td>
+          <td>off</td>
+          <td>presence toggle</td>
+          <td>Emit one <code>[rtp_demo t=Ns …]</code> line per second to the browser console with full pipeline stats.</td>
+        </tr>
+      </tbody>
+    </table>
+  </details>
 
   <footer class="site-footer">
     <a href="https://github.com/osamu620/OpenHTJ2K" target="_blank" rel="noopener">


### PR DESCRIPTION
## Summary
- Pacing radio defaults to **As-fast-as-possible** (was Paced).
- `PACE_DROP_ENABLED` flips to opt-in via `?drop=1` (was opt-out via `?nodrop=1`).
- `?nodrop=1` kept as a legacy synonym for the now-default no-drop behaviour.
- Short note under the controls explaining the tradeoff.
- Collapsible **URL parameters** reference table above the footer listing every query param and its effect, so users can discover the knobs without reading the source.

## Why
Paced + drop was great on fast decoders but produced a hard stall for slower machines — Pierre (US West) reported playback freezing after ~1 s on the Spark preset, and the data showed the burst-then-stall pattern created by pre-decode pace-drop tripping a Cloudflare/NAT timeout. The pump in #234 keeps the fetch socket alive, but that doesn't help the user-visible stutter that comes from a decoder running slower than the source rate while we still try to enforce the RTP clock.

ASAP by default means: decoder runs at natural rate, every decoded frame displays. On a fast machine it looks the same as Paced (decoder keeps up with source rate). On a slow machine it plays slow-motion but never stalls. Users who specifically want strict RTP-clock pacing for live-source emulation can still select Paced from the radio.

The URL-parameters table surfaces all existing tuning knobs (`?variant`, `?renderer`, `?drop`, `?drop_periods`, `?nodrop`, `?preroll`, `?verbose`) in a collapsed `<details>` above the footer, styled to match existing cards.

## Test plan
- [ ] Fresh load of `https://htj2k-demo.pages.dev/rtp_demo.html` — As-fast-as-possible is preselected; note is visible under the controls
- [ ] Click Play — smooth playback to the end
- [ ] Manually select Paced radio → playback matches source rate on a fast machine; falls back to slow-mo on a slow machine (no drops, no stall)
- [ ] `?drop=1` → pace-drop re-enabled; verified by watching `Pace drops` chip climb when decoder is marginal
- [ ] `?nodrop=1` → still works as a synonym for the default
- [ ] "URL parameters" section at the bottom opens on click and matches the table above

🤖 Generated with [Claude Code](https://claude.com/claude-code)