### PR TITLE
feat(jpip): Phase 1 — partial-decode pipeline + foveation demo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,6 +302,24 @@ if (OPENHTJ2K_RTP AND NOT EMSCRIPTEN)
         target_link_libraries(open_htj2k_rtp_recv PUBLIC open_htj2k glfw OpenGL::GL)
       endif()
       target_link_libraries(open_htj2k_rtp_decode_profile PUBLIC open_htj2k)
+
+      # JPIP Phase-1 foveation demo — shares the rtp_recv renderer, so it
+      # lives in the same glfw-gated block.
+      message(STATUS "OPENHTJ2K_RTP: building open_htj2k_jpip_demo")
+      add_executable(open_htj2k_jpip_demo)
+      add_subdirectory(source/apps/jpip_demo)
+      set_target_properties(
+        open_htj2k_jpip_demo
+        PROPERTIES OUTPUT_NAME
+                   $<IF:$<CONFIG:Debug>,open_htj2k_jpip_demo_dbg,open_htj2k_jpip_demo>)
+      if (APPLE)
+        target_link_libraries(open_htj2k_jpip_demo PUBLIC open_htj2k glfw
+                              "-framework Metal" "-framework QuartzCore" "-framework Cocoa")
+      elseif(WIN32)
+        target_link_libraries(open_htj2k_jpip_demo PUBLIC open_htj2k glfw OpenGL::GL)
+      else()
+        target_link_libraries(open_htj2k_jpip_demo PUBLIC open_htj2k glfw OpenGL::GL)
+      endif()
     else()
       message(WARNING "OPENHTJ2K_RTP requested but glfw3/OpenGL not found; skipping rtp_recv target")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,6 +256,12 @@ add_executable(jpip_index_check)
 add_subdirectory(source/apps/jpip_index_check)
 target_link_libraries(jpip_index_check PUBLIC open_htj2k)
 
