### PR TITLE
docs(wasm): credit Netflix Open Content for Sol Levante and Sparks

### DIFF
--- a/subprojects/rtp_demo.html
+++ b/subprojects/rtp_demo.html
@@ -570,6 +570,10 @@
     <a href="https://github.com/osamu620/OpenHTJ2K" target="_blank" rel="noopener">
       osamu620/OpenHTJ2K
     </a>
+    <div style="margin-top:10px; font-size:12px;">
+      Test content <i>Sol Levante</i> and <i>Sparks</i> courtesy of
+      <a href="https://opencontent.netflix.com/" target="_blank" rel="noopener">Netflix Open Content</a>.
+    </div>
   </footer>
 
 <script type="module">


### PR DESCRIPTION
## Summary
- Adds a footer attribution linking to [Netflix Open Content](https://opencontent.netflix.com/) for the *Sol Levante* and *Sparks* clips used as decoder test material in the preset list.

## Why
Netflix releases these clips under Creative Commons with an attribution request. The demo's preset list has been using them since the Spark and Sollevante presets were added; the credit line formalises that.

## Test plan
- [ ] Footer on `htj2k-demo.pages.dev/rtp_demo.html` shows the new line with a working link to `opencontent.netflix.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)