### PR TITLE
fix(enc): PnmStreamReader header overread on whitespace pixel bytes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ perf.data.old
 
 # Cloudflare Wrangler local state (OAuth tokens, cache, etc.)
 .wrangler/
+
+# Working planning notes that live in the repo for the author's
+# convenience and should not be tracked.
+PHASE2_PLAN.md

--- a/source/apps/encoder/main_enc.cpp
+++ b/source/apps/encoder/main_enc.cpp
@@ -138,8 +138,19 @@ class PnmStreamReader : public StreamReader {
     width_  = read_uint(fp_);
     height_ = read_uint(fp_);
     uint32_t maxval = read_uint(fp_);
-    // Skip arbitrary whitespace and comments after maxval to reach first pixel byte
-    skip_ws(fp_);
+    // Per the netpbm PPM/PGM binary spec (P5/P6), the maxval field is followed
+    // by EXACTLY ONE whitespace character; the very next byte starts the
+    // raster.  read_uint() already ungetc'd the trailing whitespace, so we
+    // consume that single byte here.  A previous version called skip_ws()
+    // which kept eating bytes greedily — fine until the first pixel value
+    // happened to be 0x09/0x0A/0x0D/0x20 (e.g. NASA Blue Marble crops where
+    // R≈10), at which point the first 1–3 pixel bytes were misread as
+    // "header whitespace" and every fread shifted, eventually overrunning
+    // EOF on the last row and aborting with "fread: failed to read row data".
+    {
+      const int sep = fgetc(fp_);
+      if (sep != ' ' && sep != '\t' && sep != '\n' && sep != '\r') return -1;
+    }
 
     if (maxval == 0 || maxval > 65535) return -1;
     // Compute the exact bit depth from maxval (e.g. 4095 → 12, 255 → 8).

--- a/source/apps/encoder/main_enc.cpp
+++ b/source/apps/encoder/main_enc.cpp
@@ -466,6 +466,7 @@ int main(int argc, char *argv[]) {
         total_size = encoder.invoke_line_based_stream(
             [&reader](uint32_t y, int32_t **rows, uint16_t nc) { reader->get_row(y, rows, nc); });
       } catch (std::exception &exc) {
+        printf("ERROR: encoder.invoke_line_based_stream failed: %s\n", exc.what());
         return EXIT_FAILURE;
       }
     }
@@ -548,6 +549,7 @@ int main(int argc, char *argv[]) {
       try {
         total_size = encoder.invoke();
       } catch (std::exception &exc) {
+        printf("ERROR: encoder.invoke() failed: %s\n", exc.what());
         return EXIT_FAILURE;
       }
     }


### PR DESCRIPTION
## Summary

- **The actual fix**: `PnmStreamReader::open()` greedily called `skip_ws()` after `maxval`, but the netpbm P5/P6 binary spec mandates exactly *one* whitespace character between `maxval` and the raster.  Any PPM whose first pixel byte happened to be 0x09 / 0x0A / 0x0D / 0x20 (e.g. NASA Blue Marble dark‑ocean centre crops where R≈10) had its first 1–3 pixel bytes silently consumed as "header whitespace", every subsequent `fseek+fread` was misaligned, and the last row's read overran EOF and threw `"fread: failed to read row data"`.  Replaced with a single `fgetc` that consumes exactly one separator byte and rejects the file if it isn't whitespace.
- **Diagnostic improvement**: the two `catch (std::exception&)` blocks in `main_enc.cpp` were swallowing the message and returning `EXIT_FAILURE` silently; now they print `exc.what()` first.  This change alone would have saved a day of bisection on the bug above and is the reason the bug took ten minutes to find once it was in.
- **Housekeeping**: gitignore `PHASE2_PLAN.md` (working notes that should not be tracked).

## Why the symptoms were so confusing

Failure depended only on whether the *first* pixel byte of the cropped region happened to be a whitespace code, which had nothing to do with image dimensions per se.  Centre crops of NASA imagery happened to land on dark ocean for most aspect ratios but not all, so the bug looked like a mysterious size/aspect threshold:

- 1920×1080 → fails (first R = 0x0A)
- 1920×1920 → works (first R = 0xa5)
- 2000×2000 → fails
- 1994×8000 → works
- The full 21600×10800 → fails (first R = 0x0A)

## Test plan

- [x] All 582 existing ctests pass.
- [x] Re-encode every previously-failing dimension: 1920×1080, 1995², 2000², 2048², 3000², 4000² centre crops — all succeed and round-trip through `open_htj2k_dec` to valid PPMs.
- [x] **The full 233 MP NASA Blue Marble (21600 × 10800)** at PCRL + 128×128 precincts encodes in 1.76 s to an 11.5 MB foveation-friendly codestream and round-trips through the decoder cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)