### PR TITLE
fix(jpip): demo displays >8-bit codestreams correctly

### DIFF
--- a/source/apps/jpip_demo/main_jpip_demo.cpp
+++ b/source/apps/jpip_demo/main_jpip_demo.cpp
@@ -390,18 +390,23 @@ int main(int argc, char **argv) {
                 static_cast<uint32_t>(static_cast<uint64_t>(y) * opt.window_h / std::max(1u, ch));
             if (target_y >= opt.window_h || row_written[target_y]) return;
             row_written[target_y] = 1;
+            // Right-shift samples to 8 bits for display.  For 8-bit sources
+            // (depth=8) the shift is 0 (no-op); for 10/12/16-bit the MSBs
+            // are preserved and the LSBs are discarded.
+            const int32_t shift = (depth.empty() ? 0 : static_cast<int32_t>(depth[0]) - 8);
             uint8_t *dst = rgb.data() + static_cast<std::size_t>(target_y) * opt.window_w * 3u;
             for (uint32_t x_w = 0; x_w < opt.window_w; ++x_w) {
               const uint32_t x_c =
                   static_cast<uint32_t>(static_cast<uint64_t>(x_w) * cw / std::max(1u, opt.window_w));
-              auto clamp_u8 = [](int32_t v) -> uint8_t {
+              auto to_u8 = [shift](int32_t v) -> uint8_t {
+                if (shift > 0) v >>= shift;
                 if (v < 0) return 0;
                 if (v > 255) return 255;
                 return static_cast<uint8_t>(v);
               };
-              dst[3u * x_w + 0] = clamp_u8(rows[0][x_c]);
-              dst[3u * x_w + 1] = clamp_u8(rows[1][x_c]);
-              dst[3u * x_w + 2] = clamp_u8(rows[2][x_c]);
+              dst[3u * x_w + 0] = to_u8(rows[0][x_c]);
+              dst[3u * x_w + 1] = to_u8(rows[1][x_c]);
+              dst[3u * x_w + 2] = to_u8(rows[2][x_c]);
             }
           },
           w, h, depth, sgn);


### PR DESCRIPTION
## Summary

The demo's row callback clamped decoded int32 samples directly to [0, 255] without right-shifting by `(depth − 8)`, so 10/12/16-bit sources saturated to white.  Now shifts before clamping — matching `rtp_recv`'s `rgb_row_to_rgb8`.

Discovered on the new `u01_Books_4K_12bit` asset (3840×2160, 12 bpp, maxval 4095).  8-bit sources are unaffected (shift = 0).

## Test plan

- [x] 12-bit Books 4K asset renders correctly (book spines/text visible, foveation effect clear).
- [x] 8-bit foveation asset still works (46–51 fps, unchanged behaviour).
- [x] 611/611 ctests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)