### PR TITLE
feat(jpip): header data-bin emitters (main / tile / metadata-bin 0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,6 +272,11 @@ add_executable(jpip_message_check)
 add_subdirectory(source/apps/jpip_message_check)
 target_link_libraries(jpip_message_check PUBLIC open_htj2k)
 
+# JPIP Phase-2 header data-bin emitter self-test (used by tests/jpip_phase1.cmake)
+add_executable(jpip_emitter_check)
+add_subdirectory(source/apps/jpip_emitter_check)
+target_link_libraries(jpip_emitter_check PUBLIC open_htj2k)
+
 # RFC 9828 RTP receiver (experimental, requires GLFW)
 option(OPENHTJ2K_RTP "Build experimental RFC 9828 RTP receiver (requires GLFW)" OFF)
 if (OPENHTJ2K_RTP AND NOT EMSCRIPTEN)

--- a/source/apps/jpip_emitter_check/CMakeLists.txt
+++ b/source/apps/jpip_emitter_check/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_policy(SET CMP0076 NEW)
+target_sources(jpip_emitter_check
+    PRIVATE
+    main.cpp
+)
+target_include_directories(jpip_emitter_check PRIVATE ${CMAKE_SOURCE_DIR}/source/core/jpip)

--- a/source/apps/jpip_emitter_check/main.cpp
+++ b/source/apps/jpip_emitter_check/main.cpp
@@ -1,0 +1,193 @@
+// jpip_emitter_check: ctest harness for the codestream walker + header
+// data-bin emitters added in PHASE2_PLAN.md item B3 (header bins).
+//
+// Usage:  jpip_emitter_check <input.j2c>
+//
+// For the asset given on the command line, this:
+//   - walks the codestream (codestream_walker) and prints the layout summary,
+//   - emits the main-header data-bin and re-decodes its message header
+//     to check class=6, in_class_id=0, payload byte-identical to the
+//     codestream's [SOC..first SOT) range,
+//   - emits the tile-header data-bin for tile 0 and re-decodes its header
+//     to check class=2, in_class_id=0, payload byte-identical to the
+//     concatenation of every contributing tile-part's marker segments
+//     between SOT and SOD,
+//   - emits metadata-bin 0, re-decodes, expects class=8, in_class_id=0,
+//     payload empty, is_last=true.
+//
+// Exits 0 on every assertion passing, 1 on the first failure.
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "codestream_walker.hpp"
+#include "data_bin_emitter.hpp"
+#include "jpp_message.hpp"
+
+using open_htj2k::jpip::CodestreamLayout;
+using open_htj2k::jpip::decode_header;
+using open_htj2k::jpip::emit_main_header_databin;
+using open_htj2k::jpip::emit_metadata_bin_zero;
+using open_htj2k::jpip::emit_tile_header_databin;
+using open_htj2k::jpip::kMsgClassMainHeader;
+using open_htj2k::jpip::kMsgClassMetadata;
+using open_htj2k::jpip::kMsgClassTileHeader;
+using open_htj2k::jpip::MessageHeader;
+using open_htj2k::jpip::MessageHeaderContext;
+using open_htj2k::jpip::walk_codestream;
+
+namespace {
+
+int failures = 0;
+
+#define CHECK(cond, ...)                                            \
+  do {                                                              \
+    if (!(cond)) {                                                  \
+      std::fprintf(stderr, "FAIL [%s:%d] %s — ", __FILE__, __LINE__, #cond); \
+      std::fprintf(stderr, __VA_ARGS__);                            \
+      std::fprintf(stderr, "\n");                                   \
+      ++failures;                                                   \
+    }                                                               \
+  } while (0)
+
+std::vector<uint8_t> read_file(const char *path) {
+  FILE *f = std::fopen(path, "rb");
+  if (!f) { std::fprintf(stderr, "ERROR: cannot open %s\n", path); return {}; }
+  std::fseek(f, 0, SEEK_END);
+  auto sz = static_cast<std::size_t>(std::ftell(f));
+  std::fseek(f, 0, SEEK_SET);
+  std::vector<uint8_t> buf(sz);
+  std::size_t rd = std::fread(buf.data(), 1, sz, f);
+  std::fclose(f);
+  if (rd != sz) { std::fprintf(stderr, "ERROR: partial read\n"); buf.clear(); }
+  return buf;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    std::fprintf(stderr, "Usage: jpip_emitter_check <input.j2c>\n");
+    return 1;
+  }
+
+  auto bytes = read_file(argv[1]);
+  if (bytes.empty()) return 1;
+
+  CodestreamLayout layout;
+  CHECK(walk_codestream(bytes.data(), bytes.size(), &layout), "walk_codestream");
+  if (failures) return 1;
+
+  std::printf("layout: SOC=%zu  main_header_end=%zu  EOC=%zu  tile_parts=%zu\n",
+              layout.soc_offset, layout.main_header_end, layout.eoc_offset,
+              layout.tile_parts.size());
+  for (const auto &tp : layout.tile_parts) {
+    std::printf("  tile=%u part=%u/%u  SOT=%zu  header_end=%zu  body=[%zu, %zu)\n",
+                tp.tile_index, tp.tile_part_idx, tp.tile_part_cnt,
+                tp.sot_offset, tp.header_end, tp.body_offset, tp.body_end);
+  }
+
+  CHECK(layout.main_header_end > 0, "main_header_end must be > 0");
+  CHECK(!layout.tile_parts.empty(), "must have at least one tile-part");
+
+  // Emit + decode the three header data-bins back-to-back through one ctx
+  // so dependent-form encoding gets exercised.
+  std::vector<uint8_t> stream;
+  MessageHeaderContext enc_ctx;
+
+  const std::size_t main_bytes = emit_main_header_databin(
+      bytes.data(), bytes.size(), layout, enc_ctx, stream);
+  CHECK(main_bytes > 0, "emit_main_header_databin returned 0");
+
+  // Tile 0 should always exist for our test assets.
+  const std::size_t tile0_bytes = emit_tile_header_databin(
+      bytes.data(), bytes.size(), /*tile_index=*/0, layout, enc_ctx, stream);
+  CHECK(tile0_bytes > 0, "emit_tile_header_databin tile=0 returned 0");
+
+  const std::size_t meta_bytes = emit_metadata_bin_zero(enc_ctx, stream);
+  CHECK(meta_bytes > 0, "emit_metadata_bin_zero returned 0");
+
+  std::printf("emitted: main=%zu  tile0=%zu  metadata0=%zu  total=%zu\n",
+              main_bytes, tile0_bytes, meta_bytes, stream.size());
+
+  // Decode and verify.
+  MessageHeaderContext dec_ctx;
+  std::size_t pos = 0;
+
+  // Main header.
+  {
+    MessageHeader m;
+    std::size_t adv = 0;
+    CHECK(decode_header(stream.data() + pos, stream.size() - pos, dec_ctx, &m, &adv),
+          "decode main header");
+    CHECK(m.class_id == kMsgClassMainHeader, "main class=%u", m.class_id);
+    CHECK(m.cs_n == 0, "main cs_n=%u", m.cs_n);
+    CHECK(m.in_class_id == 0, "main in_class_id=%llu",
+          static_cast<unsigned long long>(m.in_class_id));
+    CHECK(m.is_last, "main is_last");
+    const std::size_t expected_len = layout.main_header_end - layout.soc_offset;
+    CHECK(m.msg_length == expected_len, "main msg_length=%llu expected %zu",
+          static_cast<unsigned long long>(m.msg_length), expected_len);
+    pos += adv;
+    CHECK(std::memcmp(stream.data() + pos, bytes.data() + layout.soc_offset,
+                      expected_len) == 0,
+          "main header payload not byte-identical to codestream slice");
+    pos += expected_len;
+  }
+
+  // Tile-0 header.
+  {
+    MessageHeader m;
+    std::size_t adv = 0;
+    CHECK(decode_header(stream.data() + pos, stream.size() - pos, dec_ctx, &m, &adv),
+          "decode tile header");
+    CHECK(m.class_id == kMsgClassTileHeader, "tile class=%u", m.class_id);
+    CHECK(m.in_class_id == 0, "tile in_class_id=%llu",
+          static_cast<unsigned long long>(m.in_class_id));
+    CHECK(m.is_last, "tile is_last");
+    pos += adv;
+
+    // Reconstruct the expected tile-header payload by concatenating each
+    // tile-part's marker bytes (excluding SOT) for tile 0.
+    std::vector<uint8_t> expected;
+    for (const auto &tp : layout.tile_parts) {
+      if (tp.tile_index != 0) continue;
+      constexpr std::size_t kSotSize = 12;
+      const uint8_t *first = bytes.data() + tp.sot_offset + kSotSize;
+      const uint8_t *last  = bytes.data() + tp.header_end;
+      expected.insert(expected.end(), first, last);
+    }
+    CHECK(m.msg_length == expected.size(),
+          "tile msg_length=%llu expected %zu",
+          static_cast<unsigned long long>(m.msg_length), expected.size());
+    CHECK(std::memcmp(stream.data() + pos, expected.data(), expected.size()) == 0,
+          "tile header payload not byte-identical to expected concatenation");
+    pos += expected.size();
+  }
+
+  // Metadata-bin 0.
+  {
+    MessageHeader m;
+    std::size_t adv = 0;
+    CHECK(decode_header(stream.data() + pos, stream.size() - pos, dec_ctx, &m, &adv),
+          "decode metadata bin 0");
+    CHECK(m.class_id == kMsgClassMetadata, "meta class=%u", m.class_id);
+    CHECK(m.in_class_id == 0, "meta in_class_id=%llu",
+          static_cast<unsigned long long>(m.in_class_id));
+    CHECK(m.is_last, "meta is_last");
+    CHECK(m.msg_length == 0, "meta msg_length=%llu", static_cast<unsigned long long>(m.msg_length));
+    pos += adv;
+  }
+
+  CHECK(pos == stream.size(), "stream not fully consumed: %zu/%zu", pos, stream.size());
+
+  if (failures == 0) {
+    std::printf("OK emitter_check: main / tile0 / metadata round-trip cleanly\n");
+    return 0;
+  }
+  std::fprintf(stderr, "emitter_check: %d failures\n", failures);
+  return 1;
+}

--- a/source/core/jpip/CMakeLists.txt
+++ b/source/core/jpip/CMakeLists.txt
@@ -5,4 +5,6 @@ target_sources(open_htj2k
     view_window.cpp
     vbas.cpp
     jpp_message.cpp
+    codestream_walker.cpp
+    data_bin_emitter.cpp
 )

--- a/source/core/jpip/codestream_walker.cpp
+++ b/source/core/jpip/codestream_walker.cpp
@@ -1,0 +1,137 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+
+#include "codestream_walker.hpp"
+
+namespace open_htj2k {
+namespace jpip {
+
+namespace {
+
+constexpr uint16_t kMarkerSOC = 0xFF4F;
+constexpr uint16_t kMarkerSOT = 0xFF90;
+constexpr uint16_t kMarkerSOD = 0xFF93;
+constexpr uint16_t kMarkerEOC = 0xFFD9;
+
+inline uint16_t read_u16_be(const uint8_t *p) {
+  return static_cast<uint16_t>((static_cast<uint16_t>(p[0]) << 8) | p[1]);
+}
+inline uint32_t read_u32_be(const uint8_t *p) {
+  return (static_cast<uint32_t>(p[0]) << 24) | (static_cast<uint32_t>(p[1]) << 16)
+       | (static_cast<uint32_t>(p[2]) << 8)  |  static_cast<uint32_t>(p[3]);
+}
+
+// Markers without a length field (per ITU-T T.800 Table A.1).  All other
+// 0xFFxx markers have a 2-byte big-endian length immediately following.
+inline bool marker_has_no_length(uint16_t m) {
+  // SOC, SOD, EOC, EPH, plus the reserved single-byte 0xFF{30..3F} markers.
+  if (m == kMarkerSOC || m == kMarkerSOD || m == kMarkerEOC) return true;
+  if (m == 0xFF92 /* EPH */) return true;
+  const uint8_t low = static_cast<uint8_t>(m & 0xFF);
+  return (low >= 0x30 && low <= 0x3F);
+}
+
+}  // namespace
+
+bool walk_codestream(const uint8_t *bytes, std::size_t len, CodestreamLayout *out) {
+  if (out == nullptr || bytes == nullptr || len < 2) return false;
+
+  // Must start with SOC.  We're strict here — any prefix bytes the caller
+  // wants to skip should be stripped before calling.
+  if (read_u16_be(bytes) != kMarkerSOC) return false;
+
+  out->soc_offset      = 0;
+  out->main_header_end = 0;
+  out->eoc_offset      = len;
+  out->tile_parts.clear();
+
+  std::size_t i = 2;       // past the SOC
+  bool first_sot_seen = false;
+
+  while (i + 2 <= len) {
+    const uint16_t m = read_u16_be(bytes + i);
+
+    if (m == kMarkerEOC) {
+      out->eoc_offset = i;
+      return true;
+    }
+
+    if (m == kMarkerSOT) {
+      // SOT marker segment: 2 (marker) + 2 (Lsot) + Isot(2) + Psot(4)
+      // + TPsot(1) + TNsot(1) = 12 bytes total.  Lsot is fixed at 10.
+      if (i + 12 > len) return true;  // truncated SOT: stop, return what we have
+      const uint16_t Lsot = read_u16_be(bytes + i + 2);
+      if (Lsot != 10) return true;     // malformed
+      const uint16_t Isot = read_u16_be(bytes + i + 4);
+      const uint32_t Psot = read_u32_be(bytes + i + 6);
+      const uint8_t  TPsot = bytes[i + 10];
+      const uint8_t  TNsot = bytes[i + 11];
+
+      if (!first_sot_seen) {
+        out->main_header_end = i;
+        first_sot_seen       = true;
+      }
+
+      // Walk forward from past-SOT looking for the SOD that closes this
+      // tile-part header.
+      std::size_t j = i + 12;
+      while (j + 2 <= len) {
+        const uint16_t m2 = read_u16_be(bytes + j);
+        if (m2 == kMarkerSOD) {
+          TilePartLocation tp{};
+          tp.sot_offset    = i;
+          tp.header_end    = j;
+          tp.body_offset   = j + 2;  // skip SOD marker (2 bytes, no length field)
+          // Psot is the total tile-part length from the start of the SOT
+          // marker to the end of the tile-part data.  When Psot == 0 the
+          // last tile-part of the codestream extends to EOC (or EOF).
+          if (Psot != 0) {
+            tp.body_end = i + Psot;
+            if (tp.body_end > len) tp.body_end = len;  // truncated
+          } else {
+            tp.body_end = len;  // probe until EOC during next iteration
+          }
+          tp.tile_index    = Isot;
+          tp.tile_part_idx = TPsot;
+          tp.tile_part_cnt = TNsot;
+          out->tile_parts.push_back(tp);
+          // Advance to the next marker after this tile-part body.
+          i = tp.body_end;
+          break;
+        }
+        if (marker_has_no_length(m2)) {
+          // Single-byte markers inside a tile-part header are unusual;
+          // skip the 2-byte marker code.
+          j += 2;
+          continue;
+        }
+        if (j + 4 > len) return true;
+        const uint16_t Lmar = read_u16_be(bytes + j + 2);
+        if (Lmar < 2 || j + 2 + Lmar > len) return true;
+        j += 2 + Lmar;
+      }
+      // If we ran off the end without finding SOD, drop out.
+      if (j + 2 > len) return true;
+      continue;
+    }
+
+    if (marker_has_no_length(m)) {
+      // SOC/SOD/EOC are handled above; this catches reserved single-byte
+      // markers.  Just skip past them.
+      i += 2;
+      continue;
+    }
+
+    // Generic length-bearing main-header marker (SIZ, COD, COC, QCD, QCC,
+    // CAP, COM, PLM, PPM, TLM, RGN, POC, …).
+    if (i + 4 > len) return true;
+    const uint16_t Lmar = read_u16_be(bytes + i + 2);
+    if (Lmar < 2 || i + 2 + Lmar > len) return true;
+    i += 2 + Lmar;
+  }
+
+  return true;
+}
+
+}  // namespace jpip
+}  // namespace open_htj2k

--- a/source/core/jpip/codestream_walker.hpp
+++ b/source/core/jpip/codestream_walker.hpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+//
+// Lightweight codestream marker walker for JPIP wire-format work.
+//
+// Identifies the byte offsets of SOC, SOT, SOD, and EOC markers — enough to
+// carve out main-header / tile-header / tile-part-body byte ranges without
+// invoking the full j2k_main_header parser (which carries internal state
+// the JPIP code does not need).
+//
+// Stops at the first malformed marker; reports what it managed to find.
+#pragma once
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#if defined(_MSC_VER) && !defined(OHTJ2K_STATIC)
+  #define OPENHTJ2K_JPIP_EXPORT __declspec(dllexport)
+#else
+  #define OPENHTJ2K_JPIP_EXPORT
+#endif
+
+namespace open_htj2k {
+namespace jpip {
+
+struct TilePartLocation {
+  std::size_t sot_offset    = 0;  // start of the SOT marker (FF 90)
+  std::size_t header_end    = 0;  // start of the SOD marker (= one past last header byte)
+  std::size_t body_offset   = 0;  // start of packet data (= header_end + 2 to skip SOD)
+  std::size_t body_end      = 0;  // one past last byte of this tile-part's body
+  uint16_t    tile_index    = 0;
+  uint8_t     tile_part_idx = 0;  // TPsot field — 0 for the first tile-part of a tile
+  uint8_t     tile_part_cnt = 0;  // TNsot field — total tile-parts for this tile, or 0 if unknown
+};
+
+struct CodestreamLayout {
+  // SOC marker offset (= 0 in a well-formed codestream).
+  std::size_t soc_offset = 0;
+  // The byte just past the main-header — the offset of the first SOT.
+  // The main-header data-bin payload is bytes [soc_offset, main_header_end).
+  std::size_t main_header_end = 0;
+  // EOC marker offset, or `len` if the codestream is truncated / lacks EOC.
+  std::size_t eoc_offset = 0;
+  // Tile-parts in declaration order (which is also their byte order).
+  std::vector<TilePartLocation> tile_parts;
+};
+
+// Walk the codestream and return its layout.  Stops on the first malformed
+// marker but still returns whatever was collected up to that point — the
+// caller can validate by checking that `tile_parts` is non-empty and that
+// `eoc_offset > soc_offset`.  Returns `false` on hard errors (e.g. no SOC
+// at the start) and `true` otherwise.
+OPENHTJ2K_JPIP_EXPORT bool walk_codestream(const uint8_t *bytes, std::size_t len,
+                                           CodestreamLayout *out);
+
+}  // namespace jpip
+}  // namespace open_htj2k

--- a/source/core/jpip/data_bin_emitter.cpp
+++ b/source/core/jpip/data_bin_emitter.cpp
@@ -1,0 +1,93 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+
+#include "data_bin_emitter.hpp"
+
+namespace open_htj2k {
+namespace jpip {
+
+namespace {
+
+// Append a complete JPP-stream message (header + payload) covering
+// `payload_len` bytes from `payload`.  Reserves enough capacity in `out`
+// up front so the encoded header bytes don't trigger a reallocation
+// while we're still writing them.
+std::size_t append_message(MessageHeader hdr, const uint8_t *payload,
+                           std::size_t payload_len,
+                           MessageHeaderContext &ctx,
+                           std::vector<uint8_t> &out) {
+  hdr.msg_offset = 0;
+  hdr.msg_length = payload_len;
+  hdr.is_last    = true;
+
+  const std::size_t prev = out.size();
+  out.resize(prev + kMessageHeaderMaxBytes);
+  const std::size_t hdr_bytes = encode_header(hdr, ctx, out.data() + prev);
+  // Truncate the over-reservation back to the actual header length, then
+  // append the payload bytes.
+  out.resize(prev + hdr_bytes);
+  out.insert(out.end(), payload, payload + payload_len);
+  return hdr_bytes + payload_len;
+}
+
+}  // namespace
+
+std::size_t emit_main_header_databin(const uint8_t *codestream, std::size_t len,
+                                     const CodestreamLayout &layout,
+                                     MessageHeaderContext &ctx,
+                                     std::vector<uint8_t> &out) {
+  if (codestream == nullptr || layout.main_header_end == 0) return 0;
+  if (layout.main_header_end > len) return 0;
+  MessageHeader hdr{};
+  hdr.class_id    = kMsgClassMainHeader;
+  hdr.cs_n        = 0;
+  hdr.in_class_id = 0;
+  return append_message(hdr, codestream + layout.soc_offset,
+                        layout.main_header_end - layout.soc_offset, ctx, out);
+}
+
+std::size_t emit_tile_header_databin(const uint8_t *codestream, std::size_t len,
+                                     uint16_t tile_index,
+                                     const CodestreamLayout &layout,
+                                     MessageHeaderContext &ctx,
+                                     std::vector<uint8_t> &out) {
+  if (codestream == nullptr) return 0;
+  // Per §A.3.3, the server "is required to send a tile header data bin for
+  // a tile even if the tile header is empty" — so we emit the message
+  // (zero-length, is_last = true) whenever the tile exists in the layout,
+  // and only return 0 when no tile-parts match the requested index.
+  bool tile_exists = false;
+  std::vector<uint8_t> payload;
+  for (const auto &tp : layout.tile_parts) {
+    if (tp.tile_index != tile_index) continue;
+    tile_exists = true;
+    // SOT marker segment is fixed at 12 bytes (2 marker + 2 Lsot + 8 body).
+    constexpr std::size_t kSotSize = 12;
+    if (tp.sot_offset + kSotSize > len || tp.header_end > len ||
+        tp.sot_offset + kSotSize > tp.header_end) {
+      continue;  // malformed tile-part — skip its bytes but still emit the bin
+    }
+    const uint8_t *first = codestream + tp.sot_offset + kSotSize;
+    const uint8_t *last  = codestream + tp.header_end;
+    payload.insert(payload.end(), first, last);
+  }
+  if (!tile_exists) return 0;
+
+  MessageHeader hdr{};
+  hdr.class_id    = kMsgClassTileHeader;
+  hdr.cs_n        = 0;
+  hdr.in_class_id = tile_index;
+  return append_message(hdr, payload.data(), payload.size(), ctx, out);
+}
+
+std::size_t emit_metadata_bin_zero(MessageHeaderContext &ctx,
+                                   std::vector<uint8_t> &out) {
+  MessageHeader hdr{};
+  hdr.class_id    = kMsgClassMetadata;
+  hdr.cs_n        = 0;
+  hdr.in_class_id = 0;
+  return append_message(hdr, /*payload=*/nullptr, 0, ctx, out);
+}
+
+}  // namespace jpip
+}  // namespace open_htj2k

--- a/source/core/jpip/data_bin_emitter.hpp
+++ b/source/core/jpip/data_bin_emitter.hpp
@@ -1,0 +1,69 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+//
+// Data-bin emitters for the JPP-stream wire format (ISO/IEC 15444-9 §A.3).
+//
+// Each emit_*_databin() function appends one or more JPP-stream messages
+// to the caller-supplied buffer.  A `MessageHeaderContext` is threaded
+// through so dependent-form headers (Class/CSn omission) work across
+// successive data-bins.
+//
+// The v1 emitters always pack each data-bin into a single message — i.e.
+// msg_offset = 0, msg_length = (bin size), is_last = true.  Splitting a
+// bin across multiple messages is allowed by the spec (and useful for
+// flow-control and progressive delivery) but unnecessary for the local
+// round-trip use case in PHASE2_PLAN.md.
+//
+// Precinct data-bins (class 0/1) are not emitted by this header — they
+// require packet-header parsing and live in a follow-up commit; see
+// PHASE2_PLAN.md item B3-precincts.
+#pragma once
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "codestream_walker.hpp"
+#include "jpp_message.hpp"
+
+#if defined(_MSC_VER) && !defined(OHTJ2K_STATIC)
+  #define OPENHTJ2K_JPIP_EXPORT __declspec(dllexport)
+#else
+  #define OPENHTJ2K_JPIP_EXPORT
+#endif
+
+namespace open_htj2k {
+namespace jpip {
+
+// Emit the main-header data-bin (class 6, in-class id 0).  Payload is the
+// codestream bytes from the SOC marker (inclusive) up to the first SOT
+// marker (exclusive).  Returns the number of bytes appended to `out`, or 0
+// on error (malformed codestream / no SOT found).
+OPENHTJ2K_JPIP_EXPORT std::size_t
+emit_main_header_databin(const uint8_t *codestream, std::size_t len,
+                         const CodestreamLayout &layout,
+                         MessageHeaderContext &ctx,
+                         std::vector<uint8_t> &out);
+
+// Emit the tile-header data-bin (class 2, in-class id = `tile_index`).
+// Per §A.3.3, the bin contains all tile-part-header marker segments for
+// the tile concatenated, with SOT excluded; SOD inclusion is optional and
+// this implementation excludes them.  When a tile has multiple tile-parts
+// (TPsot > 0 in any of them), all matching tile-parts contribute their
+// header bytes in order.  Returns 0 if the tile has no tile-parts in the
+// layout.
+OPENHTJ2K_JPIP_EXPORT std::size_t
+emit_tile_header_databin(const uint8_t *codestream, std::size_t len,
+                         uint16_t tile_index,
+                         const CodestreamLayout &layout,
+                         MessageHeaderContext &ctx,
+                         std::vector<uint8_t> &out);
+
+// Emit metadata-bin 0 (class 8, in-class id 0).  Per §A.3.6.1 the server
+// must always send this bin; for raw .j2c codestreams (no JP2/JPH boxes)
+// it is empty.  This implementation emits a single zero-length, is_last
+// message.
+OPENHTJ2K_JPIP_EXPORT std::size_t
+emit_metadata_bin_zero(MessageHeaderContext &ctx, std::vector<uint8_t> &out);
+
+}  // namespace jpip
+}  // namespace open_htj2k

--- a/tests/jpip_phase1.cmake
+++ b/tests/jpip_phase1.cmake
@@ -16,6 +16,13 @@ add_test(NAME jpip_vbas_codec COMMAND jpip_vbas_check)
 # dependent-form behaviour + rejection cases.
 add_test(NAME jpip_message_codec COMMAND jpip_message_check)
 
+# ── Header data-bin emitters (§A.3.5 main-header / §A.3.3 tile-header /
+# §A.3.6 metadata-bin 0).  Validates against any conformance asset.
+add_test(NAME jpip_emitter_p0_04
+         COMMAND jpip_emitter_check ${CONFORMANCE_DATA_DIR}/p0_04.j2k)
+add_test(NAME jpip_emitter_ht_01
+         COMMAND jpip_emitter_check ${CONFORMANCE_DATA_DIR}/ds0_ht_01_b11.j2k)
+
 # ── Decoder precinct-filter sanity (§M.4.1 partial-decode plumbing) ──
 # Exercises the public openhtj2k_decoder::set_precinct_filter hook against a
 # Part-1 and a Part-15 conformance stream.  The assets live under


### PR DESCRIPTION
## Summary

First half of `PHASE2_PLAN.md` item B3 — adds the data-bin emitters that do **not** require packet-header parsing, namely the three header-class bins.  Precinct data-bins (class 0/1) need a packet locator that re-parses every packet header in the codestream and land in a follow-up commit (B3-precincts) so this PR stays at a reviewable size.

## Two new modules

**`source/core/jpip/codestream_walker.{hpp,cpp}`** — lightweight marker walker that finds SOC, SOT (with Lsot / Isot / Psot / TPsot / TNsot fields), SOD, and EOC offsets without engaging the full `j2k_main_header` parser.  Returns a `CodestreamLayout` with the main-header byte range and a vector of `TilePartLocation`s.

**`source/core/jpip/data_bin_emitter.{hpp,cpp}`** — three free functions that append complete JPP-stream messages to a caller buffer:

| function | class | in-class id | payload |
|---|---|---|---|
| `emit_main_header_databin()` | 6 | 0 | bytes [SOC, first SOT) |
| `emit_tile_header_databin()` | 2 | tile_index | concatenated marker bytes from each contributing tile-part's header, SOT excluded per §A.3.3 |
| `emit_metadata_bin_zero()` | 8 | 0 | empty payload (raw .j2c, no JP2/JPH boxes) |

The tile-header emitter always emits the bin even when the per-tile-part header is empty — §A.3.3 says the server "is required to send a tile header data bin for a tile even if the tile header is empty", which is the common case for codestreams whose markers all live in the main header.

All emitters share a `MessageHeaderContext` so the dependent form of B2's `encode_header()` is exercised across the three back-to-back messages.

## Test plan

- [x] **New ctests `jpip_emitter_p0_04` / `jpip_emitter_ht_01`** run the standalone `jpip_emitter_check` exe against two conformance assets.
- [x] The harness walks the codestream, emits the three bins through one shared ctx, decodes each message back via B2's `decode_header()`, and verifies header fields + byte-identical payloads + entire buffer consumed.
- [x] Manually verified against the foveation asset (`build/bin/land_shallow_topo_1920_fov.j2c`).
- [x] **604/604 ctests pass** (602 prior + 2 new); no decoder/encoder/JPIP regressions.

## What's next

**B3-precincts** (next commit): precinct data-bin emitter (class 0/1).  Needs a packet locator that walks every packet header in PCRL/RPCL/CPRL order to record per-precinct byte ranges.  The walker is the core complexity — once it exists the emitter is small.

**B4** (parallel with B3-precincts since both only need B2): JPP-stream parser → `DataBinSet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)