### PR TITLE
feat(jpip): JPP-stream parser → DataBinSet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,6 +277,11 @@ add_executable(jpip_emitter_check)
 add_subdirectory(source/apps/jpip_emitter_check)
 target_link_libraries(jpip_emitter_check PUBLIC open_htj2k)
 
+# JPIP Phase-2 JPP-stream parser self-test (used by tests/jpip_phase1.cmake)
+add_executable(jpip_parser_check)
+add_subdirectory(source/apps/jpip_parser_check)
+target_link_libraries(jpip_parser_check PUBLIC open_htj2k)
+
 # RFC 9828 RTP receiver (experimental, requires GLFW)
 option(OPENHTJ2K_RTP "Build experimental RFC 9828 RTP receiver (requires GLFW)" OFF)
 if (OPENHTJ2K_RTP AND NOT EMSCRIPTEN)

--- a/source/apps/jpip_parser_check/CMakeLists.txt
+++ b/source/apps/jpip_parser_check/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_policy(SET CMP0076 NEW)
+target_sources(jpip_parser_check
+    PRIVATE
+    main.cpp
+)
+target_include_directories(jpip_parser_check PRIVATE ${CMAKE_SOURCE_DIR}/source/core/jpip)

--- a/source/apps/jpip_parser_check/main.cpp
+++ b/source/apps/jpip_parser_check/main.cpp
@@ -1,0 +1,172 @@
+// jpip_parser_check: ctest harness for the JPP-stream parser (B4).
+//
+// Round-trips through the emitter and the parser:
+//   1. Walk the codestream and emit the three header data-bins (main,
+//      tile-0 header, metadata-bin 0) into a single JPP-stream buffer.
+//   2. parse_jpp_stream() the buffer into a DataBinSet.
+//   3. Verify the set has exactly three bins, each with the expected
+//      is_complete flag, and each bin's bytes are byte-identical to the
+//      corresponding slice of the source codestream.
+// Additionally exercises the in-order / is_last rejection paths.
+//
+// Usage:  jpip_parser_check <input.j2c>
+// Exits 0 on every assertion passing, 1 on the first failure.
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "codestream_walker.hpp"
+#include "data_bin_emitter.hpp"
+#include "jpp_message.hpp"
+#include "jpp_parser.hpp"
+
+using open_htj2k::jpip::CodestreamLayout;
+using open_htj2k::jpip::DataBinSet;
+using open_htj2k::jpip::emit_main_header_databin;
+using open_htj2k::jpip::emit_metadata_bin_zero;
+using open_htj2k::jpip::emit_tile_header_databin;
+using open_htj2k::jpip::kMsgClassMainHeader;
+using open_htj2k::jpip::kMsgClassMetadata;
+using open_htj2k::jpip::kMsgClassTileHeader;
+using open_htj2k::jpip::MessageHeaderContext;
+using open_htj2k::jpip::parse_jpp_stream;
+using open_htj2k::jpip::walk_codestream;
+
+namespace {
+
+int failures = 0;
+
+#define CHECK(cond, ...)                                            \
+  do {                                                              \
+    if (!(cond)) {                                                  \
+      std::fprintf(stderr, "FAIL [%s:%d] %s — ", __FILE__, __LINE__, #cond); \
+      std::fprintf(stderr, __VA_ARGS__);                            \
+      std::fprintf(stderr, "\n");                                   \
+      ++failures;                                                   \
+    }                                                               \
+  } while (0)
+
+std::vector<uint8_t> read_file(const char *path) {
+  FILE *f = std::fopen(path, "rb");
+  if (!f) { std::fprintf(stderr, "ERROR: cannot open %s\n", path); return {}; }
+  std::fseek(f, 0, SEEK_END);
+  auto sz = static_cast<std::size_t>(std::ftell(f));
+  std::fseek(f, 0, SEEK_SET);
+  std::vector<uint8_t> buf(sz);
+  std::size_t rd = std::fread(buf.data(), 1, sz, f);
+  std::fclose(f);
+  if (rd != sz) { std::fprintf(stderr, "ERROR: partial read\n"); buf.clear(); }
+  return buf;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    std::fprintf(stderr, "Usage: jpip_parser_check <input.j2c>\n");
+    return 1;
+  }
+
+  auto bytes = read_file(argv[1]);
+  if (bytes.empty()) return 1;
+
+  CodestreamLayout layout;
+  CHECK(walk_codestream(bytes.data(), bytes.size(), &layout), "walk_codestream");
+  if (failures) return 1;
+
+  // ── Emit the three header data-bins into one stream buffer ───────────
+  std::vector<uint8_t> stream;
+  MessageHeaderContext enc_ctx;
+  emit_main_header_databin(bytes.data(), bytes.size(), layout, enc_ctx, stream);
+  emit_tile_header_databin(bytes.data(), bytes.size(), /*tile=*/0, layout, enc_ctx, stream);
+  emit_metadata_bin_zero(enc_ctx, stream);
+
+  // ── Parse it back ────────────────────────────────────────────────────
+  DataBinSet set;
+  CHECK(parse_jpp_stream(stream.data(), stream.size(), &set), "parse_jpp_stream");
+  CHECK(set.size() == 3, "set.size()=%zu, expected 3", set.size());
+
+  // Main header (class 6).
+  {
+    CHECK(set.contains(kMsgClassMainHeader, 0), "main bin present");
+    CHECK(set.is_complete(kMsgClassMainHeader, 0), "main bin complete");
+    const auto &got = set.get(kMsgClassMainHeader, 0);
+    const std::size_t expected_len = layout.main_header_end - layout.soc_offset;
+    CHECK(got.size() == expected_len, "main len=%zu expected %zu", got.size(), expected_len);
+    CHECK(std::memcmp(got.data(), bytes.data() + layout.soc_offset, expected_len) == 0,
+          "main header bytes not byte-identical");
+  }
+
+  // Tile-0 header (class 2).
+  {
+    CHECK(set.contains(kMsgClassTileHeader, 0), "tile-0 bin present");
+    CHECK(set.is_complete(kMsgClassTileHeader, 0), "tile-0 bin complete");
+    const auto &got = set.get(kMsgClassTileHeader, 0);
+    // Reconstruct expected bytes — concatenation of each tile-0 tile-part's
+    // marker bytes, SOT excluded.
+    std::vector<uint8_t> expected;
+    for (const auto &tp : layout.tile_parts) {
+      if (tp.tile_index != 0) continue;
+      constexpr std::size_t kSotSize = 12;
+      const uint8_t *first = bytes.data() + tp.sot_offset + kSotSize;
+      const uint8_t *last  = bytes.data() + tp.header_end;
+      expected.insert(expected.end(), first, last);
+    }
+    CHECK(got.size() == expected.size(), "tile-0 len=%zu expected %zu",
+          got.size(), expected.size());
+    CHECK(std::memcmp(got.data(), expected.data(), expected.size()) == 0,
+          "tile-0 header bytes not byte-identical");
+  }
+
+  // Metadata-bin 0 (class 8) — should be present, complete, empty.
+  {
+    CHECK(set.contains(kMsgClassMetadata, 0), "meta bin present");
+    CHECK(set.is_complete(kMsgClassMetadata, 0), "meta bin complete");
+    const auto &got = set.get(kMsgClassMetadata, 0);
+    CHECK(got.empty(), "meta bin should be empty, got %zu bytes", got.size());
+  }
+
+  // Keys come back sorted.
+  {
+    const auto keys = set.keys();
+    CHECK(keys.size() == 3, "keys size=%zu", keys.size());
+    // class 2 (tile header), 6 (main header), 8 (metadata) — ascending by class id.
+    CHECK(keys[0].first == kMsgClassTileHeader, "keys[0].class=%u", keys[0].first);
+    CHECK(keys[1].first == kMsgClassMainHeader, "keys[1].class=%u", keys[1].first);
+    CHECK(keys[2].first == kMsgClassMetadata,   "keys[2].class=%u", keys[2].first);
+  }
+
+  // ── Rejection cases on the DataBinSet's append() contract ────────────
+  {
+    DataBinSet s;
+    // Non-contiguous offset (spec permits out-of-order; v1 parser rejects).
+    CHECK(!s.append(0, 0, /*offset=*/5, nullptr, 0, false),
+          "append with non-zero offset on empty bin should fail");
+    // Append after is_last with non-empty payload.
+    const uint8_t one = 0x42;
+    CHECK(s.append(0, 0, 0, &one, 1, /*is_last=*/true), "initial append");
+    CHECK(!s.append(0, 0, 1, &one, 1, /*is_last=*/false),
+          "append after is_last with payload should fail");
+    // Empty zero-offset append after is_last is a no-op but legal (no new bytes).
+    CHECK(s.append(0, 0, 1, nullptr, 0, /*is_last=*/true),
+          "zero-length repeat of is_last should succeed");
+  }
+
+  // Malformed stream: truncated mid-message.
+  {
+    std::vector<uint8_t> bad(stream.begin(), stream.begin() + stream.size() / 2);
+    DataBinSet t;
+    CHECK(!parse_jpp_stream(bad.data(), bad.size(), &t),
+          "truncated stream should be rejected");
+  }
+
+  if (failures == 0) {
+    std::printf("OK parser_check: emit→parse round-trip + rejection cases all pass\n");
+    return 0;
+  }
+  std::fprintf(stderr, "parser_check: %d failures\n", failures);
+  return 1;
+}

--- a/source/core/jpip/CMakeLists.txt
+++ b/source/core/jpip/CMakeLists.txt
@@ -7,4 +7,5 @@ target_sources(open_htj2k
     jpp_message.cpp
     codestream_walker.cpp
     data_bin_emitter.cpp
+    jpp_parser.cpp
 )

--- a/source/core/jpip/jpp_parser.cpp
+++ b/source/core/jpip/jpp_parser.cpp
@@ -1,0 +1,81 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+
+#include "jpp_parser.hpp"
+
+#include "jpp_message.hpp"
+
+namespace open_htj2k {
+namespace jpip {
+
+namespace {
+
+const std::vector<uint8_t> &empty_bytes() {
+  static const std::vector<uint8_t> v;
+  return v;
+}
+
+}  // namespace
+
+bool DataBinSet::contains(uint8_t class_id, uint64_t in_class_id) const {
+  return bins_.find({class_id, in_class_id}) != bins_.end();
+}
+
+bool DataBinSet::is_complete(uint8_t class_id, uint64_t in_class_id) const {
+  auto it = bins_.find({class_id, in_class_id});
+  return it != bins_.end() && it->second.is_last;
+}
+
+const std::vector<uint8_t> &DataBinSet::get(uint8_t class_id, uint64_t in_class_id) const {
+  auto it = bins_.find({class_id, in_class_id});
+  if (it == bins_.end()) return empty_bytes();
+  return it->second.bytes;
+}
+
+std::vector<std::pair<uint8_t, uint64_t>> DataBinSet::keys() const {
+  std::vector<std::pair<uint8_t, uint64_t>> out;
+  out.reserve(bins_.size());
+  for (const auto &kv : bins_) out.push_back(kv.first);
+  return out;
+}
+
+bool DataBinSet::append(uint8_t class_id, uint64_t in_class_id, uint64_t msg_offset,
+                        const uint8_t *payload, std::size_t payload_len, bool is_last) {
+  const Key key{class_id, in_class_id};
+  Entry &e = bins_[key];
+  // Reject any further bytes on a bin the server has already closed with
+  // is_last — even if the new message also carries is_last=true and a
+  // zero-length payload.  That's an encoder / protocol bug on our end.
+  if (e.is_last && payload_len > 0) return false;
+  // Strict in-order: msg_offset must equal whatever we've accumulated so
+  // far.  Anything else is a non-contiguous (out-of-order or duplicate)
+  // delivery which we reject in v1.
+  if (msg_offset != e.bytes.size()) return false;
+  if (payload_len > 0 && payload != nullptr) {
+    e.bytes.insert(e.bytes.end(), payload, payload + payload_len);
+  }
+  if (is_last) e.is_last = true;
+  return true;
+}
+
+bool parse_jpp_stream(const uint8_t *bytes, std::size_t len, DataBinSet *out) {
+  if (out == nullptr) return false;
+  MessageHeaderContext ctx;
+  std::size_t pos = 0;
+  while (pos < len) {
+    MessageHeader hdr;
+    std::size_t hdr_bytes = 0;
+    if (!decode_header(bytes + pos, len - pos, ctx, &hdr, &hdr_bytes)) return false;
+    pos += hdr_bytes;
+    if (hdr.msg_length > len - pos) return false;  // truncated payload
+    if (!out->append(hdr.class_id, hdr.in_class_id, hdr.msg_offset, bytes + pos,
+                     static_cast<std::size_t>(hdr.msg_length), hdr.is_last)) {
+      return false;
+    }
+    pos += static_cast<std::size_t>(hdr.msg_length);
+  }
+  return true;
+}
+
+}  // namespace jpip
+}  // namespace open_htj2k

--- a/source/core/jpip/jpp_parser.hpp
+++ b/source/core/jpip/jpp_parser.hpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+//
+// JPP-stream parser: consume a byte buffer of JPP-stream messages
+// (produced by B3's data-bin emitters or by a JPIP server) and aggregate
+// them into a DataBinSet keyed by (class, in-class identifier).
+//
+// In-order assumption: the v1 parser requires each message's msg_offset
+// to equal the already-accumulated byte count for the target data-bin —
+// i.e. a strict contiguous stream with no gaps and no duplicates.  This
+// matches what our B3 emitter produces and is sufficient for the local
+// round-trip use case in PHASE2_PLAN.md.  Out-of-order support can be
+// layered on top once we have a transport that reorders (Phase 3+).
+//
+// The parser ignores the CSn field for now — Phase 1/2 assets always
+// declare a single codestream (cs_n = 0).  DataBinSet's key therefore
+// omits cs_n; if multi-codestream support is needed later, the key
+// widens to a (cs_n, class, in_class_id) tuple.
+#pragma once
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <utility>
+#include <vector>
+
+#if defined(_MSC_VER) && !defined(OHTJ2K_STATIC)
+  #define OPENHTJ2K_JPIP_EXPORT __declspec(dllexport)
+#else
+  #define OPENHTJ2K_JPIP_EXPORT
+#endif
+
+namespace open_htj2k {
+namespace jpip {
+
+class OPENHTJ2K_JPIP_EXPORT DataBinSet {
+ public:
+  // True iff at least one message for this (class, id) has been received.
+  bool contains(uint8_t class_id, uint64_t in_class_id) const;
+
+  // True iff the data-bin's last message has been received (is_last bit).
+  bool is_complete(uint8_t class_id, uint64_t in_class_id) const;
+
+  // Accumulated bytes for this data-bin.  Returns a reference to an empty
+  // vector when the bin is unknown (rather than throwing), matching the
+  // spec's treatment of "not yet received".
+  const std::vector<uint8_t> &get(uint8_t class_id, uint64_t in_class_id) const;
+
+  // Number of distinct data-bins known to the set.
+  std::size_t size() const { return bins_.size(); }
+
+  // (class, in_class_id) keys in deterministic ascending order.
+  std::vector<std::pair<uint8_t, uint64_t>> keys() const;
+
+  // Feed one message's body into the set.  Returns true on success, false
+  // if the message violates the in-order assumption (non-contiguous
+  // msg_offset, or further bytes arriving on a bin that was already
+  // marked complete).  Intended for internal use by parse_jpp_stream; the
+  // public entry point is below.
+  bool append(uint8_t class_id, uint64_t in_class_id, uint64_t msg_offset,
+              const uint8_t *payload, std::size_t payload_len, bool is_last);
+
+ private:
+  struct Entry {
+    std::vector<uint8_t> bytes;
+    bool                 is_last = false;
+  };
+  using Key = std::pair<uint8_t, uint64_t>;
+  std::map<Key, Entry> bins_;
+};
+
+// Parse a complete JPP-stream byte buffer, appending every message's body
+// into `*out`'s DataBinSet.  Returns true iff the entire buffer was
+// consumed cleanly and every message obeyed the in-order assumption.
+OPENHTJ2K_JPIP_EXPORT bool parse_jpp_stream(const uint8_t *bytes, std::size_t len,
+                                            DataBinSet *out);
+
+}  // namespace jpip
+}  // namespace open_htj2k

--- a/tests/jpip_phase1.cmake
+++ b/tests/jpip_phase1.cmake
@@ -23,6 +23,13 @@ add_test(NAME jpip_emitter_p0_04
 add_test(NAME jpip_emitter_ht_01
          COMMAND jpip_emitter_check ${CONFORMANCE_DATA_DIR}/ds0_ht_01_b11.j2k)
 
+# ── JPP-stream parser → DataBinSet.  Emit the three header bins from
+# an asset, parse the stream back, verify each bin's accumulated bytes.
+add_test(NAME jpip_parser_p0_04
+         COMMAND jpip_parser_check ${CONFORMANCE_DATA_DIR}/p0_04.j2k)
+add_test(NAME jpip_parser_ht_01
+         COMMAND jpip_parser_check ${CONFORMANCE_DATA_DIR}/ds0_ht_01_b11.j2k)
+
 # ── Decoder precinct-filter sanity (§M.4.1 partial-decode plumbing) ──
 # Exercises the public openhtj2k_decoder::set_precinct_filter hook against a
 # Part-1 and a Part-15 conformance stream.  The assets live under


### PR DESCRIPTION
## Summary

B4 of `PHASE2_PLAN.md`.  Consumes a JPP-stream byte buffer produced by B3's emitters (or by any spec-conformant JPIP server that respects the in-order-delivery assumption) and aggregates it into a `DataBinSet` keyed by (class, in-class identifier).

## Two new files in `source/core/jpip/`

- **`jpp_parser.hpp`** — `DataBinSet` API + `parse_jpp_stream()` entry point.
- **`jpp_parser.cpp`** — in-order append with the `msg_offset == current-size` invariant, `is_last` tracking, `std::map`-backed storage.

## v1 decisions that will bend as the surrounding wire-format work matures

- **In-order only.**  Each message's `msg_offset` must match the already-accumulated byte count for its data-bin.  This matches B3's emitter output and sidesteps the need for a pending-chunks map.  Out-of-order support is a Phase-3 transport concern; the function will grow (or the parser gets wrapped by a reassembler) when packet loss / parallel streams arrive.
- **Ignores the CSn field.**  Phase-1/2 assets all declare a single codestream (`cs_n = 0`), and the `DataBinSet` key therefore omits `cs_n`.  Adding it back is a 2-member key widening when needed.
- **Strict `is_last` handling.**  Further non-empty payload on a bin that was already closed with `is_last` is rejected as an encoder bug.  Zero-length repeats of `is_last` are idempotent.

## Test plan

- [x] **New ctests `jpip_parser_p0_04` / `jpip_parser_ht_01`** — exercise the emit → parse round-trip.  The harness emits main / tile-0 / metadata-bin-0 via B3, parses back via B4, verifies each bin's bytes are byte-identical to the expected slice of the source codestream.
- [x] Rejection cases: non-contiguous `msg_offset`, append-after-`is_last` with non-empty payload, truncated stream.
- [x] `DataBinSet::keys()` returns bins in deterministic ascending order.
- [x] Manually verified against the foveation asset (`build/bin/land_shallow_topo_1920_fov.j2c`).
- [x] **606/606 ctests pass** (604 prior + 2 new); no decoder/encoder/JPIP regressions.

## What's next

- **B3-precincts** (unblocked, independent): precinct data-bin emitter (class 0/1).  Needs a packet locator that walks every packet header.
- **B5** (now unblocked by B4): codestream reassembler from a `DataBinSet`.  Once B3-precincts lands, the reassembler has everything it needs to rebuild a sparse codestream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)