### PR TITLE
feat(jpip): JPP-stream message header codec (§A.2 + Tables A.1, A.2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,6 +267,11 @@ add_executable(jpip_vbas_check)
 add_subdirectory(source/apps/jpip_vbas_check)
 target_link_libraries(jpip_vbas_check PUBLIC open_htj2k)
 
+# JPIP Phase-2 message header codec self-test (used by tests/jpip_phase1.cmake)
+add_executable(jpip_message_check)
+add_subdirectory(source/apps/jpip_message_check)
+target_link_libraries(jpip_message_check PUBLIC open_htj2k)
+
 # RFC 9828 RTP receiver (experimental, requires GLFW)
 option(OPENHTJ2K_RTP "Build experimental RFC 9828 RTP receiver (requires GLFW)" OFF)
 if (OPENHTJ2K_RTP AND NOT EMSCRIPTEN)

--- a/source/apps/jpip_message_check/CMakeLists.txt
+++ b/source/apps/jpip_message_check/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_policy(SET CMP0076 NEW)
+target_sources(jpip_message_check
+    PRIVATE
+    main.cpp
+)
+target_include_directories(jpip_message_check PRIVATE ${CMAKE_SOURCE_DIR}/source/core/jpip)

--- a/source/apps/jpip_message_check/main.cpp
+++ b/source/apps/jpip_message_check/main.cpp
@@ -1,0 +1,203 @@
+// jpip_message_check: ctest harness for the JPP-stream message header
+// codec (ISO/IEC 15444-9 §A.2 + Tables A.1, A.2).
+//
+// Self-contained: every assertion lives in this file, no input needed.
+// Exits 0 on every assertion passing, 1 on the first failure.
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+#include "jpp_message.hpp"
+#include "vbas.hpp"
+
+using open_htj2k::jpip::decode_header;
+using open_htj2k::jpip::encode_header;
+using open_htj2k::jpip::encode_header_independent;
+using open_htj2k::jpip::kMessageHeaderMaxBytes;
+using open_htj2k::jpip::kMsgClassExtPrecinct;
+using open_htj2k::jpip::kMsgClassMainHeader;
+using open_htj2k::jpip::kMsgClassMetadata;
+using open_htj2k::jpip::kMsgClassPrecinct;
+using open_htj2k::jpip::kMsgClassTileHeader;
+using open_htj2k::jpip::MessageHeader;
+using open_htj2k::jpip::MessageHeaderContext;
+using open_htj2k::jpip::msg_class_has_aux;
+
+namespace {
+
+int failures = 0;
+
+#define CHECK(cond, ...)                                            \
+  do {                                                              \
+    if (!(cond)) {                                                  \
+      std::fprintf(stderr, "FAIL [%s:%d] %s — ", __FILE__, __LINE__, #cond); \
+      std::fprintf(stderr, __VA_ARGS__);                            \
+      std::fprintf(stderr, "\n");                                   \
+      ++failures;                                                   \
+    }                                                               \
+  } while (0)
+
+bool eq_header(const MessageHeader &a, const MessageHeader &b) {
+  if (a.class_id    != b.class_id)    return false;
+  if (a.cs_n        != b.cs_n)        return false;
+  if (a.in_class_id != b.in_class_id) return false;
+  if (a.msg_offset  != b.msg_offset)  return false;
+  if (a.msg_length  != b.msg_length)  return false;
+  if (a.is_last     != b.is_last)     return false;
+  if (msg_class_has_aux(a.class_id) && a.aux != b.aux) return false;
+  return true;
+}
+
+void roundtrip_independent(const MessageHeader &h) {
+  uint8_t buf[kMessageHeaderMaxBytes] = {};
+  const std::size_t n = encode_header_independent(h, buf);
+  MessageHeaderContext ctx;
+  MessageHeader out;
+  std::size_t adv = 0;
+  CHECK(decode_header(buf, n, ctx, &out, &adv),
+        "decode_header returned false on independent round-trip");
+  CHECK(adv == n, "independent decode advance %zu != encoded length %zu", adv, n);
+  CHECK(eq_header(out, h),
+        "independent round-trip class=%u cs_n=%u id=%llu off=%llu len=%llu aux=%llu last=%d",
+        h.class_id, h.cs_n,
+        static_cast<unsigned long long>(h.in_class_id),
+        static_cast<unsigned long long>(h.msg_offset),
+        static_cast<unsigned long long>(h.msg_length),
+        static_cast<unsigned long long>(h.aux), h.is_last);
+}
+
+// Verify a known byte string decodes to the expected MessageHeader, and
+// then re-encode (independent form) to confirm we'd produce the same bytes
+// back when no dependent-form context is in play.
+void decode_known(const std::vector<uint8_t> &bytes, const MessageHeader &expected,
+                  std::size_t expected_advance) {
+  MessageHeaderContext ctx;
+  MessageHeader out;
+  std::size_t adv = 0;
+  CHECK(decode_header(bytes.data(), bytes.size(), ctx, &out, &adv),
+        "decode_known returned false");
+  CHECK(adv == expected_advance, "decode_known advance %zu, expected %zu", adv,
+        expected_advance);
+  CHECK(eq_header(out, expected),
+        "decode_known mismatch: got class=%u cs_n=%u id=%llu off=%llu len=%llu aux=%llu last=%d",
+        out.class_id, out.cs_n,
+        static_cast<unsigned long long>(out.in_class_id),
+        static_cast<unsigned long long>(out.msg_offset),
+        static_cast<unsigned long long>(out.msg_length),
+        static_cast<unsigned long long>(out.aux), out.is_last);
+}
+
+void reject(const std::vector<uint8_t> &bytes, const char *why) {
+  MessageHeaderContext ctx;
+  MessageHeader out;
+  std::size_t adv = 0;
+  const bool ok = decode_header(bytes.data(), bytes.size(), ctx, &out, &adv);
+  CHECK(!ok, "expected reject for %s, got class=%u id=%llu (%zu bytes)", why,
+        out.class_id, static_cast<unsigned long long>(out.in_class_id), adv);
+}
+
+}  // namespace
+
+int main() {
+  // ── Round-trip a representative cross-section of headers ──────────────
+  roundtrip_independent({/*class*/0, /*cs*/0, /*id*/3,    /*off*/107, /*len*/165, /*aux*/0, /*last*/false});
+  roundtrip_independent({/*class*/0, /*cs*/0, /*id*/3,    /*off*/0,   /*len*/512, /*aux*/0, /*last*/true });
+  roundtrip_independent({/*class*/1, /*cs*/0, /*id*/3,    /*off*/107, /*len*/165, /*aux*/3, /*last*/false});
+  roundtrip_independent({/*class*/2, /*cs*/0, /*id*/0,    /*off*/0,   /*len*/40,  /*aux*/0, /*last*/true });
+  roundtrip_independent({/*class*/6, /*cs*/0, /*id*/0,    /*off*/0,   /*len*/255, /*aux*/0, /*last*/true });
+  roundtrip_independent({/*class*/8, /*cs*/0, /*id*/42,   /*off*/100, /*len*/200, /*aux*/0, /*last*/false});
+  // Exercise multi-byte Bin-ID (in-class id > 15) and large offsets/lengths.
+  roundtrip_independent({/*class*/0, /*cs*/3,  /*id*/16,         /*off*/0x4000, /*len*/0x200000, /*aux*/0, /*last*/false});
+  roundtrip_independent({/*class*/0, /*cs*/65535, /*id*/0xDEADBEEFull, /*off*/0xCAFEBABEull, /*len*/0xFEEDFACEull, /*aux*/0, /*last*/false});
+  // Aux-bearing class with non-zero aux at multi-byte VBAS boundaries.
+  roundtrip_independent({/*class*/1, /*cs*/0, /*id*/3, /*off*/107, /*len*/165, /*aux*/0x3FFF, /*last*/false});
+  roundtrip_independent({/*class*/5, /*cs*/0, /*id*/0, /*off*/0,   /*len*/100, /*aux*/0x4000, /*last*/false});
+
+  // ── §A.3.2.2 spec examples — Case A non-extended precinct message ─────
+  // Bytes 00100011 01101011 10000001 00100101 = 0x23 0x6B 0x81 0x25.
+  // Bin-ID 0x23 = a=0 (1 byte), bb=01 (no Class/CSn), c=0, id=3.
+  // Msg-Offset 0x6B = single-byte VBAS payload 107.
+  // Msg-Length 0x81 0x25 = (1<<7) | 37 = 165.
+  decode_known({0x23, 0x6B, 0x81, 0x25},
+               {/*class*/0, /*cs*/0, /*id*/3, /*off*/107, /*len*/165, /*aux*/0, /*last*/false},
+               4);
+
+  // Case A extended (precinct + Aux): 0x43 0x01 0x6B 0x81 0x25 0x03.
+  // Bin-ID 0x43 = a=0, bb=10 (Class only), c=0, id=3.
+  // Class VBAS 0x01 = 1 (extended precinct).
+  // Then Msg-Offset/Msg-Length as above.
+  // Aux VBAS 0x03 = 3 — number of completed quality layers.
+  decode_known({0x43, 0x01, 0x6B, 0x81, 0x25, 0x03},
+               {/*class*/1, /*cs*/0, /*id*/3, /*off*/107, /*len*/165, /*aux*/3, /*last*/false},
+               6);
+
+  // Case C non-extended: 0x33 0x81 0x08 0x81 0x35.  Bin-ID 0x33 has c=1
+  // (this message contains the last byte of the data-bin).  Msg-Offset
+  // 0x81 0x08 = 136.  Msg-Length 0x81 0x35 = (1<<7) | 53 = 181.
+  decode_known({0x33, 0x81, 0x08, 0x81, 0x35},
+               {/*class*/0, /*cs*/0, /*id*/3, /*off*/136, /*len*/181, /*aux*/0, /*last*/true},
+               5);
+
+  // ── Dependent-form behaviour across a sequence of three messages ──────
+  // Encode three precinct-data-bin messages (class 0, codestream 0) into
+  // a single buffer.  Expect the second and third to omit Class/CSn.
+  {
+    std::vector<uint8_t> stream(kMessageHeaderMaxBytes * 3);
+    MessageHeaderContext enc_ctx;
+    std::size_t pos = 0;
+    pos += encode_header({/*class*/0, /*cs*/0, /*id*/3, /*off*/107, /*len*/165, /*aux*/0, /*last*/false},
+                         enc_ctx, stream.data() + pos);
+    pos += encode_header({/*class*/0, /*cs*/0, /*id*/4, /*off*/272, /*len*/200, /*aux*/0, /*last*/false},
+                         enc_ctx, stream.data() + pos);
+    pos += encode_header({/*class*/0, /*cs*/0, /*id*/5, /*off*/472, /*len*/100, /*aux*/0, /*last*/true},
+                         enc_ctx, stream.data() + pos);
+    stream.resize(pos);
+
+    // Each subsequent message should be smaller than the first because it
+    // omits Class (single-byte VBAS).  Strictly: after the first message,
+    // the Bin-ID byte's bb field changes from emit-class to no-class; the
+    // dropped Class VBAS is one byte for class 0.
+    MessageHeaderContext dec_ctx;
+    MessageHeader m1{}, m2{}, m3{};
+    std::size_t adv1 = 0, adv2 = 0, adv3 = 0;
+    CHECK(decode_header(stream.data(),                stream.size(),                  dec_ctx, &m1, &adv1), "msg 1 decode");
+    CHECK(decode_header(stream.data() + adv1,         stream.size() - adv1,           dec_ctx, &m2, &adv2), "msg 2 decode");
+    CHECK(decode_header(stream.data() + adv1 + adv2,  stream.size() - adv1 - adv2,    dec_ctx, &m3, &adv3), "msg 3 decode");
+    CHECK(adv1 + adv2 + adv3 == stream.size(), "stream not fully consumed: %zu/%zu",
+          adv1 + adv2 + adv3, stream.size());
+    CHECK(m1.class_id == 0 && m1.in_class_id == 3 && m1.msg_offset == 107 && m1.msg_length == 165, "m1 fields");
+    CHECK(m2.class_id == 0 && m2.in_class_id == 4 && m2.msg_offset == 272 && m2.msg_length == 200, "m2 fields");
+    CHECK(m3.class_id == 0 && m3.in_class_id == 5 && m3.msg_offset == 472 && m3.msg_length == 100 && m3.is_last, "m3 fields");
+  }
+
+  // CSn change forces Class to be sent again (Table A.1 has no CSn-only).
+  {
+    uint8_t buf1[kMessageHeaderMaxBytes];
+    uint8_t buf2[kMessageHeaderMaxBytes];
+    MessageHeaderContext ctx;
+    const std::size_t n1 = encode_header({/*class*/2, /*cs*/0, /*id*/0, /*off*/0, /*len*/40, /*aux*/0, /*last*/true}, ctx, buf1);
+    const std::size_t n2 = encode_header({/*class*/2, /*cs*/1, /*id*/0, /*off*/0, /*len*/40, /*aux*/0, /*last*/true}, ctx, buf2);
+    // The Bin-ID's bb field on buf2 must indicate Class AND CSn (bb=11).
+    const uint8_t bb2 = static_cast<uint8_t>((buf2[0] >> 5) & 0x3u);
+    CHECK(bb2 == 0x3u, "CSn-change without Class: bb=%u, expected 3", bb2);
+    (void)n1; (void)n2;
+  }
+
+  // ── Rejection cases ──────────────────────────────────────────────────
+  reject({},                                   "empty input");
+  reject({0x03, 0x00, 0x00},                   "bb=00 (prohibited)");
+  // Bin-ID claims continuation but no follow-up byte.
+  reject({0xA3},                               "Bin-ID continuation with no second byte");
+  // Msg-Offset truncated mid-VBAS.
+  reject({0x23, 0x80},                         "Msg-Offset VBAS truncated");
+  // Aux truncated for an aux-bearing class.
+  reject({0x43, 0x01, 0x00, 0x00, 0x80},       "Aux VBAS truncated");
+
+  if (failures == 0) {
+    std::printf("OK message_check: round-trip / spec-example / dependent-form / reject all pass\n");
+    return 0;
+  }
+  std::fprintf(stderr, "message_check: %d failures\n", failures);
+  return 1;
+}

--- a/source/core/jpip/CMakeLists.txt
+++ b/source/core/jpip/CMakeLists.txt
@@ -4,4 +4,5 @@ target_sources(open_htj2k
     precinct_index.cpp
     view_window.cpp
     vbas.cpp
+    jpp_message.cpp
 )

--- a/source/core/jpip/jpp_message.cpp
+++ b/source/core/jpip/jpp_message.cpp
@@ -1,0 +1,176 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+
+#include "jpp_message.hpp"
+
+namespace open_htj2k {
+namespace jpip {
+
+namespace {
+
+// Number of bytes required to encode `v` as a Bin-ID VBAS.  Per §A.2.1,
+// the Bin-ID's first byte holds 4 payload bits (the rest is the Class/CSn
+// indicator, the is-last flag, and the VBAS continuation bit) and each
+// subsequent byte holds 7 payload bits.  So k bytes encode 4 + 7(k-1) = 7k-3
+// bits of in-class identifier.
+std::size_t bin_id_bytes(uint64_t v) {
+  if (v < 16u) return 1;
+  std::size_t bits = 0;
+  for (uint64_t x = v; x != 0; x >>= 1) ++bits;
+  // Need 7k - 3 ≥ bits → k ≥ ceil((bits + 3) / 7).
+  return (bits + 3 + 6) / 7;
+}
+
+// Emit the Bin-ID VBAS for an in-class identifier value with the given
+// indicator bits (Table A.1: 01 / 10 / 11) and is-last flag.  Returns the
+// number of bytes written.
+std::size_t encode_bin_id(uint64_t in_class_id, uint8_t indicator_bb,
+                          bool is_last, uint8_t *dst) {
+  const std::size_t k = bin_id_bytes(in_class_id);
+  // Top 4 bits of the in-class id under the 4 + 7(k-1) layout.
+  const uint8_t top4   = static_cast<uint8_t>((in_class_id >> (7 * (k - 1))) & 0xFu);
+  const uint8_t cont0  = (k > 1) ? 0x80u : 0x00u;
+  const uint8_t bb_fld = static_cast<uint8_t>((indicator_bb & 0x3u) << 5);
+  const uint8_t c_fld  = is_last ? 0x10u : 0x00u;
+  dst[0] = static_cast<uint8_t>(cont0 | bb_fld | c_fld | top4);
+  for (std::size_t i = 1; i < k; ++i) {
+    const std::size_t shift = 7u * (k - 1 - i);
+    const uint8_t payload = static_cast<uint8_t>((in_class_id >> shift) & 0x7Fu);
+    const uint8_t cont    = (i + 1 < k) ? 0x80u : 0x00u;
+    dst[i] = static_cast<uint8_t>(payload | cont);
+  }
+  return k;
+}
+
+// Decode the Bin-ID VBAS.  Returns true on success and writes the in-class
+// id, indicator bits (1, 2, or 3), is-last flag, and bytes consumed.
+bool decode_bin_id(const uint8_t *src, std::size_t src_len, uint64_t *in_class_id,
+                   uint8_t *bb_out, bool *is_last, std::size_t *advance) {
+  if (src_len < 1) return false;
+  const uint8_t b0 = src[0];
+  const uint8_t bb = static_cast<uint8_t>((b0 >> 5) & 0x3u);
+  if (bb == 0u) return false;  // Table A.1: 00 is prohibited.
+  *bb_out  = bb;
+  *is_last = (b0 & 0x10u) != 0u;
+  uint64_t v = static_cast<uint64_t>(b0 & 0xFu);
+  std::size_t i = 1;
+  if (b0 & 0x80u) {
+    for (;;) {
+      if (i >= src_len) return false;
+      if (i >= kVbasMaxBytes) return false;
+      // Same overflow guard as the standalone VBAS decoder.
+      if ((v >> (64 - 7)) != 0u) return false;
+      const uint8_t b = src[i++];
+      v = (v << 7) | static_cast<uint64_t>(b & 0x7Fu);
+      if ((b & 0x80u) == 0u) break;
+    }
+  }
+  *in_class_id = v;
+  *advance     = i;
+  return true;
+}
+
+std::size_t encode_with_indicator(const MessageHeader &hdr, bool emit_class,
+                                  bool emit_cs_n, uint8_t *dst) {
+  // Indicator bits: 01 = neither, 10 = Class only, 11 = both.  CSn-only is
+  // not representable, so callers that need to send CSn must also send Class.
+  uint8_t bb;
+  if (!emit_class && !emit_cs_n) bb = 0x1u;
+  else if (emit_class && !emit_cs_n) bb = 0x2u;
+  else bb = 0x3u;
+
+  std::size_t pos = 0;
+  pos += encode_bin_id(hdr.in_class_id, bb, hdr.is_last, dst + pos);
+  if (emit_class) pos += vbas_encode(hdr.class_id, dst + pos);
+  if (emit_cs_n)  pos += vbas_encode(hdr.cs_n, dst + pos);
+  pos += vbas_encode(hdr.msg_offset, dst + pos);
+  pos += vbas_encode(hdr.msg_length, dst + pos);
+  if (msg_class_has_aux(hdr.class_id)) {
+    pos += vbas_encode(hdr.aux, dst + pos);
+  }
+  return pos;
+}
+
+}  // namespace
+
+std::size_t encode_header(const MessageHeader &hdr, MessageHeaderContext &ctx,
+                          uint8_t *dst) {
+  const bool class_changed = (hdr.class_id != ctx.last_class_id);
+  const bool cs_n_changed  = (hdr.cs_n     != ctx.last_cs_n);
+  // CSn change forces Class to ride along (Table A.1 has no CSn-only combo).
+  const bool emit_class = class_changed || cs_n_changed;
+  const bool emit_cs_n  = cs_n_changed;
+  const std::size_t n = encode_with_indicator(hdr, emit_class, emit_cs_n, dst);
+  ctx.last_class_id = hdr.class_id;
+  ctx.last_cs_n     = hdr.cs_n;
+  return n;
+}
+
+std::size_t encode_header_independent(const MessageHeader &hdr, uint8_t *dst) {
+  return encode_with_indicator(hdr, /*emit_class=*/true, /*emit_cs_n=*/true, dst);
+}
+
+bool decode_header(const uint8_t *src, std::size_t src_len,
+                   MessageHeaderContext &ctx, MessageHeader *out,
+                   std::size_t *advance) {
+  std::size_t pos = 0;
+  std::size_t step = 0;
+
+  uint64_t in_class_id = 0;
+  uint8_t  bb          = 0;
+  bool     is_last     = false;
+  if (!decode_bin_id(src + pos, src_len - pos, &in_class_id, &bb, &is_last, &step)) {
+    return false;
+  }
+  pos += step;
+
+  // Class / CSn handling, per Table A.1: bb ∈ {01, 10, 11}; we already
+  // rejected 00 in decode_bin_id.
+  uint8_t  class_id = ctx.last_class_id;
+  uint16_t cs_n     = ctx.last_cs_n;
+  if (bb == 0x2u || bb == 0x3u) {
+    uint64_t v = 0;
+    if (!vbas_decode(src + pos, src_len - pos, &v, &step)) return false;
+    pos += step;
+    if (v > 0xFFu) return false;        // class id field is one byte wide
+    class_id = static_cast<uint8_t>(v);
+  }
+  if (bb == 0x3u) {
+    uint64_t v = 0;
+    if (!vbas_decode(src + pos, src_len - pos, &v, &step)) return false;
+    pos += step;
+    if (v > 0xFFFFu) return false;      // codestream sequence is uint16
+    cs_n = static_cast<uint16_t>(v);
+  }
+
+  uint64_t msg_offset = 0;
+  if (!vbas_decode(src + pos, src_len - pos, &msg_offset, &step)) return false;
+  pos += step;
+
+  uint64_t msg_length = 0;
+  if (!vbas_decode(src + pos, src_len - pos, &msg_length, &step)) return false;
+  pos += step;
+
+  uint64_t aux = 0;
+  if (msg_class_has_aux(class_id)) {
+    if (!vbas_decode(src + pos, src_len - pos, &aux, &step)) return false;
+    pos += step;
+  }
+
+  out->class_id    = class_id;
+  out->cs_n        = cs_n;
+  out->in_class_id = in_class_id;
+  out->msg_offset  = msg_offset;
+  out->msg_length  = msg_length;
+  out->aux         = aux;
+  out->is_last     = is_last;
+
+  ctx.last_class_id = class_id;
+  ctx.last_cs_n     = cs_n;
+
+  *advance = pos;
+  return true;
+}
+
+}  // namespace jpip
+}  // namespace open_htj2k

--- a/source/core/jpip/jpp_message.hpp
+++ b/source/core/jpip/jpp_message.hpp
@@ -1,0 +1,105 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+//
+// JPP-stream message header codec, ISO/IEC 15444-9 §A.2 + Tables A.1, A.2.
+//
+// Each JPP-stream message starts with a header of the form:
+//
+//   Bin-ID  [, Class]  [, CSn]  ,  Msg-Offset  ,  Msg-Length  [, Aux]
+//
+// All fields are VBASs (see vbas.hpp), with the Bin-ID VBAS additionally
+// carrying three control bits: a "Class/CSn presence" indicator (Table A.1),
+// a "is last byte of data-bin" flag, and 4 bits of in-class identifier in
+// the first byte (the remaining bits live in the subsequent VBAS bytes).
+//
+// Class identifies the data-bin type per Table A.2; CSn identifies the
+// codestream index.  Both are optional in the wire format: when omitted,
+// the decoder inherits the value from the previous message in the stream
+// (defaulting to 0 at the start).  The dependent form is honoured by both
+// the encoder and the decoder via a MessageHeaderContext carried across
+// calls.
+//
+// The Aux field is present iff the class identifier is odd
+// (kMsgClassExtPrecinct, kMsgClassExtTile).  Per §A.2.2 it carries
+// auxiliary information whose meaning depends on the class.
+#pragma once
+#include <cstddef>
+#include <cstdint>
+
+#include "vbas.hpp"
+
+#if defined(_MSC_VER) && !defined(OHTJ2K_STATIC)
+  #define OPENHTJ2K_JPIP_EXPORT __declspec(dllexport)
+#else
+  #define OPENHTJ2K_JPIP_EXPORT
+#endif
+
+namespace open_htj2k {
+namespace jpip {
+
+// Class identifiers per Table A.2.
+constexpr uint8_t kMsgClassPrecinct    = 0;  // JPP-stream
+constexpr uint8_t kMsgClassExtPrecinct = 1;  // JPP-stream, has Aux
+constexpr uint8_t kMsgClassTileHeader  = 2;  // JPP-stream
+constexpr uint8_t kMsgClassTile        = 4;  // JPT-stream
+constexpr uint8_t kMsgClassExtTile     = 5;  // JPT-stream, has Aux
+constexpr uint8_t kMsgClassMainHeader  = 6;  // JPP- and JPT-stream
+constexpr uint8_t kMsgClassMetadata    = 8;  // JPP- and JPT-stream
+
+// Per §A.2.2: "Class identifiers are chosen such that an Aux VBAS is present
+// if and only if the identifier is odd."
+inline bool msg_class_has_aux(uint8_t class_id) { return (class_id & 1u) != 0u; }
+
+struct MessageHeader {
+  uint8_t  class_id    = 0;
+  uint16_t cs_n        = 0;
+  uint64_t in_class_id = 0;
+  uint64_t msg_offset  = 0;
+  uint64_t msg_length  = 0;
+  uint64_t aux         = 0;     // ignored unless msg_class_has_aux(class_id)
+  bool     is_last     = false; // bit 4 of the first Bin-ID byte
+};
+
+// Carries the most recently emitted/decoded class and codestream index
+// across calls so the dependent form of subsequent messages can omit the
+// matching Class/CSn fields (per §A.2.1).  Default-constructed values match
+// the spec's "no previous message" defaults: class 0, codestream 0.
+struct MessageHeaderContext {
+  uint8_t  last_class_id = 0;
+  uint16_t last_cs_n     = 0;
+  void clear() { *this = {}; }
+};
+
+// Worst-case encoded header size: Bin-ID can reach kVbasMaxBytes; each of
+// Class, CSn, Msg-Offset, Msg-Length, Aux is also a VBAS so the same
+// upper bound applies.  Six fields total.
+constexpr std::size_t kMessageHeaderMaxBytes = kVbasMaxBytes * 6;
+
+// Encode `hdr` into `dst` (must have ≥ kMessageHeaderMaxBytes writable).
+// Class and CSn are emitted only if they differ from `ctx`'s last seen
+// values; the spec also requires Class to accompany CSn when CSn is sent
+// (Table A.1 has no "CSn-only" combination), so a CSn change always pulls
+// Class along.  Updates `ctx` to reflect the encoded values.  Returns the
+// number of bytes written.
+OPENHTJ2K_JPIP_EXPORT std::size_t encode_header(const MessageHeader &hdr,
+                                                MessageHeaderContext &ctx,
+                                                uint8_t *dst);
+
+// As above, but always emits the independent form (Class + CSn always
+// present).  Useful for stand-alone test vectors and for the first message
+// of a stream where the caller wants no implicit defaults.
+OPENHTJ2K_JPIP_EXPORT std::size_t encode_header_independent(const MessageHeader &hdr,
+                                                            uint8_t *dst);
+
+// Decode a message header starting at `src`.  Uses `ctx` to fill in
+// missing Class/CSn from the previous message and updates `ctx` with the
+// decoded effective values.  On success, populates *out, writes the bytes
+// consumed to *advance, and returns true.  On any malformed input
+// (truncated, prohibited bb=00, value overflow) returns false and leaves
+// *out / *advance untouched.
+OPENHTJ2K_JPIP_EXPORT bool decode_header(const uint8_t *src, std::size_t src_len,
+                                         MessageHeaderContext &ctx,
+                                         MessageHeader *out, std::size_t *advance);
+
+}  // namespace jpip
+}  // namespace open_htj2k

--- a/tests/jpip_phase1.cmake
+++ b/tests/jpip_phase1.cmake
@@ -11,6 +11,11 @@ set(_JPIP_BIN_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 # Self-contained: round-trip / interop / reject cases live inside the exe.
 add_test(NAME jpip_vbas_codec COMMAND jpip_vbas_check)
 
+# ── JPP-stream message header codec (§A.2 + Tables A.1, A.2) ──
+# Self-contained: round-trip + spec §A.3.2.2 byte-identical interop +
+# dependent-form behaviour + rejection cases.
+add_test(NAME jpip_message_codec COMMAND jpip_message_check)
+
 # ── Decoder precinct-filter sanity (§M.4.1 partial-decode plumbing) ──
 # Exercises the public openhtj2k_decoder::set_precinct_filter hook against a
 # Part-1 and a Part-15 conformance stream.  The assets live under


### PR DESCRIPTION
## Summary

Second commit of Phase 2's wire-format work, sitting on top of B1's VBAS codec.  Encodes / decodes the variable-length message header that prefixes every data-bin message in a JPP-stream:

```
Bin-ID  [, Class]  [, CSn]  ,  Msg-Offset  ,  Msg-Length  [, Aux]
```

The Bin-ID's first byte packs three control bits — a Class/CSn presence indicator (Table A.1), an "is last byte of data-bin" flag, and 4 bits of in-class identifier — alongside the standard VBAS continuation bit; subsequent Bin-ID bytes contribute 7 more bits each.  Class identifies the data-bin type per Table A.2, CSn the codestream index, and Aux is present iff the class identifier is odd (`kMsgClassExtPrecinct`, `kMsgClassExtTile`).

## API surface (`source/core/jpip/jpp_message.hpp`)

```cpp
std::size_t encode_header(const MessageHeader&,
                          MessageHeaderContext&, uint8_t* dst);
std::size_t encode_header_independent(const MessageHeader&, uint8_t* dst);
bool        decode_header(const uint8_t* src, std::size_t src_len,
                          MessageHeaderContext&, MessageHeader*,
                          std::size_t* advance);
```

Plus the seven `kMsgClass*` constants and a `msg_class_has_aux()` helper.

The `MessageHeaderContext` carries the most recently emitted/decoded class and codestream index across calls so the dependent form (omit Class/CSn when unchanged) round-trips correctly.  CSn-only is not representable in Table A.1, so a CSn change pulls Class along even when the class id itself is unchanged.

The decoder tightens the spec a little: it rejects `bb=00` (already forbidden by the spec), values that would overflow `uint64_t` (via the shared VBAS overflow guard), `Class > 0xFF`, and `CSn > 0xFFFF`.

## Test plan

- [x] **New ctest `jpip_message_codec`** runs the standalone `jpip_message_check` exe.
- [x] Round-trip 10 representative `MessageHeader`s covering every class, multi-byte Bin-IDs (`id > 15`), large offsets/lengths up to ~2^32, aux at multi-byte VBAS boundaries, and `is_last` in both states.
- [x] **Three §A.3.2.2 spec examples decoded byte-for-byte**: Case A non-extended (`0x23 0x6B 0x81 0x25`), Case A extended (`0x43 0x01 0x6B 0x81 0x25 0x03`), and Case C non-extended with `c=1`.
- [x] Dependent-form behaviour: three sequential precinct messages encoded into one buffer; the second and third omit Class.
- [x] CSn-change forces Class to be sent again — `bb=11` verified on the second message.
- [x] Five rejection cases (empty input, `bb=00`, Bin-ID continuation truncation, Msg-Offset truncation, Aux truncation).
- [x] **602/602 ctests pass** (601 prior + 1 new); no decoder/encoder/JPIP regressions.

## What's next

B3 (data-bin emitters) is unblocked — emits Class 6 (main header), Class 2 (tile header), Class 0/1 (precinct), Class 8 (metadata-bin 0) data-bins from a `CodestreamIndex` + raw codestream bytes, using `encode_header()` for every message.  Branch from `main` once this lands; planned in `PHASE2_PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)