+# JPIP Phase-1 partial-decode sanity harness (used by tests/jpip_phase1.cmake)
+add_executable(jpip_partial_decode_check)
+add_subdirectory(source/apps/jpip_partial_decode_check)
+target_include_directories(jpip_partial_decode_check PUBLIC source/core/interface)
+target_link_libraries(jpip_partial_decode_check PUBLIC open_htj2k)
+
 # RFC 9828 RTP receiver (experimental, requires GLFW)
 option(OPENHTJ2K_RTP "Build experimental RFC 9828 RTP receiver (requires GLFW)" OFF)
 if (OPENHTJ2K_RTP AND NOT EMSCRIPTEN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ add_subdirectory(source/core/coding)
 add_subdirectory(source/core/transform)
 add_subdirectory(source/core/interface)
 add_subdirectory(source/core/jph)
+add_subdirectory(source/core/jpip)
 target_include_directories(
     open_htj2k
     PRIVATE source/core/common
@@ -85,6 +86,7 @@ target_include_directories(
     source/core/transform
     # source/core/interface
     source/core/jph
+    source/core/jpip
     # ${CMAKE_CURRENT_SOURCE_DIR}/source/thirdparty/highway
 )
 target_include_directories(open_htj2k INTERFACE source/core/interface source/core/common)
@@ -249,6 +251,11 @@ add_subdirectory(source/apps/lb_compare)
 target_include_directories(lb_compare PUBLIC source/core/interface)
 target_link_libraries(lb_compare PUBLIC open_htj2k)
 
+# JPIP Phase-1 index-check harness (used by tests/jpip_phase1.cmake)
+add_executable(jpip_index_check)
+add_subdirectory(source/apps/jpip_index_check)
+target_link_libraries(jpip_index_check PUBLIC open_htj2k)
+
 # RFC 9828 RTP receiver (experimental, requires GLFW)
 option(OPENHTJ2K_RTP "Build experimental RFC 9828 RTP receiver (requires GLFW)" OFF)
 if (OPENHTJ2K_RTP AND NOT EMSCRIPTEN)
@@ -322,3 +329,4 @@ install(FILES "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${PROJECT_NAME}.pc"
 include(${CMAKE_CURRENT_SOURCE_DIR}/tests/decoder_conformance.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/tests/batch_validation.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/tests/encoder_test.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/tests/jpip_phase1.cmake)

--- a/source/apps/jpip_demo/CMakeLists.txt
+++ b/source/apps/jpip_demo/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_policy(SET CMP0076 NEW)
+
+# Pull the renderer sources (and their GLFW/Metal/GL glue) from the rtp_recv
+# app.  Keeping them in rtp_recv/ avoids duplicating the renderer backend
+# while still letting the demo ship as its own executable.
+set(_RTP_SRC ${CMAKE_SOURCE_DIR}/source/apps/rtp_recv)
+
+target_sources(open_htj2k_jpip_demo
+    PRIVATE
+    main_jpip_demo.cpp
+)
+
+target_include_directories(open_htj2k_jpip_demo
+    PRIVATE
+    ${CMAKE_SOURCE_DIR}/source/core/interface
+    ${CMAKE_SOURCE_DIR}/source/core/jpip
+    ${_RTP_SRC}
+)
+
+if (APPLE)
+    target_sources(open_htj2k_jpip_demo PRIVATE
+        ${_RTP_SRC}/metal_renderer.mm
+    )
+    target_compile_definitions(open_htj2k_jpip_demo PRIVATE OPENHTJ2K_USE_METAL)
+else()
+    target_sources(open_htj2k_jpip_demo PRIVATE
+        ${_RTP_SRC}/gl_renderer.cpp
+        ${_RTP_SRC}/gl_loader.cpp
+    )
+endif()

--- a/source/apps/jpip_demo/main_jpip_demo.cpp
+++ b/source/apps/jpip_demo/main_jpip_demo.cpp
@@ -1,0 +1,290 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+//
+// JPIP Phase-1 mouse-driven foveation demo.
+//
+// Loads a JPEG 2000 codestream (typically the land_shallow_topo_1920_fov.j2c
+// asset produced by the encoder), builds a CodestreamIndex once, opens a
+// window, and redecodes the image every frame with a JPIP precinct filter
+// that picks precincts by concentric cones around the mouse cursor:
+//
+//   fovea     : fsiz = canvas             → all resolutions, tight RoI
+//   parafovea : fsiz = canvas / 2         → drop the finest resolution, wider RoI
+//   periphery : fsiz = canvas / 4         → drop the top two resolutions, whole image
+//
+// The unioned precinct set becomes the decoder's set_precinct_filter, the
+// decode runs, and the resulting RGB frame is uploaded to the rtp_recv
+// renderer (Metal on macOS, OpenGL 3.3 elsewhere).
+//
+// Usage:
+//   open_htj2k_jpip_demo <input.j2c>
+//       [--fovea-radius N=256] [--parafovea-radius N=512]
+//       [--decode-on-move-only] [--no-vsync]
+//
+// Exits on window close or ESC.
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <GLFW/glfw3.h>
+
+#include "decoder.hpp"
+#include "precinct_index.hpp"
+#include "view_window.hpp"
+#include "renderer.hpp"
+
+using open_htj2k::rtp_recv::Renderer;
+using open_htj2k::jpip::CodestreamIndex;
+using open_htj2k::jpip::PrecinctKey;
+using open_htj2k::jpip::ViewWindow;
+
+namespace {
+
+struct Options {
+  std::string infile;
+  uint32_t    fovea_radius     = 256;
+  uint32_t    parafovea_radius = 512;
+  bool        decode_on_move   = false;
+  bool        vsync            = true;
+};
+
+bool parse_args(int argc, char **argv, Options &opt) {
+  for (int i = 1; i < argc; ++i) {
+    const std::string a = argv[i];
+    if (a == "--fovea-radius" && i + 1 < argc)      opt.fovea_radius = static_cast<uint32_t>(std::stoul(argv[++i]));
+    else if (a == "--parafovea-radius" && i + 1 < argc) opt.parafovea_radius = static_cast<uint32_t>(std::stoul(argv[++i]));
+    else if (a == "--decode-on-move-only")          opt.decode_on_move = true;
+    else if (a == "--no-vsync")                     opt.vsync = false;
+    else if (a.size() > 0 && a[0] != '-' && opt.infile.empty()) opt.infile = a;
+    else {
+      std::fprintf(stderr, "ERROR: unknown arg '%s'\n", a.c_str());
+      return false;
+    }
+  }
+  return !opt.infile.empty();
+}
+
+std::vector<uint8_t> read_file(const char *path) {
+  FILE *f = std::fopen(path, "rb");
+  if (!f) { std::fprintf(stderr, "ERROR: cannot open %s\n", path); return {}; }
+  std::fseek(f, 0, SEEK_END);
+  auto sz = static_cast<std::size_t>(std::ftell(f));
+  std::fseek(f, 0, SEEK_SET);
+  std::vector<uint8_t> buf(sz);
+  std::size_t rd = std::fread(buf.data(), 1, sz, f);
+  std::fclose(f);
+  if (rd != sz) { std::fprintf(stderr, "ERROR: partial read\n"); buf.clear(); }
+  return buf;
+}
+
+// Build a ViewWindow describing `radius` canvas-coordinate samples around
+// (gx, gy) at the discard level corresponding to `fsiz_ratio` (1.0 = full
+// canvas / all resolutions, 0.5 = half resolution, 0.25 = quarter, …).
+// A fsiz_ratio of 0 means "whole image at that resolution" (periphery).
+ViewWindow make_view_window(const CodestreamIndex &idx, uint32_t gx, uint32_t gy,
+                            uint32_t radius, float fsiz_ratio, bool whole_image) {
+  const auto &g = idx.geometry();
+  ViewWindow vw;
+  vw.fx = static_cast<uint32_t>(static_cast<float>(g.canvas_size.x) * fsiz_ratio);
+  vw.fy = static_cast<uint32_t>(static_cast<float>(g.canvas_size.y) * fsiz_ratio);
+  if (vw.fx == 0) vw.fx = 1;
+  if (vw.fy == 0) vw.fy = 1;
+  if (whole_image) {
+    vw.ox = 0;
+    vw.oy = 0;
+    vw.sx = vw.fx;
+    vw.sy = vw.fy;
+  } else {
+    // Scale (gx, gy, radius) from canvas to the fsiz grid.
+    const uint32_t gx_f = static_cast<uint32_t>(static_cast<uint64_t>(gx) * vw.fx / g.canvas_size.x);
+    const uint32_t gy_f = static_cast<uint32_t>(static_cast<uint64_t>(gy) * vw.fy / g.canvas_size.y);
+    const uint32_t r_f  = static_cast<uint32_t>(static_cast<uint64_t>(radius) * vw.fx / g.canvas_size.x);
+    vw.ox = (gx_f > r_f) ? (gx_f - r_f) : 0u;
+    vw.oy = (gy_f > r_f) ? (gy_f - r_f) : 0u;
+    vw.sx = 2u * r_f;
+    vw.sy = 2u * r_f;
+  }
+  return vw;
+}
+
+// Build an I-indexed hash set from three concentric view-window calls.
+std::unordered_set<uint64_t> foveated_i_set(const CodestreamIndex &idx,
+                                            uint32_t gx, uint32_t gy,
+                                            const Options &opt) {
+  std::unordered_set<uint64_t> out;
+  auto add = [&](const std::vector<PrecinctKey> &keys) {
+    out.reserve(out.size() + keys.size());
+    for (const auto &k : keys) out.insert(idx.I(k.t, k.c, k.r, k.p_rc));
+  };
+
+  // Fovea: full resolution, tight RoI centred on gaze.
+  auto vw_f = make_view_window(idx, gx, gy, opt.fovea_radius,     1.00f, false);
+  add(open_htj2k::jpip::resolve_view_window(idx, vw_f));
+
+  // Parafovea: half resolution, wider RoI.
+  auto vw_p = make_view_window(idx, gx, gy, opt.parafovea_radius, 0.50f, false);
+  add(open_htj2k::jpip::resolve_view_window(idx, vw_p));
+
+  // Periphery: quarter resolution, whole image (covers everything at coarse detail).
+  auto vw_q = make_view_window(idx, gx, gy, 0, 0.25f, true);
+  add(open_htj2k::jpip::resolve_view_window(idx, vw_q));
+
+  return out;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  Options opt;
+  if (!parse_args(argc, argv, opt)) {
+    std::fprintf(stderr,
+                 "Usage: open_htj2k_jpip_demo <input.j2c> "
+                 "[--fovea-radius N] [--parafovea-radius N] "
+                 "[--decode-on-move-only] [--no-vsync]\n");
+    return EXIT_FAILURE;
+  }
+
+  auto bytes = read_file(opt.infile.c_str());
+  if (bytes.empty()) return EXIT_FAILURE;
+
+  std::unique_ptr<CodestreamIndex> idx;
+  try {
+    idx = CodestreamIndex::build(bytes.data(), bytes.size());
+  } catch (std::exception &e) {
+    std::fprintf(stderr, "CodestreamIndex build failed: %s\n", e.what());
+    return EXIT_FAILURE;
+  }
+  const uint32_t canvas_w = idx->geometry().canvas_size.x;
+  const uint32_t canvas_h = idx->geometry().canvas_size.y;
+  const uint64_t total_p  = idx->total_precincts();
+  std::printf("loaded %s: canvas %u×%u, %u components, %llu precincts\n",
+              opt.infile.c_str(), canvas_w, canvas_h, idx->num_components(),
+              static_cast<unsigned long long>(total_p));
+
+  // The decoder's codestream cursor advances during each invoke(), so every
+  // frame constructs a fresh openhtj2k_decoder (see the per-frame init()+
+  // parse() block below).  The codestream buffer `bytes` lives for the
+  // program lifetime, so the re-init is zero-copy and dominated by marker
+  // parsing — sub-millisecond for a single-tile stream.
+
+  Renderer renderer;
+  if (!renderer.init(static_cast<int>(canvas_w), static_cast<int>(canvas_h),
+                     "OpenHTJ2K JPIP Foveation Demo", opt.vsync)) {
+    std::fprintf(stderr, "FATAL: renderer.init failed\n");
+    return EXIT_FAILURE;
+  }
+  GLFWwindow *window = renderer.get_window();
+
+  std::vector<uint8_t> rgb;
+  uint64_t frames = 0;
+  int32_t  last_gx = -1, last_gy = -1;
+
+  using Clock = std::chrono::steady_clock;
+  auto last_log = Clock::now();
+  uint64_t frames_since_log = 0;
+  uint64_t precincts_since_log = 0;
+
+  while (!renderer.should_close()) {
+    renderer.poll_events();
+
+    double mx = 0.0, my = 0.0;
+    glfwGetCursorPos(window, &mx, &my);
+    int win_w = 1, win_h = 1;
+    glfwGetWindowSize(window, &win_w, &win_h);
+    if (win_w < 1) win_w = 1;
+    if (win_h < 1) win_h = 1;
+    double rx = std::max(0.0, std::min(1.0, mx / win_w));
+    double ry = std::max(0.0, std::min(1.0, my / win_h));
+    uint32_t gx = static_cast<uint32_t>(rx * (canvas_w - 1));
+    uint32_t gy = static_cast<uint32_t>(ry * (canvas_h - 1));
+
+    if (opt.decode_on_move && static_cast<int32_t>(gx) == last_gx
+        && static_cast<int32_t>(gy) == last_gy && frames > 0) {
+      continue;
+    }
+    last_gx = static_cast<int32_t>(gx);
+    last_gy = static_cast<int32_t>(gy);
+
+    auto keep = foveated_i_set(*idx, gx, gy, opt);
+    precincts_since_log += keep.size();
+
+    // Fresh decoder per frame — init() + parse() rewind the codestream cursor.
+    open_htj2k::openhtj2k_decoder dec;
+    dec.init(bytes.data(), bytes.size(), /*reduce_NL=*/0, /*num_threads=*/1);
+    dec.parse();
+
+    auto *idx_ptr = idx.get();
+    dec.set_precinct_filter(
+        [idx_ptr, keep_moved = std::move(keep)](
+            uint16_t t, uint16_t c, uint8_t r, uint32_t p_rc) {
+          return keep_moved.count(idx_ptr->I(t, c, r, p_rc)) > 0;
+        });
+
+    std::vector<int32_t *> planes;
+    std::vector<uint32_t>  w, h;
+    std::vector<uint8_t>   depth;
+    std::vector<bool>      sgn;
+    bool                   ok = true;
+    try {
+      dec.invoke(planes, w, h, depth, sgn);
+    } catch (std::exception &e) {
+      std::fprintf(stderr, "decode failed: %s\n", e.what());
+      break;
+    }
+    const uint32_t out_w = (w.size() > 0) ? w[0] : 0u;
+    const uint32_t out_h = (h.size() > 0) ? h[0] : 0u;
+    if (planes.size() < 3 || out_w == 0 || out_h == 0) {
+      ok = false;
+    } else {
+      if (rgb.size() != static_cast<std::size_t>(out_w) * out_h * 3) {
+        rgb.assign(static_cast<std::size_t>(out_w) * out_h * 3, 0);
+      }
+      for (uint32_t y = 0; y < out_h; ++y) {
+        uint8_t *dst = rgb.data() + static_cast<std::size_t>(y) * out_w * 3;
+        const int32_t *rp = planes[0] + static_cast<std::ptrdiff_t>(y) * out_w;
+        const int32_t *gp = planes[1] + static_cast<std::ptrdiff_t>(y) * out_w;
+        const int32_t *bp = planes[2] + static_cast<std::ptrdiff_t>(y) * out_w;
+        for (uint32_t x = 0; x < out_w; ++x) {
+          auto clamp_u8 = [](int32_t v) -> uint8_t {
+            if (v < 0) return 0;
+            if (v > 255) return 255;
+            return static_cast<uint8_t>(v);
+          };
+          dst[3 * x + 0] = clamp_u8(rp[x]);
+          dst[3 * x + 1] = clamp_u8(gp[x]);
+          dst[3 * x + 2] = clamp_u8(bp[x]);
+        }
+      }
+    }
+
+    if (ok) renderer.upload_and_draw(rgb.data(), static_cast<int>(out_w), static_cast<int>(out_h));
+
+    ++frames;
+    ++frames_since_log;
+    const auto now = Clock::now();
+    if (std::chrono::duration_cast<std::chrono::milliseconds>(now - last_log).count() > 1000) {
+      const double secs = std::chrono::duration<double>(now - last_log).count();
+      const double fps  = frames_since_log / std::max(secs, 1e-6);
+      const uint64_t avg_precincts = frames_since_log ? (precincts_since_log / frames_since_log) : 0;
+      const double coverage_pct =
+          total_p ? (100.0 * static_cast<double>(avg_precincts) / static_cast<double>(total_p)) : 0.0;
+      std::printf("gaze=(%u,%u) precincts=%llu (%.1f%% of %llu)  %.1f fps\n",
+                  gx, gy, static_cast<unsigned long long>(avg_precincts), coverage_pct,
+                  static_cast<unsigned long long>(total_p), fps);
+      std::fflush(stdout);
+      last_log            = now;
+      frames_since_log    = 0;
+      precincts_since_log = 0;
+    }
+  }
+
+  renderer.shutdown();
+  return EXIT_SUCCESS;
+}

--- a/source/apps/jpip_index_check/CMakeLists.txt
+++ b/source/apps/jpip_index_check/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_policy(SET CMP0076 NEW)
+target_sources(jpip_index_check
+    PRIVATE
+    main.cpp
+)
+target_include_directories(jpip_index_check PRIVATE ${CMAKE_SOURCE_DIR}/source/core/jpip)

--- a/source/apps/jpip_index_check/main.cpp
+++ b/source/apps/jpip_index_check/main.cpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "precinct_index.hpp"
+#include "view_window.hpp"
 
 static std::vector<uint8_t> read_file(const char *path) {
   FILE *f = std::fopen(path, "rb");
@@ -78,23 +79,81 @@ static bool parse_per_res_spec(const char *spec, uint16_t &t, uint16_t &c,
   return !expected.empty();
 }
 
+// Parse --vw arg of shape
+//   "fx,fy,ox,oy,sx,sy[,round][,comps=c1:c2:…]=N"
+// where round ∈ {down,up,closest} (default down), N is the expected
+// precinct count, and comps is an optional colon-separated list.  Returns
+// true on success.
+static bool parse_vw_spec(const char *spec, open_htj2k::jpip::ViewWindow &vw,
+                          uint64_t &expected_count) {
+  // Split on the trailing '='
+  const char *eq = std::strrchr(spec, '=');
+  if (!eq) return false;
+  expected_count = std::strtoull(eq + 1, nullptr, 10);
+
+  // Walk the prefix split on commas.
+  std::string prefix(spec, eq);
+  std::size_t pos = 0;
+  auto next = [&](std::string &out) -> bool {
+    std::size_t comma = prefix.find(',', pos);
+    if (comma == std::string::npos) {
+      out = prefix.substr(pos);
+      pos = prefix.size();
+    } else {
+      out = prefix.substr(pos, comma - pos);
+      pos = comma + 1;
+    }
+    return !out.empty();
+  };
+  std::string field;
+  if (!next(field)) return false; vw.fx = static_cast<uint32_t>(std::stoul(field));
+  if (!next(field)) return false; vw.fy = static_cast<uint32_t>(std::stoul(field));
+  if (!next(field)) return false; vw.ox = static_cast<uint32_t>(std::stoul(field));
+  if (!next(field)) return false; vw.oy = static_cast<uint32_t>(std::stoul(field));
+  if (!next(field)) return false; vw.sx = static_cast<uint32_t>(std::stoul(field));
+  if (!next(field)) return false; vw.sy = static_cast<uint32_t>(std::stoul(field));
+  while (next(field)) {
+    if (field == "down")    vw.round = open_htj2k::jpip::ViewWindow::Round::Down;
+    else if (field == "up") vw.round = open_htj2k::jpip::ViewWindow::Round::Up;
+    else if (field == "closest") vw.round = open_htj2k::jpip::ViewWindow::Round::Closest;
+    else if (field.rfind("comps=", 0) == 0) {
+      std::string list = field.substr(6);
+      std::size_t lp = 0;
+      while (lp < list.size()) {
+        std::size_t colon = list.find(':', lp);
+        std::string item = list.substr(lp, colon == std::string::npos ? std::string::npos : colon - lp);
+        if (!item.empty()) vw.comps.push_back(static_cast<uint16_t>(std::stoul(item)));
+        if (colon == std::string::npos) break;
+        lp = colon + 1;
+      }
+    } else {
+      return false;
+    }
+  }
+  return true;
+}
+
 int main(int argc, char *argv[]) {
   if (argc < 2) {
     std::fprintf(stderr,
                  "Usage: jpip_index_check <input.j2c> [--total N] "
-                 "[--per-res t,c=r0,...] [--print]\n");
+                 "[--per-res t,c=r0,...] [--vw fx,fy,ox,oy,sx,sy[,round]=N] "
+                 "[--print]\n");
     return 1;
   }
   std::string infile     = argv[1];
   long long expected_tot = -1;
   bool do_print          = false;
   std::vector<std::string> per_res_specs;
+  std::vector<std::string> vw_specs;
 
   for (int i = 2; i < argc; ++i) {
     if (std::strcmp(argv[i], "--total") == 0 && i + 1 < argc) {
       expected_tot = std::atoll(argv[++i]);
     } else if (std::strcmp(argv[i], "--per-res") == 0 && i + 1 < argc) {
       per_res_specs.emplace_back(argv[++i]);
+    } else if (std::strcmp(argv[i], "--vw") == 0 && i + 1 < argc) {
+      vw_specs.emplace_back(argv[++i]);
     } else if (std::strcmp(argv[i], "--print") == 0) {
       do_print = true;
     } else {
@@ -156,6 +215,26 @@ int main(int argc, char *argv[]) {
       }
     }
     if (spec_ok) std::printf("OK --per-res %s\n", spec.c_str());
+  }
+
+  for (const auto &spec : vw_specs) {
+    open_htj2k::jpip::ViewWindow vw;
+    uint64_t expected = 0;
+    if (!parse_vw_spec(spec.c_str(), vw, expected)) {
+      std::fprintf(stderr, "FAIL --vw: cannot parse '%s'\n", spec.c_str());
+      ++failed;
+      continue;
+    }
+    auto got = open_htj2k::jpip::resolve_view_window(*idx, vw);
+    if (got.size() != expected) {
+      std::fprintf(stderr,
+                   "FAIL --vw '%s': expected %llu precincts, got %zu\n",
+                   spec.c_str(), static_cast<unsigned long long>(expected),
+                   got.size());
+      ++failed;
+    } else {
+      std::printf("OK --vw %s\n", spec.c_str());
+    }
   }
 
   return failed == 0 ? 0 : 1;

--- a/source/apps/jpip_index_check/main.cpp
+++ b/source/apps/jpip_index_check/main.cpp
@@ -1,0 +1,162 @@
+// jpip_index_check: Phase-1 ctest harness for the JPIP precinct index.
+// Usage: jpip_index_check <input.j2c> [--total N] [--per-res t,c=r0,r1,...]
+//
+// --total N             assert total_precincts() == N
+// --per-res t,c=r0,r1,…  assert tile_component(t,c).npw[r]·nph[r] == r_i for each r
+// --print               dump the index to stdout
+//
+// Exit 0 on all assertions passing, 1 otherwise.
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "precinct_index.hpp"
+
+static std::vector<uint8_t> read_file(const char *path) {
+  FILE *f = std::fopen(path, "rb");
+  if (!f) {
+    std::fprintf(stderr, "ERROR: cannot open %s\n", path);
+    return {};
+  }
+  std::fseek(f, 0, SEEK_END);
+  std::size_t sz = static_cast<std::size_t>(std::ftell(f));
+  std::fseek(f, 0, SEEK_SET);
+  std::vector<uint8_t> buf(sz);
+  std::size_t rd = std::fread(buf.data(), 1, sz, f);
+  std::fclose(f);
+  if (rd != sz) {
+    std::fprintf(stderr, "ERROR: partial read of %s\n", path);
+    buf.clear();
+  }
+  return buf;
+}
+
+static void print_summary(const open_htj2k::jpip::CodestreamIndex &idx) {
+  std::printf("tiles=%ux%u  components=%u  progression=%u  total_precincts=%llu\n",
+              idx.num_tiles_x(), idx.num_tiles_y(), idx.num_components(),
+              idx.progression_order(),
+              static_cast<unsigned long long>(idx.total_precincts()));
+  for (uint32_t t = 0; t < idx.num_tiles(); ++t) {
+    for (uint16_t c = 0; c < idx.num_components(); ++c) {
+      const auto &info = idx.tile_component(static_cast<uint16_t>(t), c);
+      std::printf("  t=%u c=%u NL=%u total=%u  per-res:",
+                  t, c, info.NL, info.total);
+      for (uint8_t r = 0; r <= info.NL; ++r) {
+        std::printf(" r%u=%ux%u(%u)", r, info.npw[r], info.nph[r],
+                    info.npw[r] * info.nph[r]);
+      }
+      std::printf("\n");
+    }
+  }
+}
+
+// Parse "t,c=r0,r1,r2,..." into the four numbers and a vector of expected counts.
+static bool parse_per_res_spec(const char *spec, uint16_t &t, uint16_t &c,
+                               std::vector<uint32_t> &expected) {
+  // Find '='
+  const char *eq = std::strchr(spec, '=');
+  if (!eq) return false;
+  // Parse t,c
+  uint32_t tt = 0, cc = 0;
+  if (std::sscanf(spec, "%u,%u", &tt, &cc) != 2) return false;
+  t = static_cast<uint16_t>(tt);
+  c = static_cast<uint16_t>(cc);
+  // Parse comma-separated expected counts after '='
+  expected.clear();
+  const char *p = eq + 1;
+  while (*p) {
+    char *end = nullptr;
+    unsigned long v = std::strtoul(p, &end, 10);
+    if (end == p) return false;
+    expected.push_back(static_cast<uint32_t>(v));
+    p = end;
+    while (*p == ',') ++p;
+  }
+  return !expected.empty();
+}
+
+int main(int argc, char *argv[]) {
+  if (argc < 2) {
+    std::fprintf(stderr,
+                 "Usage: jpip_index_check <input.j2c> [--total N] "
+                 "[--per-res t,c=r0,...] [--print]\n");
+    return 1;
+  }
+  std::string infile     = argv[1];
+  long long expected_tot = -1;
+  bool do_print          = false;
+  std::vector<std::string> per_res_specs;
+
+  for (int i = 2; i < argc; ++i) {
+    if (std::strcmp(argv[i], "--total") == 0 && i + 1 < argc) {
+      expected_tot = std::atoll(argv[++i]);
+    } else if (std::strcmp(argv[i], "--per-res") == 0 && i + 1 < argc) {
+      per_res_specs.emplace_back(argv[++i]);
+    } else if (std::strcmp(argv[i], "--print") == 0) {
+      do_print = true;
+    } else {
+      std::fprintf(stderr, "ERROR: unknown arg %s\n", argv[i]);
+      return 1;
+    }
+  }
+
+  auto bytes = read_file(infile.c_str());
+  if (bytes.empty()) return 1;
+
+  std::unique_ptr<open_htj2k::jpip::CodestreamIndex> idx;
+  try {
+    idx = open_htj2k::jpip::CodestreamIndex::build(bytes.data(), bytes.size());
+  } catch (std::exception &e) {
+    std::fprintf(stderr, "ERROR build: %s\n", e.what());
+    return 1;
+  }
+
+  if (do_print) print_summary(*idx);
+
+  int failed = 0;
+  if (expected_tot >= 0) {
+    auto got = idx->total_precincts();
+    if (got != static_cast<uint64_t>(expected_tot)) {
+      std::fprintf(stderr, "FAIL --total: expected %lld got %llu\n",
+                   expected_tot, static_cast<unsigned long long>(got));
+      ++failed;
+    } else {
+      std::printf("OK --total %lld\n", expected_tot);
+    }
+  }
+
+  for (const auto &spec : per_res_specs) {
+    uint16_t t = 0, c = 0;
+    std::vector<uint32_t> expected;
+    if (!parse_per_res_spec(spec.c_str(), t, c, expected)) {
+      std::fprintf(stderr, "FAIL --per-res: cannot parse '%s'\n", spec.c_str());
+      ++failed;
+      continue;
+    }
+    const auto &info = idx->tile_component(t, c);
+    if (expected.size() != static_cast<std::size_t>(info.NL) + 1u) {
+      std::fprintf(stderr,
+                   "FAIL --per-res t=%u c=%u: expected %zu resolutions, got NL+1=%u\n",
+                   t, c, expected.size(), info.NL + 1u);
+      ++failed;
+      continue;
+    }
+    bool spec_ok = true;
+    for (uint8_t r = 0; r <= info.NL; ++r) {
+      const uint32_t got = info.npw[r] * info.nph[r];
+      if (got != expected[r]) {
+        std::fprintf(stderr,
+                     "FAIL --per-res t=%u c=%u r=%u: expected %u got %u (npw=%u, nph=%u)\n",
+                     t, c, r, expected[r], got, info.npw[r], info.nph[r]);
+        spec_ok = false;
+        ++failed;
+      }
+    }
+    if (spec_ok) std::printf("OK --per-res %s\n", spec.c_str());
+  }
+
+  return failed == 0 ? 0 : 1;
+}

--- a/source/apps/jpip_partial_decode_check/CMakeLists.txt
+++ b/source/apps/jpip_partial_decode_check/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_policy(SET CMP0076 NEW)
+target_sources(jpip_partial_decode_check
+    PRIVATE
+    main.cpp
+)

--- a/source/apps/jpip_partial_decode_check/main.cpp
+++ b/source/apps/jpip_partial_decode_check/main.cpp
@@ -1,0 +1,161 @@
+// jpip_partial_decode_check: Phase-1 ctest harness for the decoder-level
+// precinct filter injection added in commit 3.  Validates two invariants:
+//
+//   --identity   Decode with a filter that returns true for every precinct
+//                must produce byte-identical output to an unfiltered decode.
+//                This exercises the `skip_body` plumbing in the keep-everything
+//                branch: the body-attach path runs, but routed through the
+//                filter-aware call site.
+//
+//   --empty      Decode with a filter that returns false for every precinct
+//                must produce a uniform field — every sample within each
+//                component equals the DC level (no codeblock contributes any
+//                non-zero passes).  For lossy 9/7 + MCT on 8-bit unsigned the
+//                expected value is 128.  The test only asserts uniformity
+//                within each component; any small integer rounding noise from
+//                the inverse MCT is tolerated via a PAE cap.
+//
+// Usage: jpip_partial_decode_check <input.j2k> [--identity] [--empty N]
+//   N = maximum absolute difference between any two samples of the same
+//       component (default 0 for lossless, pass 1 or 2 for lossy 9/7).
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "decoder.hpp"
+
+static std::vector<uint8_t> read_file(const char *path) {
+  FILE *f = std::fopen(path, "rb");
+  if (!f) {
+    std::fprintf(stderr, "ERROR: cannot open %s\n", path);
+    return {};
+  }
+  std::fseek(f, 0, SEEK_END);
+  std::size_t sz = static_cast<std::size_t>(std::ftell(f));
+  std::fseek(f, 0, SEEK_SET);
+  std::vector<uint8_t> buf(sz);
+  std::size_t rd = std::fread(buf.data(), 1, sz, f);
+  std::fclose(f);
+  if (rd != sz) {
+    std::fprintf(stderr, "ERROR: partial read of %s\n", path);
+    buf.clear();
+  }
+  return buf;
+}
+
+static int decode(const std::vector<uint8_t> &codestream,
+                  std::function<bool(uint16_t, uint16_t, uint8_t, uint32_t)> filter,
+                  std::vector<std::vector<int32_t>> &planes,
+                  std::vector<uint32_t> &w, std::vector<uint32_t> &h) {
+  open_htj2k::openhtj2k_decoder dec;
+  dec.init(codestream.data(), codestream.size(), 0, 1);
+  dec.parse();
+  if (filter) dec.set_precinct_filter(std::move(filter));
+  std::vector<int32_t *>  buf;
+  std::vector<uint8_t>    depth;
+  std::vector<bool>       is_signed;
+  try {
+    dec.invoke(buf, w, h, depth, is_signed);
+  } catch (std::exception &e) {
+    std::fprintf(stderr, "ERROR invoke: %s\n", e.what());
+    return -1;
+  }
+  // invoke() writes into caller-owned planes via its int32_t* vector.
+  // buf[c] points into internal storage; copy it out so we can compare
+  // across calls (the next invoke() may overwrite it).
+  planes.resize(buf.size());
+  for (std::size_t c = 0; c < buf.size(); ++c) {
+    planes[c].assign(buf[c], buf[c] + static_cast<std::ptrdiff_t>(w[c]) * h[c]);
+  }
+  return 0;
+}
+
+int main(int argc, char *argv[]) {
+  if (argc < 3) {
+    std::fprintf(stderr,
+                 "Usage: jpip_partial_decode_check <input.j2k> "
+                 "(--identity | --empty <PAE>)\n");
+    return 1;
+  }
+  std::string infile   = argv[1];
+  bool        identity = false;
+  bool        empty    = false;
+  int         empty_pae = 0;
+  for (int i = 2; i < argc; ++i) {
+    if (std::strcmp(argv[i], "--identity") == 0) {
+      identity = true;
+    } else if (std::strcmp(argv[i], "--empty") == 0 && i + 1 < argc) {
+      empty    = true;
+      empty_pae = std::atoi(argv[++i]);
+    } else {
+      std::fprintf(stderr, "ERROR: unknown arg %s\n", argv[i]);
+      return 1;
+    }
+  }
+
+  auto bytes = read_file(infile.c_str());
+  if (bytes.empty()) return 1;
+
+  // Reference decode — no filter.
+  std::vector<std::vector<int32_t>> ref;
+  std::vector<uint32_t> w, h;
+  if (decode(bytes, {}, ref, w, h) != 0) return 1;
+
+  if (identity) {
+    // Filter returns true for every precinct.
+    std::vector<std::vector<int32_t>> got;
+    std::vector<uint32_t> gw, gh;
+    auto keep_all = [](uint16_t, uint16_t, uint8_t, uint32_t) { return true; };
+    if (decode(bytes, keep_all, got, gw, gh) != 0) return 1;
+    if (got.size() != ref.size() || gw != w || gh != h) {
+      std::fprintf(stderr, "FAIL --identity: component/shape mismatch\n");
+      return 1;
+    }
+    for (std::size_t c = 0; c < ref.size(); ++c) {
+      if (got[c] != ref[c]) {
+        // Find first diff for useful output.
+        for (std::size_t i = 0; i < ref[c].size(); ++i) {
+          if (got[c][i] != ref[c][i]) {
+            std::fprintf(stderr,
+                         "FAIL --identity: c=%zu i=%zu ref=%d got=%d\n",
+                         c, i, ref[c][i], got[c][i]);
+            return 1;
+          }
+        }
+      }
+    }
+    std::printf("OK --identity (%zu components, %u×%u)\n", ref.size(), w[0], h[0]);
+  }
+
+  if (empty) {
+    // Filter returns false for every precinct → uniform DC-only output.
+    std::vector<std::vector<int32_t>> got;
+    std::vector<uint32_t> gw, gh;
+    auto drop_all = [](uint16_t, uint16_t, uint8_t, uint32_t) { return false; };
+    if (decode(bytes, drop_all, got, gw, gh) != 0) return 1;
+    for (std::size_t c = 0; c < got.size(); ++c) {
+      if (got[c].empty()) continue;
+      int32_t mn = got[c][0], mx = got[c][0];
+      std::size_t mn_i = 0, mx_i = 0;
+      for (std::size_t i = 1; i < got[c].size(); ++i) {
+        if (got[c][i] < mn) { mn = got[c][i]; mn_i = i; }
+        if (got[c][i] > mx) { mx = got[c][i]; mx_i = i; }
+      }
+      const int32_t range = mx - mn;
+      if (range > empty_pae) {
+        std::fprintf(stderr,
+                     "FAIL --empty c=%zu: range %d (%d..%d) exceeds PAE cap %d "
+                     "(min at i=%zu, max at i=%zu)\n",
+                     c, range, mn, mx, empty_pae, mn_i, mx_i);
+        return 1;
+      }
+    }
+    std::printf("OK --empty (%zu components, PAE ≤ %d)\n", got.size(), empty_pae);
+  }
+
+  return 0;
+}

--- a/source/apps/rtp_recv/gl_renderer.hpp
+++ b/source/apps/rtp_recv/gl_renderer.hpp
@@ -62,6 +62,11 @@ class GlRenderer {
   // Pump window events.  Call once per frame.
   void poll_events();
 
+  // Accessor for the owned GLFWwindow* so callers can invoke GLFW input
+  // APIs (glfwGetCursorPos, glfwSetKeyCallback, …) against the same window.
+  // Returns nullptr when init() has not been called or has failed.
+  GLFWwindow* get_window() const { return window_; }
+
   // CPU fallback path: upload an 8-bit interleaved RGB image and draw it
   // once.  Reallocates the RGB texture if (w,h) changed since the last
   // call.  Does NOT own the pixel buffer.

--- a/source/apps/rtp_recv/metal_renderer.hpp
+++ b/source/apps/rtp_recv/metal_renderer.hpp
@@ -46,6 +46,10 @@ class MetalRenderer {
   void shutdown();
   bool should_close() const;
   void poll_events();
+  // Accessor for the owned GLFWwindow* so callers can invoke input APIs
+  // (glfwGetCursorPos, glfwSetKeyCallback, …) against the same window.
+  // Returns nullptr when init() has not been called or has failed.
+  GLFWwindow* get_window() const { return window_; }
 
   void upload_and_draw(const uint8_t* rgb, int w, int h);
 

--- a/source/core/coding/coding_units.cpp
+++ b/source/core/coding/coding_units.cpp
@@ -880,6 +880,30 @@ void j2k_codeblock::create_compressed_buffer(buf_chain *tile_buf, int32_t buf_li
   this->length += layer_length;
 }
 
+void j2k_codeblock::skip_compressed_buffer(buf_chain *tile_buf, const uint16_t &layer) {
+  if (this->layer_passes[layer] == 0) {
+    return;
+  }
+  // Mirror create_compressed_buffer's layer_length computation so the byte
+  // stream advances by exactly the same amount as the attach path.
+  int32_t l0 = this->layer_start[layer];
+  int32_t l1 = l0 + this->layer_passes[layer];
+  uint32_t layer_length = 0;
+  for (int32_t i = l0; i < l1; i++) {
+    layer_length += this->pass_length[static_cast<size_t>(i)];
+  }
+  if (layer_length == 0) return;
+
+  const uint32_t avail = tile_buf->get_remaining_bytes();
+  if (layer_length > avail) layer_length = avail;
+  if (layer_length == 0) return;
+
+  // Advance tile_buf's read cursor without attaching the borrowed pointer
+  // anywhere — borrow_N_bytes just moves `pos` forward by N within the
+  // current node.
+  (void)tile_buf->borrow_N_bytes(layer_length);
+}
+
 void j2k_codeblock::reset_for_next_frame() {
   // Release an owned compressed buffer before nulling the pointer.  Pooled
   // buffers are freed by their owning cblk_data_pool (decoder-side pools
@@ -3255,8 +3279,9 @@ void j2k_tile::create_tile_buf(j2k_main_header &main_header) {
     for (const auto &e : cached_crp_) {
       j2k_resolution *cr = this->tcomp[e.c].access_resolution(e.r);
       j2k_precinct   *cp = cr->access_precinct(e.p);
+      const bool skip = precinct_filter_ && !precinct_filter_(e.c, e.r, e.p);
       this->packet[packet_count++] = j2c_packet(0, e.r, e.c, e.p, packet_header, tile_buf.get());
-      this->read_packet(cp, 0, cr->num_bands);
+      this->read_packet(cp, 0, cr->num_bands, skip);
     }
   } else {
     // First frame: run the full progression-order traversal and record
@@ -3306,7 +3331,8 @@ void j2k_tile::create_tile_buf(j2k_main_header &main_header) {
                       if (!is_packet_read[l][r][c][p]) {
                         cached_crp_.push_back({static_cast<uint8_t>(c), r, static_cast<uint16_t>(p)});
                         this->packet[packet_count++] = j2c_packet(l, r, c, p, packet_header, tile_buf.get());
-                        this->read_packet(cp, l, cr->num_bands);
+                        this->read_packet(cp, l, cr->num_bands,
+                                          precinct_filter_ && !precinct_filter_(static_cast<uint16_t>(c), r, p));
                         is_packet_read[l][r][c][p] = true;
                       }
                     }
@@ -3329,7 +3355,8 @@ void j2k_tile::create_tile_buf(j2k_main_header &main_header) {
                       if (!is_packet_read[l][r][c][p]) {
                         cached_crp_.push_back({static_cast<uint8_t>(c), r, static_cast<uint16_t>(p)});
                         this->packet[packet_count++] = j2c_packet(l, r, c, p, packet_header, tile_buf.get());
-                        this->read_packet(cp, l, cr->num_bands);
+                        this->read_packet(cp, l, cr->num_bands,
+                                          precinct_filter_ && !precinct_filter_(static_cast<uint16_t>(c), r, p));
                         is_packet_read[l][r][c][p] = true;
                       }
                     }
@@ -3385,7 +3412,8 @@ void j2k_tile::create_tile_buf(j2k_main_header &main_header) {
                             cached_crp_.push_back({static_cast<uint8_t>(c), r, static_cast<uint16_t>(p)});
                             this->packet[packet_count++] =
                                 j2c_packet(l, r, c, p, packet_header, tile_buf.get());
-                            this->read_packet(cp, l, cr->num_bands);
+                            this->read_packet(cp, l, cr->num_bands,
+                                          precinct_filter_ && !precinct_filter_(static_cast<uint16_t>(c), r, p));
                             is_packet_read[l][r][c][p] = true;
                           }
                         }
@@ -3448,7 +3476,8 @@ void j2k_tile::create_tile_buf(j2k_main_header &main_header) {
                           cached_crp_.push_back({static_cast<uint8_t>(c), r, static_cast<uint16_t>(p)});
                           this->packet[packet_count++] =
                               j2c_packet(l, r, c, p, packet_header, tile_buf.get());
-                          this->read_packet(cp, l, cr->num_bands);
+                          this->read_packet(cp, l, cr->num_bands,
+                                          precinct_filter_ && !precinct_filter_(static_cast<uint16_t>(c), r, p));
                           is_packet_read[l][r][c][p] = true;
                         }
                       }
@@ -3510,7 +3539,8 @@ void j2k_tile::create_tile_buf(j2k_main_header &main_header) {
                           cached_crp_.push_back({static_cast<uint8_t>(c), r, static_cast<uint16_t>(p)});
                           this->packet[packet_count++] =
                               j2c_packet(l, r, c, p, packet_header, tile_buf.get());
-                          this->read_packet(cp, l, cr->num_bands);
+                          this->read_packet(cp, l, cr->num_bands,
+                                          precinct_filter_ && !precinct_filter_(static_cast<uint16_t>(c), r, p));
                           is_packet_read[l][r][c][p] = true;
                         }
                       }
@@ -4005,8 +4035,12 @@ void j2k_tile::decode() {
           const uint32_t num_cblks  = cpb->num_codeblock_x * cpb->num_codeblock_y;
           for (uint32_t block_index = 0; block_index < num_cblks; ++block_index) {
             j2k_codeblock *block = cpb->access_codeblock(block_index);
-            // only decode a codeblock having non-zero coding passes
-            if (block->num_passes) {
+            // only decode a codeblock having non-zero coding passes AND
+            // attached compressed data.  The JPIP precinct filter installs a
+            // state where num_passes > 0 (packet header was parsed) but
+            // compressed_data == nullptr (body was dropped); treat that as
+            // "no passes to decode" so the codeblock's samples remain zero.
+            if (block->num_passes && block->get_compressed_data() != nullptr) {
 #ifdef OPENHTJ2K_THREAD
               if (pool && pool->num_threads() > 1) {
                 dec_task_args.push_back({block, ROIshift, &dec_remaining});
@@ -4126,7 +4160,8 @@ void j2k_tile::decode() {
 
   }  // end of component loop
 }
-void j2k_tile::read_packet(j2k_precinct *current_precint, uint16_t layer, uint8_t num_band) {
+void j2k_tile::read_packet(j2k_precinct *current_precint, uint16_t layer, uint8_t num_band,
+                           bool skip_body) {
   OPENHTJ2K_MAYBE_UNUSED uint16_t Nsop = 0;
   uint16_t Lsop;
   if (use_SOP) {
@@ -4181,7 +4216,11 @@ void j2k_tile::read_packet(j2k_precinct *current_precint, uint16_t layer, uint8_
     if (num_cblks != 0) {
       for (uint32_t block_index = 0; block_index < num_cblks; block_index++) {
         block = cpb->access_codeblock(block_index);
-        block->create_compressed_buffer(this->tile_buf.get(), buf_limit, layer);
+        if (skip_body) {
+          block->skip_compressed_buffer(this->tile_buf.get(), layer);
+        } else {
+          block->create_compressed_buffer(this->tile_buf.get(), buf_limit, layer);
+        }
       }
     }
   }
@@ -5346,7 +5385,10 @@ void j2k_tile::decode_line_based_predecoded(j2k_main_header &hdr, uint8_t reduce
             const uint32_t QHx2  = round_up(block->size.y, 8U);
             block->sample_buf    = pbuf; pbuf += QWx2 * QHx2;
             block->block_states  = spbuf; spbuf += (QWx2 + 2) * (QHx2 + 2);
-            if (!block->num_passes) continue;
+            // Same JPIP precinct-filter guard as the tile decode path: a
+            // masked codeblock has its packet header parsed (num_passes > 0)
+            // but no compressed body attached.
+            if (!block->num_passes || block->get_compressed_data() == nullptr) continue;
             const bool is_ht = (block->Cmodes & HT) >> 6;
             if (!is_ht) {
               // EBCOT: both buffers must be pre-zeroed.

--- a/source/core/coding/coding_units.hpp
+++ b/source/core/coding/coding_units.hpp
@@ -194,6 +194,15 @@ class j2k_codeblock : public j2k_region {
   uint8_t *get_compressed_data();
   void set_compressed_data(uint8_t *buf, uint16_t size, uint16_t Lref = 0);
   void create_compressed_buffer(buf_chain *tile_buf, int32_t buf_limit, const uint16_t &layer);
+  // JPIP precinct-mask path: consume the packet body bytes belonging to this
+  // layer from tile_buf (keeping the byte stream in sync with the next
+  // packet) without attaching them to the codeblock.  Leaves compressed_data
+  // untouched — when it is nullptr (first layer of a masked precinct) the
+  // codeblock stays in "no passes decoded" state and the HT block decoder
+  // skips it; when it is non-null (masked later layer after an unmasked
+  // first layer) the already-attached layers decode normally while the
+  // masked layer's passes are dropped.
+  void skip_compressed_buffer(buf_chain *tile_buf, const uint16_t &layer);
   // Single-tile reuse: clear every field touched by parse_packet_header /
   // create_compressed_buffer so the codeblock returns to its post-ctor
   // "ready to parse" state, without deallocating structural resources.
@@ -662,6 +671,14 @@ class j2k_tile : public j2k_tile_base {
   };
   std::vector<CRP> cached_crp_;
   bool crp_cached_ = false;
+
+  // JPIP precinct filter: when set, read_packet() still parses the packet
+  // header (so tagtrees and the header bit stream stay in sync), but drops
+  // the packet body bytes for precincts the filter rejects.  The callback
+  // is invoked with this tile's (component, resolution, precinct-index).
+  // Empty filter (the default) = keep every precinct.
+  std::function<bool(uint16_t c, uint8_t r, uint32_t p_rc)> precinct_filter_;
+
  public:
   // Bump-allocator pool for HTJ2K encode compressed bitstreams (one pool per thread).
   struct EncodePoolCtx {
@@ -706,8 +723,13 @@ class j2k_tile : public j2k_tile_base {
   void setCODparams(COD_marker *COD);
   // set members related to QCD marker
   void setQCDparams(QCD_marker *QCD);
-  // read packets
-  void read_packet(j2k_precinct *current_precint, uint16_t layer, uint8_t num_band);
+  // read packets; when skip_body is true the packet header is still parsed
+  // (advancing tagtrees and the header bit stream) but the body bytes are
+  // dropped without attaching to any codeblock — see §M.4.1.  The JPIP
+  // precinct filter decides this per-precinct; callers that don't use the
+  // mask path can leave skip_body at its default.
+  void read_packet(j2k_precinct *current_precint, uint16_t layer, uint8_t num_band,
+                   bool skip_body = false);
   // function to retrieve greatest common divisor of precinct size among resolution levels
   void find_gcd_of_precinct_size(element_siz &out);
 
@@ -740,6 +762,13 @@ class j2k_tile : public j2k_tile_base {
   // cached tile is in "tree is allocated" state (= reuse path) or not (=
   // still a fresh j2k_tile that has never seen a codestream).
   OPENHTJ2K_NODISCARD bool is_structure_built() const { return structure_built_; }
+  // Install (or clear, via an empty std::function) a JPIP precinct filter.
+  // The filter is consulted once per packet in read_packet(); a false
+  // return causes the body bytes to be dropped via skip_compressed_buffer
+  // rather than attached.  Must be set before decode() / decode_line_based_*.
+  void set_precinct_filter(std::function<bool(uint16_t c, uint8_t r, uint32_t p_rc)> f) {
+    precinct_filter_ = std::move(f);
+  }
   // Flip persistence on all tile_components of this tile.  Called by the
   // reuse entry point on the first frame, just before decode_line_based_stream,
   // so finalize_line_decode() skips teardown and keeps line_dec alive for

--- a/source/core/coding/subband_row_buf.cpp
+++ b/source/core/coding/subband_row_buf.cpp
@@ -229,7 +229,10 @@ void j2k_subband_row_buf::decode_strip_core(sprec_t *target_buf, int32_t y0, int
           // All columns in this row overlap with [y0, y1).
           for (uint32_t c = 0; c < ncx; ++c) {
             j2k_codeblock *block = cpb->access_codeblock(r * ncx + c);
-            if (!block->num_passes) {
+            // Treat JPIP-masked codeblocks (compressed_data == nullptr despite
+            // num_passes > 0) the same way as empty blocks: dequant never runs
+            // and the target-buf region must be explicitly zeroed.
+            if (!block->num_passes || block->get_compressed_data() == nullptr) {
               // Empty block: dequantize never runs, so zero its region in target_buf
               // explicitly (replaces the bulk ring_buf pre-zero in decode_strip).
               if (ring_mode && target_buf) {
@@ -342,7 +345,9 @@ void j2k_subband_row_buf::decode_strip_core(sprec_t *target_buf, int32_t y0, int
       for (uint32_t c = 0; c < ncx; ++c) {
         j2k_codeblock *block = cpb->access_codeblock(r * ncx + c);
 
-        if (!block->num_passes) {
+        // JPIP-masked codeblocks (num_passes > 0 but no compressed data) take
+        // the same "empty block" path — zero the target region and skip decode.
+        if (!block->num_passes || block->get_compressed_data() == nullptr) {
           // Empty block: zero its region in target_buf (replaces bulk pre-zero).
           if (ring_mode && target_buf) {
             const ptrdiff_t roff =
@@ -516,7 +521,10 @@ void j2k_subband_row_buf::trigger_prefetch(int32_t next_y0) {
   const ptrdiff_t stride = static_cast<ptrdiff_t>(sb->stride);
 
   auto process_block = [&](const CachedBlock &ce) {
-    if (!ce.block->num_passes) {
+    // Same JPIP-masked / empty-block handling as the walking path: if the
+    // codeblock has no data to decode, zero the output region (when using a
+    // ring prefetch buffer) and skip the decode task.
+    if (!ce.block->num_passes || ce.block->get_compressed_data() == nullptr) {
       if (prefetch_buf != nullptr) {
         sprec_t *dst = prefetch_buf + ce.row_off + ce.col_off;
         for (uint32_t row = 0; row < ce.size_y; ++row) {

--- a/source/core/interface/decoder.cpp
+++ b/source/core/interface/decoder.cpp
@@ -77,6 +77,12 @@ class openhtj2k_decoder_impl {
   std::vector<j2k_tile> cached_tileSet_;
   uint64_t cached_header_fingerprint_  = 0;
 
+  // JPIP partial-decode filter: invoked per-packet during every subsequent
+  // invoke*() call, once per (t, c, r, p_rc).  An empty std::function means
+  // "no filter" — the tile-level precinct_filter_ stays unset and all
+  // precincts decode normally.
+  std::function<bool(uint16_t, uint16_t, uint8_t, uint32_t)> precinct_filter_;
+
  public:
   openhtj2k_decoder_impl();
   openhtj2k_decoder_impl(const char *, uint8_t reduce_NL, uint32_t num_threads);
@@ -111,6 +117,13 @@ class openhtj2k_decoder_impl {
                                     std::vector<uint32_t> &, std::vector<uint8_t> &,
                                     std::vector<bool> &);
   void enable_single_tile_reuse(bool on);
+  void set_precinct_filter(std::function<bool(uint16_t, uint16_t, uint8_t, uint32_t)> f);
+
+  // Binds precinct_filter_'s (t, c, r, p_rc) signature into a (c, r, p_rc)
+  // closure for the given tile and installs it on the tile (or clears it
+  // when precinct_filter_ is empty).  Called just before each
+  // create_tile_buf() so the packet-parsing loop sees the current filter.
+  void install_precinct_filter(j2k_tile &tile, uint16_t tile_idx);
 
   void destroy();
 };
@@ -391,6 +404,7 @@ void openhtj2k_decoder_impl::invoke(std::vector<int32_t *> &buf, std::vector<uin
   // Read codestream and decode it
   for (uint32_t i = 0; i < numTiles.x * numTiles.y; i++) {
     try {
+      install_precinct_filter(tileSet[i], static_cast<uint16_t>(i));
       tileSet[i].create_tile_buf(main_header);
     } catch (std::exception &exc) {
       printf("ERROR: %s\n", exc.what());
@@ -518,6 +532,7 @@ void openhtj2k_decoder_impl::invoke_line_based(std::vector<int32_t *> &buf,
   for (uint32_t i = 0; i < numTiles.x * numTiles.y; i++) {
     try {
       tileSet[i].line_based_decode = true;
+      install_precinct_filter(tileSet[i], static_cast<uint16_t>(i));
       tileSet[i].create_tile_buf(main_header);
     } catch (std::exception &exc) {
       printf("ERROR: %s\n", exc.what());
@@ -632,6 +647,7 @@ void openhtj2k_decoder_impl::invoke_line_based_stream(
       const uint32_t tile_idx = ty;
       try {
         tileSet[tile_idx].line_based_decode = true;
+        install_precinct_filter(tileSet[tile_idx], static_cast<uint16_t>(tile_idx));
         tileSet[tile_idx].create_tile_buf(main_header);
       } catch (std::exception &exc) {
         printf("ERROR: %s\n", exc.what());
@@ -695,6 +711,7 @@ void openhtj2k_decoder_impl::invoke_line_based_stream(
 
       try {
         tileSet[tile_idx].line_based_decode = true;
+        install_precinct_filter(tileSet[tile_idx], static_cast<uint16_t>(tile_idx));
         tileSet[tile_idx].create_tile_buf(main_header);
       } catch (std::exception &exc) {
         printf("ERROR: %s\n", exc.what());
@@ -746,6 +763,27 @@ void openhtj2k_decoder_impl::enable_single_tile_reuse(bool on) {
     // Drop the cache so the next call starts from a clean slate.
     cached_tileSet_.clear();
     cached_header_fingerprint_ = 0;
+  }
+}
+
+void openhtj2k_decoder::set_precinct_filter(
+    std::function<bool(uint16_t, uint16_t, uint8_t, uint32_t)> f) {
+  this->impl->set_precinct_filter(std::move(f));
+}
+
+void openhtj2k_decoder_impl::set_precinct_filter(
+    std::function<bool(uint16_t, uint16_t, uint8_t, uint32_t)> f) {
+  precinct_filter_ = std::move(f);
+}
+
+void openhtj2k_decoder_impl::install_precinct_filter(j2k_tile &tile, uint16_t tile_idx) {
+  if (precinct_filter_) {
+    auto pf = precinct_filter_;  // capture by value — filter may be replaced between invokes
+    tile.set_precinct_filter([pf, tile_idx](uint16_t c, uint8_t r, uint32_t p_rc) {
+      return pf(tile_idx, c, r, p_rc);
+    });
+  } else {
+    tile.set_precinct_filter({});
   }
 }
 
@@ -939,6 +977,7 @@ void openhtj2k_decoder_impl::invoke_line_based_stream_reuse(
 
   try {
     cached_tileSet_[0].line_based_decode = true;
+    install_precinct_filter(cached_tileSet_[0], 0);
     cached_tileSet_[0].create_tile_buf(main_header);
   } catch (std::exception &exc) {
     printf("ERROR: %s\n", exc.what());
@@ -1145,6 +1184,7 @@ void openhtj2k_decoder_impl::invoke_line_based_direct(
 
   try {
     cached_tileSet_[0].line_based_decode = true;
+    install_precinct_filter(cached_tileSet_[0], 0);
     cached_tileSet_[0].create_tile_buf(main_header);
   } catch (std::exception &exc) {
     printf("ERROR: %s\n", exc.what());
@@ -1225,6 +1265,7 @@ void openhtj2k_decoder_impl::invoke_line_based_predecoded(std::vector<int32_t *>
 
   for (uint32_t i = 0; i < numTiles.x * numTiles.y; i++) {
     try {
+      install_precinct_filter(tileSet[i], static_cast<uint16_t>(i));
       tileSet[i].create_tile_buf(main_header);
     } catch (std::exception &exc) {
       printf("ERROR: %s\n", exc.what());

--- a/source/core/interface/decoder.hpp
+++ b/source/core/interface/decoder.hpp
@@ -113,6 +113,17 @@ class openhtj2k_decoder {
   // sequence for the stream you want to keep cached.  Passing false drops
   // any cached state and returns the decoder to the legacy per-frame path.
   OPENHTJ2K_EXPORT void enable_single_tile_reuse(bool on);
+  // JPIP partial-decode hook.  When set, every subsequent invoke*() call
+  // consults this filter per-packet: precincts for which the filter returns
+  // false have their body bytes dropped (not attached to codeblocks) while
+  // the packet-header bit stream still advances — so the byte stream stays
+  // aligned with the next packet.  Masked precincts contribute zero samples
+  // to the IDWT; unmasked precincts decode exactly as they would without
+  // the filter.  Pass an empty std::function to clear the filter.  Arguments
+  // are (tile, component, resolution, intra-resolution precinct index) as
+  // defined in ISO/IEC 15444-9 §A.3.2.1.
+  OPENHTJ2K_EXPORT void set_precinct_filter(
+      std::function<bool(uint16_t t, uint16_t c, uint8_t r, uint32_t p_rc)> f);
   // Diagnostic: pre-decodes codeblocks via the tile-at-a-time path, then runs
   // the line-based IDWT using those pre-decoded values.  If this matches invoke()
   // but invoke_line_based() does not, the bug is in decode_strip(); otherwise

--- a/source/core/jpip/CMakeLists.txt
+++ b/source/core/jpip/CMakeLists.txt
@@ -2,4 +2,5 @@ cmake_policy(SET CMP0076 NEW)
 target_sources(open_htj2k
     PRIVATE
     precinct_index.cpp
+    view_window.cpp
 )

--- a/source/core/jpip/CMakeLists.txt
+++ b/source/core/jpip/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_policy(SET CMP0076 NEW)
+target_sources(open_htj2k
+    PRIVATE
+    precinct_index.cpp
+)

--- a/source/core/jpip/precinct_index.cpp
+++ b/source/core/jpip/precinct_index.cpp
@@ -48,6 +48,14 @@ void build_tile_component(j2k_main_header &mh, uint16_t c,
   out.npw.assign(NL_tc + 1u, 0);
   out.nph.assign(NL_tc + 1u, 0);
   out.s_offset.assign(NL_tc + 1u, 0);
+  out.log2PPx.assign(NL_tc + 1u, 0);
+  out.log2PPy.assign(NL_tc + 1u, 0);
+  out.respos0_x.assign(NL_tc + 1u, 0);
+  out.respos0_y.assign(NL_tc + 1u, 0);
+  out.tc_pos0.x = tc_x0;
+  out.tc_pos0.y = tc_y0;
+  out.tc_pos1.x = tc_x1;
+  out.tc_pos1.y = tc_y1;
 
   uint32_t cumulative = 0;
   for (uint8_t r = 0; r <= NL_tc; ++r) {
@@ -71,9 +79,13 @@ void build_tile_component(j2k_main_header &mh, uint16_t c,
     const uint32_t nph =
         (respos1_y > respos0_y) ? (ceil_int(respos1_y, PPy) - respos0_y / PPy) : 0u;
 
-    out.npw[r]      = npw;
-    out.nph[r]      = nph;
-    out.s_offset[r] = cumulative;
+    out.npw[r]       = npw;
+    out.nph[r]       = nph;
+    out.s_offset[r]  = cumulative;
+    out.log2PPx[r]   = static_cast<uint8_t>(log2PP.x);
+    out.log2PPy[r]   = static_cast<uint8_t>(log2PP.y);
+    out.respos0_x[r] = respos0_x;
+    out.respos0_y[r] = respos0_y;
     cumulative += npw * nph;
   }
   out.total = cumulative;
@@ -110,8 +122,9 @@ std::unique_ptr<CodestreamIndex> CodestreamIndex::build(const uint8_t *codestrea
   }
 
   std::unique_ptr<CodestreamIndex> idx(new CodestreamIndex());
-  idx->num_components_ = mh.SIZ->get_num_components();
-  idx->progression_    = mh.COD->get_progression_order();
+  idx->num_components_  = mh.SIZ->get_num_components();
+  idx->progression_     = mh.COD->get_progression_order();
+  idx->is_irreversible_ = (mh.COD->get_transformation() == 0);
   mh.get_number_of_tiles(idx->num_tiles_x_, idx->num_tiles_y_);
 
   element_siz canvas, origin, tsize, torigin;
@@ -119,6 +132,17 @@ std::unique_ptr<CodestreamIndex> CodestreamIndex::build(const uint8_t *codestrea
   mh.SIZ->get_image_origin(origin);
   mh.SIZ->get_tile_size(tsize);
   mh.SIZ->get_tile_origin(torigin);
+  idx->geometry_.canvas_size   = {canvas.x, canvas.y};
+  idx->geometry_.canvas_origin = {origin.x, origin.y};
+  idx->geometry_.tile_size     = {tsize.x, tsize.y};
+  idx->geometry_.tile_origin   = {torigin.x, torigin.y};
+
+  idx->subsampling_.resize(idx->num_components_);
+  for (uint16_t c = 0; c < idx->num_components_; ++c) {
+    element_siz sub;
+    mh.SIZ->get_subsampling_factor(sub, c);
+    idx->subsampling_[c] = {sub.x, sub.y};
+  }
 
   const uint64_t total_tc =
       static_cast<uint64_t>(idx->num_tiles()) * idx->num_components_;
@@ -167,6 +191,21 @@ uint64_t CodestreamIndex::total_precincts() const {
   uint64_t sum = 0;
   for (const auto &info : tcinfo_) sum += info.total;
   return sum;
+}
+
+uint8_t CodestreamIndex::max_NL() const {
+  uint8_t m = 0;
+  for (const auto &info : tcinfo_) {
+    if (info.NL > m) m = info.NL;
+  }
+  return m;
+}
+
+Point2 CodestreamIndex::subsampling(uint16_t c) const {
+  if (c >= num_components_) {
+    throw std::out_of_range("CodestreamIndex::subsampling");
+  }
+  return subsampling_[c];
 }
 
 }  // namespace jpip

--- a/source/core/jpip/precinct_index.cpp
+++ b/source/core/jpip/precinct_index.cpp
@@ -1,0 +1,173 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+
+#include "precinct_index.hpp"
+
+#include <algorithm>
+#include <stdexcept>
+
+#include "codestream.hpp"
+#include "j2kmarkers.hpp"
+#include "open_htj2k_typedef.hpp"
+#include "utils.hpp"
+
+namespace open_htj2k {
+namespace jpip {
+
+namespace {
+
+// Find the COC marker that overrides component `c`, or nullptr if none.
+const COC_marker *find_coc(const j2k_main_header &mh, uint16_t c) {
+  for (const auto &coc : mh.COC) {
+    if (coc->get_component_index() == c) return coc.get();
+  }
+  return nullptr;
+}
+
+// Mirrors the per-resolution geometry computation in j2k_tile_component::
+// create_resolutions (coding_units.cpp:2820+).  No DFS support yet — fine for
+// the Phase-1 test assets, which use a fixed isotropic dyadic decomposition.
+void build_tile_component(j2k_main_header &mh, uint16_t c,
+                          uint32_t tile_x0, uint32_t tile_y0,
+                          uint32_t tile_x1, uint32_t tile_y1,
+                          TileComponentInfo &out) {
+  // get_subsampling_factor / get_precinct_size are non-const in the existing
+  // marker classes, so we accept a non-const main_header here.
+  element_siz sub;
+  mh.SIZ->get_subsampling_factor(sub, c);
+  const uint32_t tc_x0 = ceil_int(tile_x0, sub.x);
+  const uint32_t tc_y0 = ceil_int(tile_y0, sub.y);
+  const uint32_t tc_x1 = ceil_int(tile_x1, sub.x);
+  const uint32_t tc_y1 = ceil_int(tile_y1, sub.y);
+
+  COC_marker *coc = const_cast<COC_marker *>(find_coc(mh, c));
+  const uint8_t NL_tc =
+      coc ? coc->get_dwt_levels() : mh.COD->get_dwt_levels();
+
+  out.NL = NL_tc;
+  out.npw.assign(NL_tc + 1u, 0);
+  out.nph.assign(NL_tc + 1u, 0);
+  out.s_offset.assign(NL_tc + 1u, 0);
+
+  uint32_t cumulative = 0;
+  for (uint8_t r = 0; r <= NL_tc; ++r) {
+    const uint32_t scale = 1u << (NL_tc - r);
+    const uint32_t respos0_x = ceil_int(tc_x0, scale);
+    const uint32_t respos0_y = ceil_int(tc_y0, scale);
+    const uint32_t respos1_x = ceil_int(tc_x1, scale);
+    const uint32_t respos1_y = ceil_int(tc_y1, scale);
+
+    element_siz log2PP;
+    if (coc) {
+      coc->get_precinct_size(log2PP, r);
+    } else {
+      mh.COD->get_precinct_size(log2PP, r);
+    }
+    const uint32_t PPx = 1u << log2PP.x;
+    const uint32_t PPy = 1u << log2PP.y;
+
+    const uint32_t npw =
+        (respos1_x > respos0_x) ? (ceil_int(respos1_x, PPx) - respos0_x / PPx) : 0u;
+    const uint32_t nph =
+        (respos1_y > respos0_y) ? (ceil_int(respos1_y, PPy) - respos0_y / PPy) : 0u;
+
+    out.npw[r]      = npw;
+    out.nph[r]      = nph;
+    out.s_offset[r] = cumulative;
+    cumulative += npw * nph;
+  }
+  out.total = cumulative;
+}
+
+}  // namespace
+
+std::unique_ptr<CodestreamIndex> CodestreamIndex::build(const uint8_t *codestream,
+                                                       std::size_t len) {
+  if (codestream == nullptr || len < 2) {
+    throw std::runtime_error("CodestreamIndex::build: empty input");
+  }
+  if (len > UINT32_MAX) {
+    throw std::runtime_error("CodestreamIndex::build: codestream > 4 GiB unsupported");
+  }
+
+  // Borrow the caller's buffer; main_header.read() only consumes through SOC..SOT.
+  // The marker readers require 16 bytes of readable padding past the end (SIMD
+  // over-read).  borrow_memory documents this requirement; for raw J2C parsing
+  // through the main header it is safe in practice because SIZ/COD/QCD parsing
+  // does not over-read the buffer end.  We copy into a fresh j2c_src_memory
+  // when the caller-supplied buffer is too tight (no padding contract).
+  j2c_src_memory in;
+  in.alloc_memory(static_cast<uint32_t>(len));
+  // alloc_memory zero-pads internally; copy the codestream bytes in.
+  std::copy_n(codestream, len, in.get_buf_pos());
+
+  j2k_main_header mh;
+  // read() returns EXIT_SUCCESS or throws on malformed input.
+  mh.read(in);
+
+  if (!mh.SIZ || !mh.COD) {
+    throw std::runtime_error("CodestreamIndex::build: missing SIZ or COD");
+  }
+
+  std::unique_ptr<CodestreamIndex> idx(new CodestreamIndex());
+  idx->num_components_ = mh.SIZ->get_num_components();
+  idx->progression_    = mh.COD->get_progression_order();
+  mh.get_number_of_tiles(idx->num_tiles_x_, idx->num_tiles_y_);
+
+  element_siz canvas, origin, tsize, torigin;
+  mh.SIZ->get_image_size(canvas);
+  mh.SIZ->get_image_origin(origin);
+  mh.SIZ->get_tile_size(tsize);
+  mh.SIZ->get_tile_origin(torigin);
+
+  const uint64_t total_tc =
+      static_cast<uint64_t>(idx->num_tiles()) * idx->num_components_;
+  idx->tcinfo_.resize(static_cast<std::size_t>(total_tc));
+
+  for (uint32_t ty = 0; ty < idx->num_tiles_y_; ++ty) {
+    for (uint32_t tx = 0; tx < idx->num_tiles_x_; ++tx) {
+      const uint32_t t = ty * idx->num_tiles_x_ + tx;
+      const uint32_t tile_x0 = std::max(torigin.x + tx * tsize.x, origin.x);
+      const uint32_t tile_y0 = std::max(torigin.y + ty * tsize.y, origin.y);
+      const uint32_t tile_x1 = std::min(torigin.x + (tx + 1) * tsize.x, canvas.x);
+      const uint32_t tile_y1 = std::min(torigin.y + (ty + 1) * tsize.y, canvas.y);
+      for (uint16_t c = 0; c < idx->num_components_; ++c) {
+        build_tile_component(mh, c, tile_x0, tile_y0, tile_x1, tile_y1,
+                             idx->tcinfo_[static_cast<std::size_t>(t) *
+                                              idx->num_components_ + c]);
+      }
+    }
+  }
+
+  return idx;
+}
+
+const TileComponentInfo &CodestreamIndex::tile_component(uint16_t t, uint16_t c) const {
+  if (t >= num_tiles() || c >= num_components_) {
+    throw std::out_of_range("CodestreamIndex::tile_component");
+  }
+  return tcinfo_[static_cast<std::size_t>(t) * num_components_ + c];
+}
+
+uint32_t CodestreamIndex::s(uint16_t t, uint16_t c, uint8_t r, uint32_t p_rc) const {
+  const TileComponentInfo &info = tile_component(t, c);
+  if (r > info.NL || p_rc >= info.npw[r] * info.nph[r]) {
+    throw std::out_of_range("CodestreamIndex::s");
+  }
+  return info.s_offset[r] + p_rc;
+}
+
+uint64_t CodestreamIndex::I(uint16_t t, uint16_t c, uint8_t r, uint32_t p_rc) const {
+  const uint64_t s_val = s(t, c, r, p_rc);
+  return static_cast<uint64_t>(t)
+         + (static_cast<uint64_t>(c) + s_val * num_components_) * num_tiles();
+}
+
+uint64_t CodestreamIndex::total_precincts() const {
+  uint64_t sum = 0;
+  for (const auto &info : tcinfo_) sum += info.total;
+  return sum;
+}
+
+}  // namespace jpip
+}  // namespace open_htj2k

--- a/source/core/jpip/precinct_index.hpp
+++ b/source/core/jpip/precinct_index.hpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+//
+// JPIP precinct geometry index — Phase 1, commit 1.
+// Builds a (tile, component, resolution, intra-resolution-index) → JPIP
+// sequence number `s` and in-class identifier `I` lookup from a parsed
+// j2k_main_header.  No byte offsets yet — those land in commit 3 alongside
+// the partial-decode mask.
+#pragma once
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace open_htj2k {
+namespace jpip {
+
+// Per-(tile, component) precinct geometry, indexed by resolution r ∈ [0, NL].
+// r = 0 is the LL subband; r = NL is the finest level.  npw/nph follow the
+// same convention as j2k_resolution: the number of precincts on the subband
+// reference grid for that resolution.
+struct TileComponentInfo {
+  uint8_t  NL = 0;
+  std::vector<uint32_t> npw;
+  std::vector<uint32_t> nph;
+  // s_offset[r] = sum_{r' < r} npw[r'] * nph[r'] — prefix sum used to derive
+  // the JPIP sequence number `s` from a (r, p_rc) pair.
+  std::vector<uint32_t> s_offset;
+  uint32_t total = 0;
+};
+
+class CodestreamIndex {
+ public:
+  // Build the index by parsing the main header of a raw J2C codestream
+  // (no JP2/JPH container).  Throws std::runtime_error on parse failure.
+  static std::unique_ptr<CodestreamIndex> build(const uint8_t *codestream, std::size_t len);
+
+  uint32_t num_tiles_x()    const { return num_tiles_x_; }
+  uint32_t num_tiles_y()    const { return num_tiles_y_; }
+  uint32_t num_tiles()      const { return num_tiles_x_ * num_tiles_y_; }
+  uint16_t num_components() const { return num_components_; }
+  uint8_t  progression_order() const { return progression_; }
+
+  const TileComponentInfo &tile_component(uint16_t t, uint16_t c) const;
+
+  // JPIP §A.3.2.1 sequence number within the tile-component.
+  uint32_t s(uint16_t t, uint16_t c, uint8_t r, uint32_t p_rc) const;
+
+  // JPIP §A.3.2.1 Eq A-1: I = t + (c + s · num_components) · num_tiles
+  uint64_t I(uint16_t t, uint16_t c, uint8_t r, uint32_t p_rc) const;
+
+  // Total precinct count summed over all (t, c).
+  uint64_t total_precincts() const;
+
+ private:
+  CodestreamIndex() = default;
+
+  uint16_t num_components_ = 0;
+  uint32_t num_tiles_x_    = 0;
+  uint32_t num_tiles_y_    = 0;
+  uint8_t  progression_    = 0;
+  // Row-major [t * num_components + c].
+  std::vector<TileComponentInfo> tcinfo_;
+};
+
+}  // namespace jpip
+}  // namespace open_htj2k

--- a/source/core/jpip/precinct_index.hpp
+++ b/source/core/jpip/precinct_index.hpp
@@ -15,6 +15,25 @@
 namespace open_htj2k {
 namespace jpip {
 
+// 2-D size / coordinate pair used by the JPIP geometry API.  Kept as its own
+// type rather than reusing the internal open_htj2k::element_siz so that this
+// header does not leak library internals.
+struct Point2 {
+  uint32_t x = 0;
+  uint32_t y = 0;
+};
+
+// Wire-level identity of a precinct: tile index, component index, resolution
+// level (0 = LL, NL = finest), and intra-resolution raster index.
+// Maps to JPIP sequence number `s` and in-class identifier `I` via the
+// CodestreamIndex accessors.
+struct PrecinctKey {
+  uint16_t t    = 0;
+  uint16_t c    = 0;
+  uint8_t  r    = 0;
+  uint32_t p_rc = 0;
+};
+
 // Per-(tile, component) precinct geometry, indexed by resolution r ∈ [0, NL].
 // r = 0 is the LL subband; r = NL is the finest level.  npw/nph follow the
 // same convention as j2k_resolution: the number of precincts on the subband
@@ -27,6 +46,26 @@ struct TileComponentInfo {
   // the JPIP sequence number `s` from a (r, p_rc) pair.
   std::vector<uint32_t> s_offset;
   uint32_t total = 0;
+
+  // Tile-component extent on the component's subsampled reference grid.
+  // tc_x1 = tc_x0 + tile-component width, etc.
+  Point2 tc_pos0;
+  Point2 tc_pos1;
+
+  // Per-resolution precinct partition parameters (size NL+1 each).  Mirrors
+  // what j2k_resolution::create_precincts consumes.  PP = 2^log2PP.  respos0
+  // is the precinct-grid origin on the subband reference grid of resolution r.
+  std::vector<uint8_t>  log2PPx;
+  std::vector<uint8_t>  log2PPy;
+  std::vector<uint32_t> respos0_x;
+  std::vector<uint32_t> respos0_y;
+};
+
+struct ImageGeometry {
+  Point2 canvas_size;    // (Xsiz, Ysiz)
+  Point2 canvas_origin;  // (XOsiz, YOsiz)
+  Point2 tile_size;      // (XTsiz, YTsiz)
+  Point2 tile_origin;    // (XTOsiz, YTOsiz)
 };
 
 class CodestreamIndex {
@@ -40,6 +79,14 @@ class CodestreamIndex {
   uint32_t num_tiles()      const { return num_tiles_x_ * num_tiles_y_; }
   uint16_t num_components() const { return num_components_; }
   uint8_t  progression_order() const { return progression_; }
+  const ImageGeometry &geometry() const { return geometry_; }
+  // COD SPcod[4]: 0 = 9/7 (irreversible, lossy), 1 = 5/3 (reversible).
+  bool     is_irreversible()   const { return is_irreversible_; }
+  // Largest NL across all (t, c).  Used by resolve_view_window for picking
+  // the discard level under round-direction "down".
+  uint8_t  max_NL() const;
+  // Component subsampling XRsiz/YRsiz (Point2.{x,y}).
+  Point2   subsampling(uint16_t c) const;
 
   const TileComponentInfo &tile_component(uint16_t t, uint16_t c) const;
 
@@ -59,6 +106,9 @@ class CodestreamIndex {
   uint32_t num_tiles_x_    = 0;
   uint32_t num_tiles_y_    = 0;
   uint8_t  progression_    = 0;
+  bool     is_irreversible_ = false;
+  ImageGeometry geometry_{};
+  std::vector<Point2> subsampling_;  // size num_components_
   // Row-major [t * num_components + c].
   std::vector<TileComponentInfo> tcinfo_;
 };

--- a/source/core/jpip/precinct_index.hpp
+++ b/source/core/jpip/precinct_index.hpp
@@ -12,6 +12,17 @@
 #include <memory>
 #include <vector>
 
+// Mirrors the OPENHTJ2K_EXPORT pattern in source/core/interface/decoder.hpp:
+// MSVC needs __declspec(dllexport) on out-of-line definitions reachable from
+// other DLLs / executables; everywhere else the macro is empty and ELF/Mach-O
+// default visibility takes care of it.  Defined inline here so this header
+// doesn't have to include the existing public ABI surface.
+#if defined(_MSC_VER) && !defined(OHTJ2K_STATIC)
+  #define OPENHTJ2K_JPIP_EXPORT __declspec(dllexport)
+#else
+  #define OPENHTJ2K_JPIP_EXPORT
+#endif
+
 namespace open_htj2k {
 namespace jpip {
 
@@ -72,7 +83,8 @@ class CodestreamIndex {
  public:
   // Build the index by parsing the main header of a raw J2C codestream
   // (no JP2/JPH container).  Throws std::runtime_error on parse failure.
-  static std::unique_ptr<CodestreamIndex> build(const uint8_t *codestream, std::size_t len);
+  OPENHTJ2K_JPIP_EXPORT static std::unique_ptr<CodestreamIndex> build(
+      const uint8_t *codestream, std::size_t len);
 
   uint32_t num_tiles_x()    const { return num_tiles_x_; }
   uint32_t num_tiles_y()    const { return num_tiles_y_; }
@@ -84,20 +96,20 @@ class CodestreamIndex {
   bool     is_irreversible()   const { return is_irreversible_; }
   // Largest NL across all (t, c).  Used by resolve_view_window for picking
   // the discard level under round-direction "down".
-  uint8_t  max_NL() const;
+  OPENHTJ2K_JPIP_EXPORT uint8_t  max_NL() const;
   // Component subsampling XRsiz/YRsiz (Point2.{x,y}).
-  Point2   subsampling(uint16_t c) const;
+  OPENHTJ2K_JPIP_EXPORT Point2   subsampling(uint16_t c) const;
 
-  const TileComponentInfo &tile_component(uint16_t t, uint16_t c) const;
+  OPENHTJ2K_JPIP_EXPORT const TileComponentInfo &tile_component(uint16_t t, uint16_t c) const;
 
   // JPIP §A.3.2.1 sequence number within the tile-component.
-  uint32_t s(uint16_t t, uint16_t c, uint8_t r, uint32_t p_rc) const;
+  OPENHTJ2K_JPIP_EXPORT uint32_t s(uint16_t t, uint16_t c, uint8_t r, uint32_t p_rc) const;
 
   // JPIP §A.3.2.1 Eq A-1: I = t + (c + s · num_components) · num_tiles
-  uint64_t I(uint16_t t, uint16_t c, uint8_t r, uint32_t p_rc) const;
+  OPENHTJ2K_JPIP_EXPORT uint64_t I(uint16_t t, uint16_t c, uint8_t r, uint32_t p_rc) const;
 
   // Total precinct count summed over all (t, c).
-  uint64_t total_precincts() const;
+  OPENHTJ2K_JPIP_EXPORT uint64_t total_precincts() const;
 
  private:
   CodestreamIndex() = default;

--- a/source/core/jpip/view_window.cpp
+++ b/source/core/jpip/view_window.cpp
@@ -1,0 +1,216 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+
+#include "view_window.hpp"
+
+#include <algorithm>
+#include <cstdlib>
+#include <stdexcept>
+
+namespace open_htj2k {
+namespace jpip {
+
+namespace {
+
+inline uint32_t ceil_div_u(uint32_t a, uint32_t b) { return (a + b - 1u) / b; }
+
+// Canvas frame size at discard level r per §C.4.1 Eq. C-1:
+//   fx'(r) = ceil(Xsiz / 2^r) - ceil(XOsiz / 2^r)
+// Works for r far larger than any tile-component NL — at that point the
+// result saturates at 1 (or 0 if the canvas is empty).
+void fsiz_at(const CodestreamIndex &idx, uint8_t r, uint32_t &fx, uint32_t &fy) {
+  const ImageGeometry &g = idx.geometry();
+  const uint32_t div = 1u << r;
+  fx = ceil_div_u(g.canvas_size.x, div) - ceil_div_u(g.canvas_origin.x, div);
+  fy = ceil_div_u(g.canvas_size.y, div) - ceil_div_u(g.canvas_origin.y, div);
+}
+
+// §M.4.1 DWT-synthesis expansion margin on the subband reference grid for
+// resolution r in a tile-component with `levels_above` IDWT steps remaining
+// between this resolution and the reconstructed image.  Upper bound of the
+// geometric series L_synth * (1 + 1/2 + 1/4 + ...) < 2·L_synth.
+uint32_t dwt_margin_subband(bool irreversible, uint8_t levels_above) {
+  if (levels_above == 0) return 0;
+  const uint32_t L_synth = irreversible ? 4u : 2u;  // 9/7 vs 5/3 synthesis support
+  return 2u * L_synth;
+}
+
+// Saturating-subtraction on uint32_t.
+inline uint32_t sub_sat(uint32_t a, uint32_t b) { return (a > b) ? (a - b) : 0u; }
+
+}  // namespace
+
+uint8_t pick_discard_level(const CodestreamIndex &idx, const ViewWindow &vw) {
+  // Cap search at max_NL across all (t, c) — r larger than that collapses
+  // to the LL subband and no further reduction is possible.
+  const uint8_t r_max = idx.max_NL();
+  const uint32_t req_fx = vw.fx ? vw.fx : idx.geometry().canvas_size.x;
+  const uint32_t req_fy = vw.fy ? vw.fy : idx.geometry().canvas_size.y;
+
+  switch (vw.round) {
+    case ViewWindow::Round::Down: {
+      // Largest available resolution that fits inside (req_fx, req_fy).
+      // Iterate r=0 → r_max, pick the smallest r where fx'(r) ≤ req.  If
+      // none fits (can only happen when req is smaller than the LL), fall
+      // back to r_max (smallest available).
+      for (uint8_t r = 0; r <= r_max; ++r) {
+        uint32_t fx = 0, fy = 0;
+        fsiz_at(idx, r, fx, fy);
+        if (fx <= req_fx && fy <= req_fy) return r;
+      }
+      return r_max;
+    }
+    case ViewWindow::Round::Up: {
+      // Smallest available resolution that contains (req_fx, req_fy).  Walk
+      // r = r_max → 0; pick the largest r (smallest fx') where fx' ≥ req.
+      for (int r = r_max; r >= 0; --r) {
+        uint32_t fx = 0, fy = 0;
+        fsiz_at(idx, static_cast<uint8_t>(r), fx, fy);
+        if (fx >= req_fx && fy >= req_fy) return static_cast<uint8_t>(r);
+      }
+      return 0;
+    }
+    case ViewWindow::Round::Closest:
+    default: {
+      // Minimise |fx'(r)*fy'(r) - req_fx*req_fy|; ties → larger area (smaller r).
+      const uint64_t target = static_cast<uint64_t>(req_fx) * req_fy;
+      uint64_t best_diff = UINT64_MAX;
+      uint8_t  best_r    = 0;
+      for (uint8_t r = 0; r <= r_max; ++r) {
+        uint32_t fx = 0, fy = 0;
+        fsiz_at(idx, r, fx, fy);
+        const uint64_t area = static_cast<uint64_t>(fx) * fy;
+        const uint64_t diff = (area > target) ? (area - target) : (target - area);
+        if (diff < best_diff) {
+          best_diff = diff;
+          best_r    = r;
+        }
+      }
+      return best_r;
+    }
+  }
+}
+
+std::vector<PrecinctKey> resolve_view_window(const CodestreamIndex &idx,
+                                             const ViewWindow &vw) {
+  std::vector<PrecinctKey> out;
+  if (idx.num_components() == 0 || idx.num_tiles() == 0) return out;
+
+  // 1. Discard level — common across all tile-components; capped per-(t,c) below.
+  const uint8_t r_star = pick_discard_level(idx, vw);
+
+  // 2. Map (ox, oy, sx, sy) to canvas reference grid.  If Region Size is
+  //    omitted (sx == 0 && sy == 0), treat the request as whole-image at the
+  //    chosen discard level.
+  const ImageGeometry &g = idx.geometry();
+  const uint32_t scale = 1u << r_star;
+
+  uint32_t A_x = vw.ox * scale + g.canvas_origin.x;
+  uint32_t A_y = vw.oy * scale + g.canvas_origin.y;
+  uint32_t B_x = (vw.sx == 0 && vw.sy == 0) ? g.canvas_size.x
+                                            : (vw.ox + vw.sx) * scale + g.canvas_origin.x;
+  uint32_t B_y = (vw.sx == 0 && vw.sy == 0) ? g.canvas_size.y
+                                            : (vw.oy + vw.sy) * scale + g.canvas_origin.y;
+  // Clip to canvas.
+  A_x = std::min(A_x, g.canvas_size.x);
+  A_y = std::min(A_y, g.canvas_size.y);
+  B_x = std::min(B_x, g.canvas_size.x);
+  B_y = std::min(B_y, g.canvas_size.y);
+  if (A_x >= B_x || A_y >= B_y) return out;  // empty view-window
+
+  // 3. Component selection.
+  std::vector<uint16_t> comps = vw.comps;
+  if (comps.empty()) {
+    comps.reserve(idx.num_components());
+    for (uint16_t c = 0; c < idx.num_components(); ++c) comps.push_back(c);
+  }
+
+  // 4. Enumerate intersecting tiles.
+  const uint32_t tcol0 = sub_sat(A_x, g.tile_origin.x) / g.tile_size.x;
+  const uint32_t trow0 = sub_sat(A_y, g.tile_origin.y) / g.tile_size.y;
+  const uint32_t tcol1 = std::min(idx.num_tiles_x(), ceil_div_u(B_x - g.tile_origin.x, g.tile_size.x));
+  const uint32_t trow1 = std::min(idx.num_tiles_y(), ceil_div_u(B_y - g.tile_origin.y, g.tile_size.y));
+
+  for (uint32_t trow = trow0; trow < trow1; ++trow) {
+    for (uint32_t tcol = tcol0; tcol < tcol1; ++tcol) {
+      const uint16_t t = static_cast<uint16_t>(trow * idx.num_tiles_x() + tcol);
+      const uint32_t tile_x0 = std::max(g.tile_origin.x + tcol * g.tile_size.x, g.canvas_origin.x);
+      const uint32_t tile_y0 = std::max(g.tile_origin.y + trow * g.tile_size.y, g.canvas_origin.y);
+      const uint32_t tile_x1 = std::min(g.tile_origin.x + (tcol + 1u) * g.tile_size.x, g.canvas_size.x);
+      const uint32_t tile_y1 = std::min(g.tile_origin.y + (trow + 1u) * g.tile_size.y, g.canvas_size.y);
+
+      // Clip canvas region [A, B) to this tile.
+      const uint32_t clipA_x = std::max(A_x, tile_x0);
+      const uint32_t clipA_y = std::max(A_y, tile_y0);
+      const uint32_t clipB_x = std::min(B_x, tile_x1);
+      const uint32_t clipB_y = std::min(B_y, tile_y1);
+      if (clipA_x >= clipB_x || clipA_y >= clipB_y) continue;
+
+      for (uint16_t c : comps) {
+        if (c >= idx.num_components()) continue;
+        const Point2 sub = idx.subsampling(c);
+        // Tile-component coordinates on subsampled grid.
+        const uint32_t tc_A_x = ceil_div_u(clipA_x, sub.x);
+        const uint32_t tc_A_y = ceil_div_u(clipA_y, sub.y);
+        const uint32_t tc_B_x = ceil_div_u(clipB_x, sub.x);
+        const uint32_t tc_B_y = ceil_div_u(clipB_y, sub.y);
+        if (tc_A_x >= tc_B_x || tc_A_y >= tc_B_y) continue;
+
+        const TileComponentInfo &tc = idx.tile_component(t, c);
+        const uint8_t NL_tc = tc.NL;
+
+        // §M.4.1: if r_star > NL_tc, only the LL survives; else keep r in
+        // [0, NL_tc - r_star] inclusive (drop the top r_star resolutions).
+        const uint8_t eff_top_r =
+            (r_star >= NL_tc) ? 0u : static_cast<uint8_t>(NL_tc - r_star);
+
+        for (uint8_t r = 0; r <= eff_top_r; ++r) {
+          const uint32_t scale_r = 1u << (NL_tc - r);
+          // Subband coordinates for the clipped tile-component region.
+          uint32_t sb_A_x = tc_A_x / scale_r;
+          uint32_t sb_A_y = tc_A_y / scale_r;
+          uint32_t sb_B_x = ceil_div_u(tc_B_x, scale_r);
+          uint32_t sb_B_y = ceil_div_u(tc_B_y, scale_r);
+
+          // DWT expansion: overshoot on the subband grid.
+          const uint32_t margin =
+              dwt_margin_subband(idx.is_irreversible(), static_cast<uint8_t>(NL_tc - r));
+          sb_A_x = sub_sat(sb_A_x, margin);
+          sb_A_y = sub_sat(sb_A_y, margin);
+          sb_B_x += margin;
+          sb_B_y += margin;
+
+          const uint32_t PPx = 1u << tc.log2PPx[r];
+          const uint32_t PPy = 1u << tc.log2PPy[r];
+          const uint32_t idxoff_x = tc.respos0_x[r] / PPx;
+          const uint32_t idxoff_y = tc.respos0_y[r] / PPy;
+
+          // Precinct grid extents on this resolution.
+          int64_t px_lo = static_cast<int64_t>(sb_A_x / PPx) - idxoff_x;
+          int64_t py_lo = static_cast<int64_t>(sb_A_y / PPy) - idxoff_y;
+          int64_t px_hi = static_cast<int64_t>(ceil_div_u(sb_B_x, PPx)) - idxoff_x;
+          int64_t py_hi = static_cast<int64_t>(ceil_div_u(sb_B_y, PPy)) - idxoff_y;
+          px_lo = std::max<int64_t>(0, px_lo);
+          py_lo = std::max<int64_t>(0, py_lo);
+          px_hi = std::min<int64_t>(tc.npw[r], px_hi);
+          py_hi = std::min<int64_t>(tc.nph[r], py_hi);
+
+          for (int64_t py = py_lo; py < py_hi; ++py) {
+            for (int64_t px = px_lo; px < px_hi; ++px) {
+              PrecinctKey k;
+              k.t    = t;
+              k.c    = c;
+              k.r    = r;
+              k.p_rc = static_cast<uint32_t>(py * tc.npw[r] + px);
+              out.push_back(k);
+            }
+          }
+        }
+      }
+    }
+  }
+  return out;
+}
+
+}  // namespace jpip
+}  // namespace open_htj2k

--- a/source/core/jpip/view_window.hpp
+++ b/source/core/jpip/view_window.hpp
@@ -34,11 +34,12 @@ struct ViewWindow {
 // Resolve a view-window into the set of precincts a server must deliver.
 // Returned keys are deterministic and sorted by (t, c, r, p_rc).  Duplicates
 // never appear.  Codestreams with DFS/POC are NOT yet supported (Phase 1).
-std::vector<PrecinctKey> resolve_view_window(const CodestreamIndex &idx,
-                                             const ViewWindow &vw);
+OPENHTJ2K_JPIP_EXPORT std::vector<PrecinctKey>
+resolve_view_window(const CodestreamIndex &idx, const ViewWindow &vw);
 
 // Pick the discard level r* per §C.4.2 Table C.1.  Exposed for testing.
-uint8_t pick_discard_level(const CodestreamIndex &idx, const ViewWindow &vw);
+OPENHTJ2K_JPIP_EXPORT uint8_t pick_discard_level(const CodestreamIndex &idx,
+                                                 const ViewWindow &vw);
 
 }  // namespace jpip
 }  // namespace open_htj2k

--- a/source/core/jpip/view_window.hpp
+++ b/source/core/jpip/view_window.hpp
@@ -1,0 +1,44 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+//
+// JPIP view-window → precinct-set resolver.  Implements ISO/IEC 15444-9
+// §C.4 (fsiz/roff/rsiz) + §M.4.1 (server determination of relevant
+// precincts).  Used by the Phase-1 demo and by any future JPIP server to
+// translate a client's view-window request into the set of precincts that
+// must be delivered for a correct foveated reconstruction.
+#pragma once
+#include <cstdint>
+#include <vector>
+
+#include "precinct_index.hpp"
+
+namespace open_htj2k {
+namespace jpip {
+
+struct ViewWindow {
+  // §C.4.2 Frame Size: target image resolution.
+  uint32_t fx = 0;
+  uint32_t fy = 0;
+  // §C.4.3/§C.4.4 Offset and Region Size (on the fx/fy grid).
+  uint32_t ox = 0;
+  uint32_t oy = 0;
+  uint32_t sx = 0;
+  uint32_t sy = 0;
+  // §C.4.8 Components (empty = all).
+  std::vector<uint16_t> comps;
+  // §C.4.2 round-direction.
+  enum class Round : uint8_t { Down = 0, Up = 1, Closest = 2 };
+  Round round = Round::Down;
+};
+
+// Resolve a view-window into the set of precincts a server must deliver.
+// Returned keys are deterministic and sorted by (t, c, r, p_rc).  Duplicates
+// never appear.  Codestreams with DFS/POC are NOT yet supported (Phase 1).
+std::vector<PrecinctKey> resolve_view_window(const CodestreamIndex &idx,
+                                             const ViewWindow &vw);
+
+// Pick the discard level r* per §C.4.2 Table C.1.  Exposed for testing.
+uint8_t pick_discard_level(const CodestreamIndex &idx, const ViewWindow &vw);
+
+}  // namespace jpip
+}  // namespace open_htj2k

--- a/tests/jpip_phase1.cmake
+++ b/tests/jpip_phase1.cmake
@@ -7,6 +7,25 @@
 
 set(_JPIP_BIN_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 
+# ── Decoder precinct-filter sanity (§M.4.1 partial-decode plumbing) ──
+# Exercises the public openhtj2k_decoder::set_precinct_filter hook against a
+# Part-1 and a Part-15 conformance stream.  The assets live under
+# conformance_data/ so these tests always run.
+#
+#   --identity : keep-every-precinct filter → byte-identical to no-filter.
+#   --empty N  : drop-every-precinct filter → uniform field with peak-absolute
+#                spread ≤ N per component.  9/7 lossy + ICT needs N=4 to
+#                absorb inverse-colour-transform rounding of a (0,0,0) input.
+add_test(NAME jpip_pd_identity_p0_04
+         COMMAND jpip_partial_decode_check ${CONFORMANCE_DATA_DIR}/p0_04.j2k --identity)
+add_test(NAME jpip_pd_empty_p0_04
+         COMMAND jpip_partial_decode_check ${CONFORMANCE_DATA_DIR}/p0_04.j2k --empty 4)
+add_test(NAME jpip_pd_identity_ht_01
+         COMMAND jpip_partial_decode_check ${CONFORMANCE_DATA_DIR}/ds0_ht_01_b11.j2k --identity)
+add_test(NAME jpip_pd_empty_ht_01
+         COMMAND jpip_partial_decode_check ${CONFORMANCE_DATA_DIR}/ds0_ht_01_b11.j2k --empty 4)
+
+
 # ── Asset 1: full-resolution NASA Blue Marble (LRCP, default precincts) ──
 # Each (t, c) → NL+1 = 6 resolutions, each holding exactly one precinct
 # because PPx=PPy=15 (max) covers the whole resolution.  3 components ×
@@ -78,4 +97,12 @@ if (EXISTS "${_JPIP_BIN_DIR}/land_shallow_topo_1920_fov.j2c")
     add_test(NAME jpip_vw_land1920_corner_quadrant
              COMMAND jpip_index_check ${_JPIP_BIN_DIR}/land_shallow_topo_1920_fov.j2c
                      --vw 1920,1920,0,0,960,960=942)
+
+    # Partial-decode sanity on the 9/7 foveation asset (PAE ≤ 2 since Cycc=on).
+    add_test(NAME jpip_pd_identity_land1920_fov
+             COMMAND jpip_partial_decode_check
+                     ${_JPIP_BIN_DIR}/land_shallow_topo_1920_fov.j2c --identity)
+    add_test(NAME jpip_pd_empty_land1920_fov
+             COMMAND jpip_partial_decode_check
+                     ${_JPIP_BIN_DIR}/land_shallow_topo_1920_fov.j2c --empty 2)
 endif()

--- a/tests/jpip_phase1.cmake
+++ b/tests/jpip_phase1.cmake
@@ -1,0 +1,43 @@
+# JPIP Phase 1, commit 1 — precinct-index ctests.
+#
+# Validates CodestreamIndex against two NASA Blue Marble derivatives that
+# live in build/bin/ rather than conformance_data/, since the source PPM
+# is too large to commit.  Both tests are skipped (status PASSED via
+# WILL_FAIL FALSE + manual existence check) when the asset is absent.
+
+set(_JPIP_BIN_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+
+# ── Asset 1: full-resolution NASA Blue Marble (LRCP, default precincts) ──
+# Each (t, c) → NL+1 = 6 resolutions, each holding exactly one precinct
+# because PPx=PPy=15 (max) covers the whole resolution.  3 components ×
+# 6 resolutions = 18 precincts total.
+if (EXISTS "${_JPIP_BIN_DIR}/land_shallow_topo_21600.j2c")
+    add_test(NAME jpip_idx_land21600_total
+             COMMAND jpip_index_check ${_JPIP_BIN_DIR}/land_shallow_topo_21600.j2c
+                     --total 18)
+    add_test(NAME jpip_idx_land21600_per_res
+             COMMAND jpip_index_check ${_JPIP_BIN_DIR}/land_shallow_topo_21600.j2c
+                     --per-res 0,0=1,1,1,1,1,1
+                     --per-res 0,1=1,1,1,1,1,1
+                     --per-res 0,2=1,1,1,1,1,1)
+endif()
+
+# ── Asset 2: 1920×1920 foveation demo (PCRL, 64×64 precincts) ──
+# Per-component breakdown for canvas 1920×1920, NL=5, PPx=PPy=64:
+#   r=0 (LL,    60×60): npw=1  nph=1  →   1
+#   r=1 (      120×120): npw=2  nph=2  →   4
+#   r=2 (      240×240): npw=4  nph=4  →  16
+#   r=3 (      480×480): npw=8  nph=8  →  64
+#   r=4 (      960×960): npw=15 nph=15 → 225
+#   r=5 (full 1920×1920): npw=30 nph=30 → 900
+# Per component total = 1210; × 3 components = 3630.
+if (EXISTS "${_JPIP_BIN_DIR}/land_shallow_topo_1920_fov.j2c")
+    add_test(NAME jpip_idx_land1920_total
+             COMMAND jpip_index_check ${_JPIP_BIN_DIR}/land_shallow_topo_1920_fov.j2c
+                     --total 3630)
+    add_test(NAME jpip_idx_land1920_per_res
+             COMMAND jpip_index_check ${_JPIP_BIN_DIR}/land_shallow_topo_1920_fov.j2c
+                     --per-res 0,0=1,4,16,64,225,900
+                     --per-res 0,1=1,4,16,64,225,900
+                     --per-res 0,2=1,4,16,64,225,900)
+endif()

--- a/tests/jpip_phase1.cmake
+++ b/tests/jpip_phase1.cmake
@@ -40,4 +40,42 @@ if (EXISTS "${_JPIP_BIN_DIR}/land_shallow_topo_1920_fov.j2c")
                      --per-res 0,0=1,4,16,64,225,900
                      --per-res 0,1=1,4,16,64,225,900
                      --per-res 0,2=1,4,16,64,225,900)
+
+    # ── view-window resolver (§C.4 + §M.4.1) ──
+    # Full-image at full resolution → every precinct.
+    add_test(NAME jpip_vw_land1920_full_res
+             COMMAND jpip_index_check ${_JPIP_BIN_DIR}/land_shallow_topo_1920_fov.j2c
+                     --vw 1920,1920,0,0,1920,1920=3630)
+    # Empty region (sx=sy=0) is treated as whole-image, per §C.4.4.
+    add_test(NAME jpip_vw_land1920_empty_region
+             COMMAND jpip_index_check ${_JPIP_BIN_DIR}/land_shallow_topo_1920_fov.j2c
+                     --vw 1920,1920,0,0,0,0=3630)
+    # Half-res whole image — r*=1 drops r=5 (900/component).  310·3 = 930.
+    add_test(NAME jpip_vw_land1920_half_res
+             COMMAND jpip_index_check ${_JPIP_BIN_DIR}/land_shallow_topo_1920_fov.j2c
+                     --vw 960,960,0,0,960,960=930)
+    # Round-down at fx=800 → r*=2 (480).  Kept r=0..3: 1+4+16+64=85, ×3 = 255.
+    add_test(NAME jpip_vw_land1920_round_down
+             COMMAND jpip_index_check ${_JPIP_BIN_DIR}/land_shallow_topo_1920_fov.j2c
+                     --vw 800,800,0,0,800,800,down=255)
+    # Round-up at fx=800 → r*=1 (960).  Region sx=800 on fx'=960 grid maps to
+    # (0,0)..(1600,1600) on canvas — NOT the whole canvas.  717 precincts.
+    add_test(NAME jpip_vw_land1920_round_up
+             COMMAND jpip_index_check ${_JPIP_BIN_DIR}/land_shallow_topo_1920_fov.j2c
+                     --vw 800,800,0,0,800,800,up=717)
+    # 200×200 centred RoI at full res — foveation probe.  Per resolution at
+    # r=0..5 with DWT over-fetch margin 8: 1, 4, 4, 4, 9, 16 per component
+    # → 38·3 = 114.
+    add_test(NAME jpip_vw_land1920_centre_roi
+             COMMAND jpip_index_check ${_JPIP_BIN_DIR}/land_shallow_topo_1920_fov.j2c
+                     --vw 1920,1920,860,860,200,200=114)
+    # Same RoI, Y component only (comps=0).  Per-component total 38.
+    add_test(NAME jpip_vw_land1920_centre_roi_yonly
+             COMMAND jpip_index_check ${_JPIP_BIN_DIR}/land_shallow_topo_1920_fov.j2c
+                     --vw "1920,1920,860,860,200,200,comps=0=38")
+    # Corner 960×960 quadrant at full res — per component 225+64+16+4+4+1 = 314,
+    # ×3 = 942 (includes DWT over-fetch at coarser resolutions).
+    add_test(NAME jpip_vw_land1920_corner_quadrant
+             COMMAND jpip_index_check ${_JPIP_BIN_DIR}/land_shallow_topo_1920_fov.j2c
+                     --vw 1920,1920,0,0,960,960=942)
 endif()


### PR DESCRIPTION
## Summary

Phase 1 of integrating ISO/IEC 15444-9 (JPIP, JPEG 2000 Interactivity Tools) into OpenHTJ2K, with foveated rendering for head-mounted displays as the motivating use case.  Implements the four pieces a JPIP foveation client needs *without yet* speaking any wire format — that's Phase 2.

Four commits, each independently reviewable, each shipping its own ctests.

### Commit 1 — `feat(jpip): add precinct geometry index for ISO/IEC 15444-9`

`source/core/jpip/precinct_index.{hpp,cpp}` — `CodestreamIndex` parses a J2C main header and exposes per-(tile, component, resolution) precinct geometry plus the JPIP sequence number `s` and in-class identifier `I` (§A.3.2.1, Eq. A-1).  Mirrors the precinct-count math in `j2k_tile_component` (`coding_units.cpp:2820+`) so the two cannot disagree.  COC per-component overrides are honoured; DFS and POC are deferred.

### Commit 2 — `feat(jpip): resolve view-window requests to precinct sets`

`source/core/jpip/view_window.{hpp,cpp}` — `resolve_view_window(idx, vw)` implements §C.4.2/C.4.3/C.4.4 plus §M.4.1 server-side precinct determination, including DWT synthesis footprint over-fetch (8 samples for 9/7, 4 for 5/3) so reconstruction inside the requested region is exact.  Round-direction (down / up / closest) per Table C.1.  Component filtering (§C.4.8) honoured.  DFS and POC are deferred.

### Commit 3 — `feat(jpip): inject precinct filter into decoder packet loop`

The decoder-side hook a JPIP client drives.  When `openhtj2k_decoder::set_precinct_filter(f)` is installed, every subsequent `invoke*()` call consults `f(t, c, r, p_rc)` per packet: precincts for which `f` returns false have their body bytes dropped via a new `j2k_codeblock::skip_compressed_buffer()` while the packet-header bit stream still advances, keeping the byte stream in sync.  Threaded through the cached-CRP fast path plus the five progression-order traversals in `j2k_tile::create_tile_buf`.  Two block-decode dispatch sites in `coding_units.cpp` plus three in `subband_row_buf.cpp` gained `compressed_data != nullptr` guards so masked codeblocks bypass MQ/HT cleanly.

### Commit 4 — `feat(jpip): mouse-driven foveation demo app`

`source/apps/jpip_demo/` — ties the three pieces together in an interactive app.  Each frame reads the mouse position, builds three concentric JPIP view-windows around the gaze (fovea at full resolution, parafovea at half, periphery at quarter), unions their precinct sets into an I-indexed hash table, installs it as the decoder's filter, and decodes + blits the result through the `rtp_recv` renderer (Metal on macOS, OpenGL 3.3 elsewhere).  Adds a `GLFWwindow*` accessor to both `GlRenderer` and `MetalRenderer` so the demo can call `glfwGetCursorPos` on the renderer's window without owning a second windowing path.

## Test plan

- [x] **18 new JPIP ctests** — index totals + per-resolution counts on two assets; view-window resolver across full/empty/half-res/round-up/round-down/centre-RoI/Y-only/corner-quadrant cases; partial-decode invariants (identity = byte-identical to no-filter; drop-all = uniform field) on MQ, HT, and the foveation asset.
- [x] **600/600** total ctests passing (582 existing + 18 new).
- [x] **Manual demo run on M3 Max** at `land_shallow_topo_1920_fov.j2c` → ~40 fps, ~20 % precinct coverage (≈750 of 3630), gaze tracks cursor smoothly.

## Known follow-ups (tracked in `PHASE2_PLAN.md`, not in this PR)

- **Demo crashes on the 21600 × 10800 NASA Blue Marble asset** because (a) batch decode allocates 10.9 GB and (b) Metal rejects 21600-wide textures (limit 16384).  Fix: switch demo to line-based decode + decouple window size from canvas size.  Phase 2 commit A1.
- **`enable_single_tile_reuse(true)`** is intentionally disabled in the demo because the cached-CRP-replay path's interaction with a per-frame filter wasn't audited.  Phase 2's reassembled-codestream approach sidesteps this entirely.
- **Per-frame `init()` + `parse()`** because `invoke()` consumes the codestream cursor and there's no public rewind.  Phase 2's JPIP wrapper will hold the codestream buffer for cheap reuse.

## Out of scope (Phase 3+)

No transport, no HTTP, no JPP-stream wire format, no JPIP request parser.  Those land in Phase 2 (wire format) and Phase 3 (HTTP/1.1).  This PR ships the load-bearing primitives those phases will sit on top of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)