### PR TITLE
feat(jpip): VBAS codec (ISO/IEC 15444-9 §A.2.1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,11 @@ add_subdirectory(source/apps/jpip_partial_decode_check)
 target_include_directories(jpip_partial_decode_check PUBLIC source/core/interface)
 target_link_libraries(jpip_partial_decode_check PUBLIC open_htj2k)
 
+# JPIP Phase-2 VBAS codec self-test (used by tests/jpip_phase1.cmake)
+add_executable(jpip_vbas_check)
+add_subdirectory(source/apps/jpip_vbas_check)
+target_link_libraries(jpip_vbas_check PUBLIC open_htj2k)
+
 # RFC 9828 RTP receiver (experimental, requires GLFW)
 option(OPENHTJ2K_RTP "Build experimental RFC 9828 RTP receiver (requires GLFW)" OFF)
 if (OPENHTJ2K_RTP AND NOT EMSCRIPTEN)

--- a/source/apps/jpip_vbas_check/CMakeLists.txt
+++ b/source/apps/jpip_vbas_check/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_policy(SET CMP0076 NEW)
+target_sources(jpip_vbas_check
+    PRIVATE
+    main.cpp
+)
+target_include_directories(jpip_vbas_check PRIVATE ${CMAKE_SOURCE_DIR}/source/core/jpip)

--- a/source/apps/jpip_vbas_check/main.cpp
+++ b/source/apps/jpip_vbas_check/main.cpp
@@ -1,0 +1,114 @@
+// jpip_vbas_check: ctest harness for the VBAS codec (ISO/IEC 15444-9 §A.2.1).
+//
+// Self-contained — runs every test internally, takes no input.  Exit 0 on
+// every assertion passing, 1 on the first failure.
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+#include "vbas.hpp"
+
+using open_htj2k::jpip::kVbasMaxBytes;
+using open_htj2k::jpip::vbas_decode;
+using open_htj2k::jpip::vbas_encode;
+
+namespace {
+
+int failures = 0;
+
+#define CHECK(cond, ...)                                            \
+  do {                                                              \
+    if (!(cond)) {                                                  \
+      std::fprintf(stderr, "FAIL [%s:%d] %s — ", __FILE__, __LINE__, #cond); \
+      std::fprintf(stderr, __VA_ARGS__);                            \
+      std::fprintf(stderr, "\n");                                   \
+      ++failures;                                                   \
+    }                                                               \
+  } while (0)
+
+// Encode v, then decode the result and check the round-trip yields v with
+// the expected number of bytes consumed.
+void roundtrip(uint64_t v, std::size_t expected_len) {
+  uint8_t buf[kVbasMaxBytes] = {};
+  const std::size_t enc = vbas_encode(v, buf);
+  CHECK(enc == expected_len, "encode(%llu) wrote %zu bytes, expected %zu",
+        static_cast<unsigned long long>(v), enc, expected_len);
+  uint64_t out      = ~v;       // poison
+  std::size_t adv   = 0;
+  const bool ok     = vbas_decode(buf, enc, &out, &adv);
+  CHECK(ok, "decode(encode(%llu)) returned false", static_cast<unsigned long long>(v));
+  CHECK(out == v, "decode(encode(%llu)) yielded %llu",
+        static_cast<unsigned long long>(v), static_cast<unsigned long long>(out));
+  CHECK(adv == enc, "decode advance %zu != encoded length %zu", adv, enc);
+}
+
+// Decode `bytes` and check the result equals `expected`.  Useful for
+// verifying byte-identical interop with reference encodings.
+void decode_known(const std::vector<uint8_t> &bytes, uint64_t expected,
+                  std::size_t expected_advance) {
+  uint64_t out      = ~expected;
+  std::size_t adv   = 0;
+  const bool ok     = vbas_decode(bytes.data(), bytes.size(), &out, &adv);
+  CHECK(ok, "decode_known returned false");
+  CHECK(out == expected, "decode_known got %llu, expected %llu",
+        static_cast<unsigned long long>(out),
+        static_cast<unsigned long long>(expected));
+  CHECK(adv == expected_advance, "decode_known advance %zu, expected %zu", adv,
+        expected_advance);
+}
+
+// Decode should reject `bytes` (truncated, or value would overflow).
+void reject(const std::vector<uint8_t> &bytes, const char *why) {
+  uint64_t out    = 0;
+  std::size_t adv = 0;
+  const bool ok   = vbas_decode(bytes.data(), bytes.size(), &out, &adv);
+  CHECK(!ok, "expected reject for %s, got value %llu (%zu bytes consumed)", why,
+        static_cast<unsigned long long>(out), adv);
+}
+
+}  // namespace
+
+int main() {
+  // ── Round-trip values that exercise every byte-length boundary ─────────
+  roundtrip(0,                          1);
+  roundtrip(1,                          1);
+  roundtrip(0x7F,                       1);
+  roundtrip(0x80,                       2);
+  roundtrip(0x3FFFu,                    2);
+  roundtrip(0x4000u,                    3);
+  roundtrip(0x1FFFFFu,                  3);
+  roundtrip(0x200000u,                  4);
+  roundtrip(0xFFFFFFFFu,                5);
+  roundtrip(0x7FFFFFFFFFFFFFFFull,      9);
+  // Full unsigned 64-bit range — needs the 10th byte.
+  roundtrip(0xFFFFFFFFFFFFFFFFull,     10);
+  roundtrip(0x8000000000000000ull,     10);
+
+  // ── Byte-identical interop checks ──────────────────────────────────────
+  // 0x80 → bytes 0x81 0x00 (cont, payload=1; last, payload=0 → 1<<7 == 128).
+  decode_known({0x81, 0x00},                 128,   2);
+  // 0x4000 → bytes 0x81 0x80 0x00 → 1<<14 == 16384.
+  decode_known({0x81, 0x80, 0x00},           16384, 3);
+  // Trailing garbage after a complete VBAS must not be consumed.
+  decode_known({0x7F, 0xDE, 0xAD},           127,   1);
+
+  // ── Rejection cases ────────────────────────────────────────────────────
+  reject({},                                            "empty input");
+  reject({0x80},                                        "single byte with continuation set, no follow-up");
+  reject({0x81, 0x82},                                  "second byte also has continuation, no terminator");
+  // 11-byte continuation chain — exceeds kVbasMaxBytes, even before considering value overflow.
+  reject({0x81, 0x81, 0x81, 0x81, 0x81, 0x81, 0x81, 0x81, 0x81, 0x81, 0x00},
+         "11-byte VBAS over limit");
+  // 10-byte VBAS whose value would overflow uint64_t: payload 2 in the
+  // first byte (so the implied bit 64 is set after concatenation).
+  reject({0x82, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x00},
+         "10-byte VBAS encoding > 2^64-1");
+
+  if (failures == 0) {
+    std::printf("OK vbas_check: all round-trip / interop / reject cases pass\n");
+    return 0;
+  }
+  std::fprintf(stderr, "vbas_check: %d failures\n", failures);
+  return 1;
+}

--- a/source/core/jpip/CMakeLists.txt
+++ b/source/core/jpip/CMakeLists.txt
@@ -3,4 +3,5 @@ target_sources(open_htj2k
     PRIVATE
     precinct_index.cpp
     view_window.cpp
+    vbas.cpp
 )

--- a/source/core/jpip/vbas.cpp
+++ b/source/core/jpip/vbas.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+
+#include "vbas.hpp"
+
+namespace open_htj2k {
+namespace jpip {
+
+std::size_t vbas_encode(uint64_t value, uint8_t *dst) {
+  if (value == 0) {
+    dst[0] = 0;
+    return 1;
+  }
+  // Number of 7-bit groups needed: floor(log2(value)/7) + 1.
+  std::size_t n = 0;
+  for (uint64_t v = value; v != 0; v >>= 7) ++n;
+  // Big-endian: the most significant group first; continuation bit set on
+  // every byte except the last.
+  for (std::size_t i = 0; i < n; ++i) {
+    const std::size_t shift = (n - 1 - i) * 7;
+    const uint8_t group = static_cast<uint8_t>((value >> shift) & 0x7F);
+    const bool more = (i + 1 < n);
+    dst[i] = static_cast<uint8_t>(group | (more ? 0x80 : 0x00));
+  }
+  return n;
+}
+
+bool vbas_decode(const uint8_t *src, std::size_t src_len, uint64_t *out,
+                 std::size_t *advance) {
+  uint64_t v = 0;
+  std::size_t i = 0;
+  for (;;) {
+    if (i >= src_len) return false;          // truncated input
+    if (i >= kVbasMaxBytes) return false;    // implausibly long encoding
+    // Before shifting the accumulated value left by 7, verify no payload
+    // bits would be lost.  This rejects values that would overflow uint64_t
+    // and accepts the legitimate full unsigned 64-bit range (which uses up
+    // to 10 bytes).  At iteration 0 the check is trivially satisfied since
+    // v == 0, so we skip it.
+    if (i > 0 && (v >> (64 - 7)) != 0) return false;
+    const uint8_t byte = src[i++];
+    v = (v << 7) | static_cast<uint64_t>(byte & 0x7F);
+    if ((byte & 0x80) == 0) {
+      *out     = v;
+      *advance = i;
+      return true;
+    }
+  }
+}
+
+}  // namespace jpip
+}  // namespace open_htj2k

--- a/source/core/jpip/vbas.hpp
+++ b/source/core/jpip/vbas.hpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+//
+// VBAS (Variable Byte Aligned Segment) codec, ISO/IEC 15444-9 §A.2.1.
+//
+// A VBAS encodes a non-negative integer as a sequence of bytes.  Each byte
+// carries 7 bits of payload (bits 0..6) and a continuation flag in bit 7
+// (1 = "another byte follows", 0 = "this is the last byte").  The value is
+// formed by concatenating the 7-bit payloads in big-endian order.
+//
+// The smallest VBAS is one byte; the value zero is encoded as the single
+// byte 0x00.
+#pragma once
+#include <cstddef>
+#include <cstdint>
+
+#if defined(_MSC_VER) && !defined(OHTJ2K_STATIC)
+  #define OPENHTJ2K_JPIP_EXPORT __declspec(dllexport)
+#else
+  #define OPENHTJ2K_JPIP_EXPORT
+#endif
+
+namespace open_htj2k {
+namespace jpip {
+
+// 10 = ceil(64 / 7) — the maximum number of bytes a uint64_t can require.
+constexpr std::size_t kVbasMaxBytes = 10;
+
+// Encode `value` as a VBAS into `dst`.  The caller must provide at least
+// kVbasMaxBytes writable bytes at `dst`.  Returns the number of bytes
+// written (1 .. kVbasMaxBytes).
+OPENHTJ2K_JPIP_EXPORT std::size_t vbas_encode(uint64_t value, uint8_t *dst);
+
+// Decode a VBAS starting at `src` (which has `src_len` bytes available).
+// On success: writes the decoded value to *out, the number of consumed
+// bytes to *advance, and returns true.  On failure (truncated input, or
+// the encoded value would overflow uint64_t): returns false and leaves
+// *out / *advance untouched.
+OPENHTJ2K_JPIP_EXPORT bool vbas_decode(const uint8_t *src, std::size_t src_len,
+                                       uint64_t *out, std::size_t *advance);
+
+}  // namespace jpip
+}  // namespace open_htj2k

--- a/tests/jpip_phase1.cmake
+++ b/tests/jpip_phase1.cmake
@@ -7,6 +7,10 @@
 
 set(_JPIP_BIN_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 
+# ── VBAS codec (ISO/IEC 15444-9 §A.2.1) ──
+# Self-contained: round-trip / interop / reject cases live inside the exe.
+add_test(NAME jpip_vbas_codec COMMAND jpip_vbas_check)
+
 # ── Decoder precinct-filter sanity (§M.4.1 partial-decode plumbing) ──
 # Exercises the public openhtj2k_decoder::set_precinct_filter hook against a
 # Part-1 and a Part-15 conformance stream.  The assets live under


### PR DESCRIPTION
## Summary

First commit of Phase 2's wire-format work — adds the bottom layer of the JPP-stream encoding: variable-byte aligned segments, the prefix-free integer encoding the spec uses for every length, offset, class and identifier field in a JPP-stream message header.

Two free functions in `source/core/jpip/vbas.{hpp,cpp}`:

```cpp
std::size_t vbas_encode(uint64_t value, uint8_t *dst);
bool        vbas_decode(const uint8_t *src, std::size_t src_len,
                        uint64_t *out, std::size_t *advance);
```

Decode supports the full unsigned 64-bit range (10 bytes max) and rejects: empty input, truncated continuation chains, encodings that exceed `kVbasMaxBytes`, and 10-byte encodings whose value would overflow `uint64_t`.

## Test plan

- [x] **New ctest `jpip_vbas_codec`** runs the standalone `jpip_vbas_check` exe; every assertion lives inside the exe (no codestream input needed).
- [x] Round-trip across every byte-length boundary: 0, 1, 0x7F, 0x80, 0x3FFF, 0x4000, 0x1FFFFF, 0x200000, 0xFFFFFFFF, 2^63-1, 2^63, 2^64-1.
- [x] Byte-identical interop: encode 128 → `0x81 0x00`, encode 16384 → `0x81 0x80 0x00`, decode-with-trailing-garbage stops at the terminator.
- [x] Five rejection cases: empty input, dangling continuation bit, single follow-up byte without terminator, 11-byte over-long chain, 10-byte VBAS encoding > `2^64-1`.
- [x] **601/601 ctests pass** (600 prior + 1 new); no decoder/encoder/JPIP regressions.

## What's next

B2 (JPP-stream message header codec) builds on this — `Bin-ID`, `Class`, `CSn`, `Msg-Offset`, `Msg-Length`, `Aux` are all VBASs.  Branch from `main` once this lands; planned in `PHASE2_PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)