### PR TITLE
feat(wasm): add Sollevante presets + default to 1080p 24fps

### DIFF
--- a/.github/deploy/rtp-samples.txt
+++ b/.github/deploy/rtp-samples.txt
@@ -1,2 +1,4 @@
 https://samples.osamu620.dev/Spark_4K_2997_422_1.7bpp.part06of08.rtp
 https://samples.osamu620.dev/Spark_4K_2997_422_1.7bpp.rtp
+https://samples.osamu620.dev/sollevante_1080p_24_422_744frames_1.5bpp.rtp
+https://samples.osamu620.dev/sollevante_2160p_24_422_300frame_0.9bpps.rtp

--- a/subprojects/rtp_demo.html
+++ b/subprojects/rtp_demo.html
@@ -366,13 +366,13 @@
           <option value="https://dgto7aaavl083.cloudfront.net/2026_04_14_osamu_rtp_file/1080p2997_10bit_150frames.rtp">
             1080p 29.97 10bit 4:2:2 — 150 frames (AWS CloudFront)
           </option>
-          <option value="https://samples.osamu620.dev/sollevante_1080p_24_422_744frames_1.5bpp.rtp">
+          <option value="https://samples.osamu620.dev/sollevante_1080p_24_422_744frames_1.5bpp.rtp" selected>
             1080p 24 4:2:2 @ 1.5 bpp — Sollevante 744 frames (Cloudflare R2, edge-cached)
           </option>
           <option value="https://samples.osamu620.dev/sollevante_2160p_24_422_300frame_0.9bpps.rtp">
             4K 24 4:2:2 @ 0.9 bpp — Sollevante 300 frames (Cloudflare R2, edge-cached)
           </option>
-          <option value="https://samples.osamu620.dev/Spark_4K_2997_422_1.7bpp.part06of08.rtp" selected>
+          <option value="https://samples.osamu620.dev/Spark_4K_2997_422_1.7bpp.part06of08.rtp">
             4K 29.97 10bit 4:2:2 @ 1.7 bpp — Spark part 6/8 (Cloudflare R2, edge-cached)
           </option>
         </select>
@@ -384,7 +384,7 @@
       <div>
         <input id="rtp-url" type="url"
                placeholder="https://example.com/clip.rtp"
-               value="https://samples.osamu620.dev/Spark_4K_2997_422_1.7bpp.part06of08.rtp">
+               value="https://samples.osamu620.dev/sollevante_1080p_24_422_744frames_1.5bpp.rtp">
         <div style="font-size:11px;color:var(--text-sub);margin-top:6px;">
           Requires CORS <code>Access-Control-Allow-Origin</code> on the host.
         </div>

--- a/subprojects/rtp_demo.html
+++ b/subprojects/rtp_demo.html
@@ -366,6 +366,12 @@
           <option value="https://dgto7aaavl083.cloudfront.net/2026_04_14_osamu_rtp_file/1080p2997_10bit_150frames.rtp">
             1080p 29.97 10bit 4:2:2 — 150 frames (AWS CloudFront)
           </option>
+          <option value="https://samples.osamu620.dev/sollevante_1080p_24_422_744frames_1.5bpp.rtp">
+            1080p 24 4:2:2 @ 1.5 bpp — Sollevante 744 frames (Cloudflare R2, edge-cached)
+          </option>
+          <option value="https://samples.osamu620.dev/sollevante_2160p_24_422_300frame_0.9bpps.rtp">
+            4K 24 4:2:2 @ 0.9 bpp — Sollevante 300 frames (Cloudflare R2, edge-cached)
+          </option>
           <option value="https://samples.osamu620.dev/Spark_4K_2997_422_1.7bpp.part06of08.rtp" selected>
             4K 29.97 10bit 4:2:2 @ 1.7 bpp — Spark part 6/8 (Cloudflare R2, edge-cached)
           </option>


### PR DESCRIPTION
## Summary
- Adds two new preset entries to the `rtp_demo.html` dropdown:
  - **1080p 24 4:2:2 @ 1.5 bpp — Sollevante 744 frames** (294 MB, ~31 s)
  - **4K 24 4:2:2 @ 0.9 bpp — Sollevante 300 frames** (285 MB, ~12.5 s)
- Makes the **Sollevante 1080p** clip the new default preset (both the dropdown's `selected` and the `rtp-url` input's `value=`). A 1080p 24 fps source is a better out-of-the-box choice than 4K 29.97 fps — decode headroom is ~3× easier, so modest hardware sees smooth playback rather than a choppy 4K clip.
- Appends both new URLs to `.github/deploy/rtp-samples.txt` so the `warm-rtp-cache` workflow auto-warms the US POPs on merge.

## Eligibility
Both files are ≤512 MiB, below Cloudflare's per-object cache-size limit. The existing zone Cache Rule for `*.rtp` on `samples.osamu620.dev` covers them with Edge TTL 30 days.

## Test plan
- [ ] Fresh load of `htj2k-demo.pages.dev/rtp_demo.html` — Sollevante 1080p is preselected, URL field matches
- [ ] Preset dropdown shows all five entries; switching preselects the URL field correctly
- [ ] Actions → warm-rtp-cache run after merge: log shows `cf-ray: …-LAX/SJC`, initial `MISS` then subsequent `HIT` for both new URLs
- [ ] Sollevante 4K preset plays (may be slow-mo on weaker CPUs — expected given the ASAP default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)