### PR TITLE
feat(jpip): HTTP request/response formatting (§C.1–C.4, §D.2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,6 +282,11 @@ add_executable(jpip_parser_check)
 add_subdirectory(source/apps/jpip_parser_check)
 target_link_libraries(jpip_parser_check PUBLIC open_htj2k)
 
+# JPIP Phase-3 HTTP request/response formatting self-test
+add_executable(jpip_http_check)
+add_subdirectory(source/apps/jpip_http_check)
+target_link_libraries(jpip_http_check PUBLIC open_htj2k)
+
 # JPIP Phase-2 precinct data-bin + packet-locator self-test
 add_executable(jpip_precinct_check)
 add_subdirectory(source/apps/jpip_precinct_check)

--- a/source/apps/jpip_http_check/CMakeLists.txt
+++ b/source/apps/jpip_http_check/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_policy(SET CMP0076 NEW)
+target_sources(jpip_http_check
+    PRIVATE
+    main.cpp
+)
+target_include_directories(jpip_http_check PRIVATE ${CMAKE_SOURCE_DIR}/source/core/jpip)

--- a/source/apps/jpip_http_check/main.cpp
+++ b/source/apps/jpip_http_check/main.cpp
@@ -1,0 +1,159 @@
+// jpip_http_check: ctest harness for the JPIP request parser + response
+// formatter (Phase 3, S1).
+//
+// Self-contained — runs every test internally, takes no input.
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "jpip_request.hpp"
+#include "jpip_response.hpp"
+
+using open_htj2k::jpip::format_error_response;
+using open_htj2k::jpip::format_jpp_response;
+using open_htj2k::jpip::JpipRequest;
+using open_htj2k::jpip::parse_http_content_length;
+using open_htj2k::jpip::parse_jpip_query;
+using open_htj2k::jpip::RequestParseStatus;
+using open_htj2k::jpip::split_http_get_line;
+using open_htj2k::jpip::ViewWindow;
+
+namespace {
+
+int failures = 0;
+
+#define CHECK(cond, ...)                                            \
+  do {                                                              \
+    if (!(cond)) {                                                  \
+      std::fprintf(stderr, "FAIL [%s:%d] %s — ", __FILE__, __LINE__, #cond); \
+      std::fprintf(stderr, __VA_ARGS__);                            \
+      std::fprintf(stderr, "\n");                                   \
+      ++failures;                                                   \
+    }                                                               \
+  } while (0)
+
+}  // namespace
+
+int main() {
+  // ── split_http_get_line ────────────────────────────────────────────────
+  {
+    std::string path, query;
+    CHECK(split_http_get_line("GET /jpip?fsiz=1920,1080&type=jpp-stream HTTP/1.1", &path, &query),
+          "split basic");
+    CHECK(path == "/jpip", "path='%s'", path.c_str());
+    CHECK(query == "fsiz=1920,1080&type=jpp-stream", "query='%s'", query.c_str());
+
+    CHECK(split_http_get_line("GET /jpip HTTP/1.1", &path, &query), "split no query");
+    CHECK(path == "/jpip", "path='%s'", path.c_str());
+    CHECK(query.empty(), "query should be empty");
+
+    CHECK(!split_http_get_line("POST /foo HTTP/1.1", &path, &query), "reject POST");
+    CHECK(!split_http_get_line("", &path, &query), "reject empty");
+  }
+
+  // ── parse_jpip_query: full request ─────────────────────────────────────
+  {
+    JpipRequest req;
+    auto s = parse_jpip_query(
+        "target=image.j2c&fsiz=1920,1080,round-up&roff=400,300&rsiz=500,500"
+        "&comps=0,1,2&type=jpp-stream", &req);
+    CHECK(s == RequestParseStatus::Ok, "status=%d", static_cast<int>(s));
+    CHECK(req.target == "image.j2c", "target='%s'", req.target.c_str());
+    CHECK(req.has_fsiz, "has_fsiz");
+    CHECK(req.view_window.fx == 1920, "fx=%u", req.view_window.fx);
+    CHECK(req.view_window.fy == 1080, "fy=%u", req.view_window.fy);
+    CHECK(req.view_window.round == ViewWindow::Round::Up, "round");
+    CHECK(req.has_roff, "has_roff");
+    CHECK(req.view_window.ox == 400, "ox=%u", req.view_window.ox);
+    CHECK(req.view_window.oy == 300, "oy=%u", req.view_window.oy);
+    CHECK(req.has_rsiz, "has_rsiz");
+    CHECK(req.view_window.sx == 500, "sx=%u", req.view_window.sx);
+    CHECK(req.view_window.sy == 500, "sy=%u", req.view_window.sy);
+    CHECK(req.has_comps, "has_comps");
+    CHECK(req.view_window.comps.size() == 3, "comps size=%zu", req.view_window.comps.size());
+    CHECK(req.type == "jpp-stream", "type='%s'", req.type.c_str());
+  }
+
+  // ── parse_jpip_query: minimal (fsiz only) ──────────────────────────────
+  {
+    JpipRequest req;
+    auto s = parse_jpip_query("?fsiz=960,960", &req);
+    CHECK(s == RequestParseStatus::Ok, "status=%d", static_cast<int>(s));
+    CHECK(req.view_window.fx == 960, "fx=%u", req.view_window.fx);
+    CHECK(req.view_window.round == ViewWindow::Round::Down, "default round");
+    CHECK(!req.has_roff && !req.has_rsiz && !req.has_comps, "no optional fields");
+  }
+
+  // ── parse_jpip_query: round-down explicit ──────────────────────────────
+  {
+    JpipRequest req;
+    auto s = parse_jpip_query("fsiz=480,270,round-down", &req);
+    CHECK(s == RequestParseStatus::Ok, "status=%d", static_cast<int>(s));
+    CHECK(req.view_window.fx == 480, "fx");
+    CHECK(req.view_window.fy == 270, "fy");
+    CHECK(req.view_window.round == ViewWindow::Round::Down, "round-down");
+  }
+
+  // ── parse_jpip_query: closest ──────────────────────────────────────────
+  {
+    JpipRequest req;
+    auto s = parse_jpip_query("fsiz=800,600,closest", &req);
+    CHECK(s == RequestParseStatus::Ok, "status=%d", static_cast<int>(s));
+    CHECK(req.view_window.round == ViewWindow::Round::Closest, "closest");
+  }
+
+  // ── parse_jpip_query: unsupported type ──────────────────────────────────
+  {
+    JpipRequest req;
+    auto s = parse_jpip_query("fsiz=100,100&type=jpt-stream", &req);
+    CHECK(s == RequestParseStatus::UnsupportedType, "type");
+  }
+
+  // ── parse_jpip_query: malformed fsiz ────────────────────────────────────
+  {
+    JpipRequest req;
+    auto s = parse_jpip_query("fsiz=abc", &req);
+    CHECK(s == RequestParseStatus::MalformedField, "malformed fsiz");
+  }
+
+  // ── parse_jpip_query: unknown fields silently ignored ──────────────────
+  {
+    JpipRequest req;
+    auto s = parse_jpip_query("fsiz=100,200&foo=bar&baz=1", &req);
+    CHECK(s == RequestParseStatus::Ok, "unknown fields accepted");
+    CHECK(req.view_window.fx == 100, "fx after unknown");
+  }
+
+  // ── format + parse round-trip ──────────────────────────────────────────
+  {
+    const uint8_t body[] = {0xDE, 0xAD, 0xBE, 0xEF};
+    auto resp = format_jpp_response(body, 4, "mytarget");
+    // Parse Content-Length back.
+    std::size_t hdr_end = 0;
+    const std::size_t cl = parse_http_content_length(resp.data(), resp.size(), &hdr_end);
+    CHECK(cl == 4, "Content-Length=%zu", cl);
+    CHECK(hdr_end + 4 == resp.size(), "total=%zu hdr_end=%zu", resp.size(), hdr_end);
+    CHECK(std::memcmp(resp.data() + hdr_end, body, 4) == 0, "body mismatch");
+    // Check JPIP-tid header is present.
+    std::string hdr_str(resp.begin(), resp.begin() + static_cast<std::ptrdiff_t>(hdr_end));
+    CHECK(hdr_str.find("JPIP-tid: mytarget") != std::string::npos, "JPIP-tid missing");
+    CHECK(hdr_str.find("image/jpp-stream") != std::string::npos, "Content-Type missing");
+  }
+
+  // ── error response ─────────────────────────────────────────────────────
+  {
+    auto resp = format_error_response(404, "Not Found");
+    std::string s(resp.begin(), resp.end());
+    CHECK(s.find("404 Not Found") != std::string::npos, "404");
+    CHECK(s.find("Content-Length: 0") != std::string::npos, "empty body");
+  }
+
+  if (failures == 0) {
+    std::printf("OK http_check: request/response formatting all pass\n");
+    return 0;
+  }
+  std::fprintf(stderr, "http_check: %d failures\n", failures);
+  return 1;
+}

--- a/source/core/jpip/CMakeLists.txt
+++ b/source/core/jpip/CMakeLists.txt
@@ -10,4 +10,6 @@ target_sources(open_htj2k
     jpp_parser.cpp
     packet_locator.cpp
     codestream_assembler.cpp
+    jpip_request.cpp
+    jpip_response.cpp
 )

--- a/source/core/jpip/jpip_request.cpp
+++ b/source/core/jpip/jpip_request.cpp
@@ -1,0 +1,137 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+
+#include "jpip_request.hpp"
+
+#include <cstdlib>
+
+namespace open_htj2k {
+namespace jpip {
+
+namespace {
+
+// Split "key=val" pairs from a '&'-delimited query string.  Calls fn
+// with each (key, val) pair; val may be empty.
+template <typename Fn>
+void for_each_param(const std::string &query, Fn &&fn) {
+  std::size_t pos = 0;
+  while (pos < query.size()) {
+    const std::size_t amp = query.find('&', pos);
+    const std::string param = query.substr(pos, amp == std::string::npos ? std::string::npos : amp - pos);
+    pos = (amp == std::string::npos) ? query.size() : amp + 1;
+    if (param.empty()) continue;
+    const std::size_t eq = param.find('=');
+    if (eq == std::string::npos) {
+      fn(param, std::string());
+    } else {
+      fn(param.substr(0, eq), param.substr(eq + 1));
+    }
+  }
+}
+
+// Parse "N,M" into two uint32_t values.  Returns false on any syntax error.
+bool parse_pair(const std::string &val, uint32_t &a, uint32_t &b) {
+  const std::size_t comma = val.find(',');
+  if (comma == std::string::npos) return false;
+  char *end = nullptr;
+  a = static_cast<uint32_t>(std::strtoul(val.c_str(), &end, 10));
+  if (end != val.c_str() + comma) return false;
+  b = static_cast<uint32_t>(std::strtoul(val.c_str() + comma + 1, &end, 10));
+  if (*end != '\0') return false;
+  return true;
+}
+
+}  // namespace
+
+RequestParseStatus parse_jpip_query(const std::string &query_in, JpipRequest *out) {
+  if (!out) return RequestParseStatus::EmptyQuery;
+  *out = {};
+  std::string query = query_in;
+  if (!query.empty() && query[0] == '?') query = query.substr(1);
+  if (query.empty()) return RequestParseStatus::EmptyQuery;
+
+  RequestParseStatus status = RequestParseStatus::Ok;
+  for_each_param(query, [&](const std::string &key, const std::string &val) {
+    if (status != RequestParseStatus::Ok) return;
+
+    if (key == "target") {
+      out->target = val;
+    } else if (key == "fsiz") {
+      // "fx,fy[,round-direction]"
+      // Split on first comma to get fx, then check for a second comma.
+      const std::size_t c1 = val.find(',');
+      if (c1 == std::string::npos) { status = RequestParseStatus::MalformedField; return; }
+      const std::size_t c2 = val.find(',', c1 + 1);
+      char *end = nullptr;
+      out->view_window.fx = static_cast<uint32_t>(std::strtoul(val.c_str(), &end, 10));
+      if (end != val.c_str() + c1) { status = RequestParseStatus::MalformedField; return; }
+      if (c2 == std::string::npos) {
+        out->view_window.fy = static_cast<uint32_t>(std::strtoul(val.c_str() + c1 + 1, &end, 10));
+        if (*end != '\0') { status = RequestParseStatus::MalformedField; return; }
+      } else {
+        out->view_window.fy = static_cast<uint32_t>(std::strtoul(val.c_str() + c1 + 1, &end, 10));
+        if (end != val.c_str() + c2) { status = RequestParseStatus::MalformedField; return; }
+        const std::string rd = val.substr(c2 + 1);
+        if (rd == "round-up")        out->view_window.round = ViewWindow::Round::Up;
+        else if (rd == "round-down")  out->view_window.round = ViewWindow::Round::Down;
+        else if (rd == "closest")     out->view_window.round = ViewWindow::Round::Closest;
+        else { status = RequestParseStatus::MalformedField; return; }
+      }
+      out->has_fsiz = true;
+    } else if (key == "roff") {
+      if (!parse_pair(val, out->view_window.ox, out->view_window.oy)) {
+        status = RequestParseStatus::MalformedField; return;
+      }
+      out->has_roff = true;
+    } else if (key == "rsiz") {
+      if (!parse_pair(val, out->view_window.sx, out->view_window.sy)) {
+        status = RequestParseStatus::MalformedField; return;
+      }
+      out->has_rsiz = true;
+    } else if (key == "comps") {
+      // Comma-separated uint16 list, e.g. "0,1,2" or "0-2".
+      // v1: only comma-separated individual indices.
+      out->view_window.comps.clear();
+      std::size_t p = 0;
+      while (p < val.size()) {
+        const std::size_t c = val.find(',', p);
+        const std::string item = val.substr(p, c == std::string::npos ? std::string::npos : c - p);
+        if (!item.empty()) {
+          out->view_window.comps.push_back(static_cast<uint16_t>(std::strtoul(item.c_str(), nullptr, 10)));
+        }
+        p = (c == std::string::npos) ? val.size() : c + 1;
+      }
+      out->has_comps = true;
+    } else if (key == "type") {
+      out->type = val;
+      if (val != "jpp-stream") {
+        status = RequestParseStatus::UnsupportedType;
+        return;
+      }
+    }
+    // Unknown keys are silently ignored per §C.1.
+  });
+
+  return status;
+}
+
+bool split_http_get_line(const std::string &line, std::string *path, std::string *query) {
+  // Expect "GET /path?query HTTP/1.x"
+  if (line.size() < 14) return false;  // "GET / HTTP/1.1" minimum
+  if (line.substr(0, 4) != "GET ") return false;
+  const std::size_t sp = line.find(' ', 4);
+  if (sp == std::string::npos) return false;
+  const std::string uri = line.substr(4, sp - 4);
+  const std::size_t qm = uri.find('?');
+  if (qm == std::string::npos) {
+    if (path) *path = uri;
+    if (query) query->clear();
+  } else {
+    if (path) *path = uri.substr(0, qm);
+    if (query) *query = uri.substr(qm + 1);
+  }
+  return true;
+}
+
+}  // namespace jpip
+}  // namespace open_htj2k

--- a/source/core/jpip/jpip_request.hpp
+++ b/source/core/jpip/jpip_request.hpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+//
+// JPIP request parser — extracts view-window parameters from an HTTP GET
+// query string per ISO/IEC 15444-9 §C.1–C.4.
+//
+// A typical JPIP request URL looks like:
+//
+//   GET /jpip?target=image.j2c&fsiz=1920,1080&roff=400,300&rsiz=500,500
+//             &type=jpp-stream HTTP/1.1
+//
+// This module parses the query-string portion (after '?') into a
+// ViewWindow plus an optional target filename.  Only the fields needed
+// for Phase 3 v1 stateless delivery are supported.
+#pragma once
+#include <cstdint>
+#include <string>
+
+#include "view_window.hpp"
+
+#if defined(_MSC_VER) && !defined(OHTJ2K_STATIC)
+  #define OPENHTJ2K_JPIP_EXPORT __declspec(dllexport)
+#else
+  #define OPENHTJ2K_JPIP_EXPORT
+#endif
+
+namespace open_htj2k {
+namespace jpip {
+
+struct JpipRequest {
+  std::string target;       // §C.2.1: filename / resource identifier
+  ViewWindow  view_window;
+  bool        has_fsiz   = false;
+  bool        has_roff   = false;
+  bool        has_rsiz   = false;
+  bool        has_comps  = false;
+  // §C.4 Table C.4: image return type.  Must be "jpp-stream" for our use.
+  std::string type;
+};
+
+enum class RequestParseStatus : uint8_t {
+  Ok                  = 0,
+  EmptyQuery          = 1,
+  UnsupportedType     = 2,  // type != "jpp-stream"
+  MalformedField      = 3,  // bad syntax in a known field
+  UnknownField        = 4,  // unrecognised key (informational)
+};
+
+// Parse a query string ("key=val&key=val&...") into a JpipRequest.
+// Leading '?' is accepted and stripped.  Unknown fields are silently
+// ignored (per §C.1: "A server shall ignore request fields it does not
+// recognize").  Returns Ok on success; on failure the request is
+// partially populated and the status indicates the first problem.
+OPENHTJ2K_JPIP_EXPORT RequestParseStatus
+parse_jpip_query(const std::string &query, JpipRequest *out);
+
+// Extract the query-string portion from a full HTTP request line
+// ("GET /path?query HTTP/1.1") and also the path.  Returns false if
+// the line is not a valid GET request.
+OPENHTJ2K_JPIP_EXPORT bool
+split_http_get_line(const std::string &request_line,
+                    std::string *path, std::string *query);
+
+}  // namespace jpip
+}  // namespace open_htj2k

--- a/source/core/jpip/jpip_response.cpp
+++ b/source/core/jpip/jpip_response.cpp
@@ -1,0 +1,85 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+
+#include "jpip_response.hpp"
+
+#include <cstdio>
+#include <cstring>
+
+namespace open_htj2k {
+namespace jpip {
+
+std::vector<uint8_t> format_jpp_response(const uint8_t *body, std::size_t body_len,
+                                         const std::string &target_id) {
+  char header[512];
+  int n = std::snprintf(header, sizeof(header),
+                        "HTTP/1.1 200 OK\r\n"
+                        "Content-Type: image/jpp-stream\r\n"
+                        "Content-Length: %zu\r\n"
+                        "Connection: close\r\n",
+                        body_len);
+  std::vector<uint8_t> out;
+  out.reserve(static_cast<std::size_t>(n) + target_id.size() + 32 + body_len);
+  out.insert(out.end(), reinterpret_cast<const uint8_t *>(header),
+             reinterpret_cast<const uint8_t *>(header) + n);
+  if (!target_id.empty()) {
+    char tid[256];
+    int tn = std::snprintf(tid, sizeof(tid), "JPIP-tid: %s\r\n", target_id.c_str());
+    out.insert(out.end(), reinterpret_cast<const uint8_t *>(tid),
+               reinterpret_cast<const uint8_t *>(tid) + tn);
+  }
+  out.push_back('\r');
+  out.push_back('\n');
+  if (body != nullptr && body_len > 0) {
+    out.insert(out.end(), body, body + body_len);
+  }
+  return out;
+}
+
+std::vector<uint8_t> format_error_response(int http_status, const std::string &reason) {
+  char buf[512];
+  int n = std::snprintf(buf, sizeof(buf),
+                        "HTTP/1.1 %d %s\r\n"
+                        "Content-Length: 0\r\n"
+                        "Connection: close\r\n"
+                        "\r\n",
+                        http_status, reason.c_str());
+  return {reinterpret_cast<const uint8_t *>(buf),
+          reinterpret_cast<const uint8_t *>(buf) + n};
+}
+
+std::size_t parse_http_content_length(const uint8_t *data, std::size_t len,
+                                      std::size_t *header_end_out) {
+  // Find "\r\n\r\n" boundary.
+  const char *s = reinterpret_cast<const char *>(data);
+  const char *end = s + len;
+  const char *boundary = nullptr;
+  for (const char *p = s; p + 4 <= end; ++p) {
+    if (p[0] == '\r' && p[1] == '\n' && p[2] == '\r' && p[3] == '\n') {
+      boundary = p;
+      break;
+    }
+  }
+  if (!boundary) return SIZE_MAX;
+  if (header_end_out) *header_end_out = static_cast<std::size_t>(boundary - s) + 4;
+
+  // Scan headers for "Content-Length: N".
+  for (const char *line = s; line < boundary;) {
+    const char *eol = static_cast<const char *>(std::memchr(line, '\n', static_cast<std::size_t>(boundary - line)));
+    if (!eol) eol = boundary;
+    const std::size_t line_len = static_cast<std::size_t>(eol - line);
+    if (line_len > 16 &&
+        (line[0] == 'C' || line[0] == 'c') &&
+        (std::strncmp(line, "Content-Length:", 15) == 0 ||
+         std::strncmp(line, "content-length:", 15) == 0)) {
+      const char *val = line + 15;
+      while (val < eol && (*val == ' ' || *val == '\t')) ++val;
+      return static_cast<std::size_t>(std::strtoull(val, nullptr, 10));
+    }
+    line = eol + 1;
+  }
+  return SIZE_MAX;
+}
+
+}  // namespace jpip
+}  // namespace open_htj2k

--- a/source/core/jpip/jpip_response.hpp
+++ b/source/core/jpip/jpip_response.hpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+//
+// JPIP HTTP/1.1 response formatting per ISO/IEC 15444-9 §D.2 + Annex F.
+#pragma once
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#if defined(_MSC_VER) && !defined(OHTJ2K_STATIC)
+  #define OPENHTJ2K_JPIP_EXPORT __declspec(dllexport)
+#else
+  #define OPENHTJ2K_JPIP_EXPORT
+#endif
+
+namespace open_htj2k {
+namespace jpip {
+
+// Format a complete HTTP/1.1 response (headers + body) for a JPP-stream
+// payload.  `target_id` is the JPIP-tid response header (§D.2.3); an
+// empty string omits the header.  The response uses Connection: close
+// for v1 simplicity.
+OPENHTJ2K_JPIP_EXPORT std::vector<uint8_t>
+format_jpp_response(const uint8_t *body, std::size_t body_len,
+                    const std::string &target_id = "");
+
+// Format a simple error response (no body).
+OPENHTJ2K_JPIP_EXPORT std::vector<uint8_t>
+format_error_response(int http_status, const std::string &reason);
+
+// Parse the Content-Length from an HTTP response header block.  Returns
+// the body length if found, or SIZE_MAX if not parseable.  Also reports
+// the offset of the first byte after the blank line ("\r\n\r\n") that
+// separates headers from body.
+OPENHTJ2K_JPIP_EXPORT std::size_t
+parse_http_content_length(const uint8_t *data, std::size_t len,
+                          std::size_t *header_end_out);
+
+}  // namespace jpip
+}  // namespace open_htj2k

--- a/tests/jpip_phase1.cmake
+++ b/tests/jpip_phase1.cmake
@@ -11,6 +11,9 @@ set(_JPIP_BIN_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 # Self-contained: round-trip / interop / reject cases live inside the exe.
 add_test(NAME jpip_vbas_codec COMMAND jpip_vbas_check)
 
+# ── JPIP HTTP request/response formatting (§C.1–C.4, §D.2) ──
+add_test(NAME jpip_http_format COMMAND jpip_http_check)
+
 # ── JPP-stream message header codec (§A.2 + Tables A.1, A.2) ──
 # Self-contained: round-trip + spec §A.3.2.2 byte-identical interop +
 # dependent-form behaviour + rejection cases.


### PR DESCRIPTION
## Summary

S1 of `PHASE3_PLAN.md`.  Application-layer framing for JPIP over HTTP/1.1: query-string parser + response formatter.

**`jpip_request.{hpp,cpp}`** — `parse_jpip_query("fsiz=W,H&roff=X,Y&rsiz=W,H&comps=0,1,2&type=jpp-stream", &req)` → `JpipRequest{target, ViewWindow, has_* flags, type}`.  Plus `split_http_get_line("GET /path?query HTTP/1.1", &path, &query)`.

**`jpip_response.{hpp,cpp}`** — `format_jpp_response(body, len, tid)` → complete HTTP/1.1 200 response.  `format_error_response(status, reason)` → 4xx/5xx.  `parse_http_content_length(data, len, &hdr_end)` for client-side response parsing.

## Test plan

- [x] New ctest `jpip_http_format` runs `jpip_http_check` with: GET line splitting, full/minimal/round-direction query parsing, type rejection, malformed-field rejection, unknown-field tolerance, format+parse Content-Length round-trip, error response formatting.
- [x] **612/612 ctests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)