### PR TITLE
feat(jpip): cross-platform TCP socket wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,10 @@ if (NOT EMSCRIPTEN)
     message(STATUS "OPENHTJ2K_TIFF_SUPPORT is set ")
     set(PKG_CONFIG_REQUIRES "libtiff")
   endif()
+  # JPIP TCP socket wrapper (source/core/jpip/tcp_socket.cpp) uses Winsock2.
+  if(WIN32)
+    target_link_libraries(open_htj2k PUBLIC ws2_32)
+  endif()
 endif()
 
 # Compiler optimization settings
@@ -286,6 +290,14 @@ target_link_libraries(jpip_parser_check PUBLIC open_htj2k)
 add_executable(jpip_http_check)
 add_subdirectory(source/apps/jpip_http_check)
 target_link_libraries(jpip_http_check PUBLIC open_htj2k)
+
+# JPIP Phase-3 TCP socket wrapper self-test
+add_executable(jpip_tcp_check)
+add_subdirectory(source/apps/jpip_tcp_check)
+target_link_libraries(jpip_tcp_check PUBLIC open_htj2k)
+if(WIN32)
+  target_link_libraries(jpip_tcp_check PUBLIC ws2_32)
+endif()
 
 # JPIP Phase-2 precinct data-bin + packet-locator self-test
 add_executable(jpip_precinct_check)

--- a/source/apps/jpip_tcp_check/CMakeLists.txt
+++ b/source/apps/jpip_tcp_check/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_policy(SET CMP0076 NEW)
+target_sources(jpip_tcp_check
+    PRIVATE
+    main.cpp
+)
+target_include_directories(jpip_tcp_check PRIVATE ${CMAKE_SOURCE_DIR}/source/core/jpip)

--- a/source/apps/jpip_tcp_check/main.cpp
+++ b/source/apps/jpip_tcp_check/main.cpp
@@ -1,0 +1,113 @@
+// jpip_tcp_check: ctest harness for the TCP socket wrapper.
+//
+// Spawns a listener on a localhost port, connects a client, sends a
+// payload, receives it on the server side, and echoes it back.
+// Verifies byte-identical round-trip.
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <thread>
+#include <vector>
+
+#include "tcp_socket.hpp"
+
+using open_htj2k::jpip::TcpListener;
+using open_htj2k::jpip::TcpStream;
+using open_htj2k::jpip::tcp_wsa_cleanup;
+using open_htj2k::jpip::tcp_wsa_init;
+
+namespace {
+
+int failures = 0;
+
+#define CHECK(cond, ...)                                            \
+  do {                                                              \
+    if (!(cond)) {                                                  \
+      std::fprintf(stderr, "FAIL [%s:%d] %s — ", __FILE__, __LINE__, #cond); \
+      std::fprintf(stderr, __VA_ARGS__);                            \
+      std::fprintf(stderr, "\n");                                   \
+      ++failures;                                                   \
+    }                                                               \
+  } while (0)
+
+}  // namespace
+
+int main() {
+  tcp_wsa_init();
+
+  constexpr uint16_t kPort = 0;  // 0 = let OS pick an ephemeral port
+
+  // Use a fixed port for simplicity (ephemeral port selection would
+  // require getsockname).  Pick something unlikely to collide.
+  constexpr uint16_t kTestPort = 19283;
+
+  // ── Server thread: accept one connection, echo the payload back ────
+  std::vector<uint8_t> server_got;
+  bool server_ok = false;
+  std::thread server_thread([&]() {
+    TcpListener listener;
+    if (!listener.bind(kTestPort, "127.0.0.1")) {
+      std::fprintf(stderr, "server bind: %s\n", listener.last_error().c_str());
+      return;
+    }
+    if (!listener.listen()) {
+      std::fprintf(stderr, "server listen: %s\n", listener.last_error().c_str());
+      return;
+    }
+    TcpStream conn = listener.accept();
+    if (!conn.is_open()) {
+      std::fprintf(stderr, "server accept: %s\n", listener.last_error().c_str());
+      return;
+    }
+    // Read a 4-byte length prefix, then that many bytes.
+    uint8_t len_buf[4];
+    if (!conn.recv_all(len_buf, 4)) return;
+    const uint32_t payload_len =
+        (static_cast<uint32_t>(len_buf[0]) << 24) | (static_cast<uint32_t>(len_buf[1]) << 16) |
+        (static_cast<uint32_t>(len_buf[2]) << 8)  |  static_cast<uint32_t>(len_buf[3]);
+    server_got.resize(payload_len);
+    if (!conn.recv_all(server_got.data(), payload_len)) return;
+    // Echo back.
+    if (!conn.send_all(server_got.data(), payload_len)) return;
+    server_ok = true;
+  });
+
+  // Give the server thread a moment to bind+listen.
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+  // ── Client: connect, send, receive echo ────────────────────────────
+  {
+    TcpStream client;
+    CHECK(client.connect("127.0.0.1", kTestPort), "client connect: %s",
+          client.last_error().c_str());
+    if (failures) { server_thread.join(); tcp_wsa_cleanup(); return 1; }
+
+    const std::vector<uint8_t> payload = {0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE};
+    const uint32_t plen = static_cast<uint32_t>(payload.size());
+    const uint8_t len_buf[4] = {
+        static_cast<uint8_t>((plen >> 24) & 0xFF),
+        static_cast<uint8_t>((plen >> 16) & 0xFF),
+        static_cast<uint8_t>((plen >> 8) & 0xFF),
+        static_cast<uint8_t>(plen & 0xFF),
+    };
+    CHECK(client.send_all(len_buf, 4), "send length");
+    CHECK(client.send_all(payload.data(), payload.size()), "send payload");
+
+    std::vector<uint8_t> echo(payload.size());
+    CHECK(client.recv_all(echo.data(), echo.size()), "recv echo");
+    CHECK(echo == payload, "echo mismatch");
+  }
+
+  server_thread.join();
+  CHECK(server_ok, "server thread reported failure");
+  CHECK(server_got.size() == 6, "server got %zu bytes", server_got.size());
+
+  tcp_wsa_cleanup();
+
+  if (failures == 0) {
+    std::printf("OK tcp_check: loopback send/recv round-trip\n");
+    return 0;
+  }
+  std::fprintf(stderr, "tcp_check: %d failures\n", failures);
+  return 1;
+}

--- a/source/core/jpip/CMakeLists.txt
+++ b/source/core/jpip/CMakeLists.txt
@@ -12,4 +12,5 @@ target_sources(open_htj2k
     codestream_assembler.cpp
     jpip_request.cpp
     jpip_response.cpp
+    tcp_socket.cpp
 )

--- a/source/core/jpip/tcp_socket.cpp
+++ b/source/core/jpip/tcp_socket.cpp
@@ -1,0 +1,189 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+
+#include "tcp_socket.hpp"
+
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+
+#ifndef _WIN32
+  #include <arpa/inet.h>
+  #include <netdb.h>
+  #include <netinet/in.h>
+  #include <sys/socket.h>
+  #include <unistd.h>
+#endif
+
+namespace open_htj2k {
+namespace jpip {
+
+namespace {
+
+#ifdef _WIN32
+std::string sock_error_str() {
+  int e = WSAGetLastError();
+  char buf[256] = {};
+  FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, static_cast<DWORD>(e), 0,
+                 buf, sizeof(buf), nullptr);
+  return std::string(buf);
+}
+inline void close_socket(tcp_socket_t fd) { closesocket(fd); }
+#else
+std::string sock_error_str() { return std::strerror(errno); }
+inline void close_socket(tcp_socket_t fd) { ::close(fd); }
+#endif
+
+}  // namespace
+
+bool tcp_wsa_init() {
+#ifdef _WIN32
+  WSADATA wd;
+  return WSAStartup(MAKEWORD(2, 2), &wd) == 0;
+#else
+  return true;
+#endif
+}
+
+void tcp_wsa_cleanup() {
+#ifdef _WIN32
+  WSACleanup();
+#endif
+}
+
+// ── TcpListener ──────────────────────────────────────────────────────────
+
+TcpListener::~TcpListener() { close(); }
+
+bool TcpListener::bind(uint16_t port, const std::string &host) {
+  close();
+  fd_ = ::socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+  if (fd_ == kTcpInvalidSocket) { err_ = sock_error_str(); return false; }
+  int opt = 1;
+  setsockopt(fd_, SOL_SOCKET, SO_REUSEADDR,
+             reinterpret_cast<const char *>(&opt), sizeof(opt));
+  struct sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_port   = htons(port);
+  if (host.empty() || host == "0.0.0.0") {
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  } else {
+    inet_pton(AF_INET, host.c_str(), &addr.sin_addr);
+  }
+  if (::bind(fd_, reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr)) != 0) {
+    err_ = sock_error_str();
+    close();
+    return false;
+  }
+  return true;
+}
+
+bool TcpListener::listen(int backlog) {
+  if (fd_ == kTcpInvalidSocket) { err_ = "not bound"; return false; }
+  if (::listen(fd_, backlog) != 0) { err_ = sock_error_str(); return false; }
+  return true;
+}
+
+TcpStream TcpListener::accept() {
+  if (fd_ == kTcpInvalidSocket) { err_ = "not bound"; return {}; }
+  struct sockaddr_in client_addr{};
+  socklen_t client_len = sizeof(client_addr);
+  tcp_socket_t cfd = ::accept(fd_, reinterpret_cast<struct sockaddr *>(&client_addr),
+                              &client_len);
+  if (cfd == kTcpInvalidSocket) { err_ = sock_error_str(); return {}; }
+  return TcpStream(cfd);
+}
+
+void TcpListener::close() {
+  if (fd_ != kTcpInvalidSocket) { close_socket(fd_); fd_ = kTcpInvalidSocket; }
+}
+
+// ── TcpStream ────────────────────────────────────────────────────────────
+
+TcpStream::~TcpStream() { close(); }
+
+TcpStream &TcpStream::operator=(TcpStream &&o) noexcept {
+  if (this != &o) {
+    close();
+    fd_  = o.fd_;
+    err_ = std::move(o.err_);
+    o.fd_ = kTcpInvalidSocket;
+  }
+  return *this;
+}
+
+bool TcpStream::connect(const std::string &host, uint16_t port) {
+  close();
+  struct addrinfo hints{}, *res = nullptr;
+  hints.ai_family   = AF_INET;
+  hints.ai_socktype = SOCK_STREAM;
+  char port_str[8];
+  std::snprintf(port_str, sizeof(port_str), "%u", port);
+  if (getaddrinfo(host.c_str(), port_str, &hints, &res) != 0 || !res) {
+    err_ = "getaddrinfo failed: " + sock_error_str();
+    return false;
+  }
+  fd_ = ::socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+  if (fd_ == kTcpInvalidSocket) { err_ = sock_error_str(); freeaddrinfo(res); return false; }
+  if (::connect(fd_, res->ai_addr, static_cast<socklen_t>(res->ai_addrlen)) != 0) {
+    err_ = sock_error_str();
+    close();
+    freeaddrinfo(res);
+    return false;
+  }
+  freeaddrinfo(res);
+  return true;
+}
+
+bool TcpStream::send_all(const uint8_t *buf, std::size_t len) {
+  std::size_t sent = 0;
+  while (sent < len) {
+    auto n = ::send(fd_, reinterpret_cast<const char *>(buf + sent),
+                    static_cast<int>(len - sent), 0);
+    if (n <= 0) { err_ = sock_error_str(); return false; }
+    sent += static_cast<std::size_t>(n);
+  }
+  return true;
+}
+
+bool TcpStream::recv_all(uint8_t *buf, std::size_t len) {
+  std::size_t got = 0;
+  while (got < len) {
+    auto n = ::recv(fd_, reinterpret_cast<char *>(buf + got),
+                    static_cast<int>(len - got), 0);
+    if (n <= 0) { err_ = (n == 0) ? "EOF" : sock_error_str(); return false; }
+    got += static_cast<std::size_t>(n);
+  }
+  return true;
+}
+
+std::size_t TcpStream::recv_until_header_end(std::vector<uint8_t> &buf,
+                                             std::size_t max_bytes) {
+  buf.clear();
+  uint8_t tmp[4096];
+  while (buf.size() < max_bytes) {
+    auto chunk = std::min<std::size_t>(sizeof(tmp), max_bytes - buf.size());
+    auto n = ::recv(fd_, reinterpret_cast<char *>(tmp), static_cast<int>(chunk), 0);
+    if (n <= 0) return buf.size();  // EOF or error
+    buf.insert(buf.end(), tmp, tmp + n);
+    // Check for "\r\n\r\n" in the last few bytes.
+    if (buf.size() >= 4) {
+      for (std::size_t i = (buf.size() > static_cast<std::size_t>(n) + 3)
+                               ? (buf.size() - static_cast<std::size_t>(n) - 3)
+                               : 0;
+           i + 4 <= buf.size(); ++i) {
+        if (buf[i] == '\r' && buf[i + 1] == '\n' && buf[i + 2] == '\r' && buf[i + 3] == '\n') {
+          return buf.size();
+        }
+      }
+    }
+  }
+  return buf.size();
+}
+
+void TcpStream::close() {
+  if (fd_ != kTcpInvalidSocket) { close_socket(fd_); fd_ = kTcpInvalidSocket; }
+}
+
+}  // namespace jpip
+}  // namespace open_htj2k

--- a/source/core/jpip/tcp_socket.hpp
+++ b/source/core/jpip/tcp_socket.hpp
@@ -1,0 +1,101 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+//
+// Cross-platform TCP socket wrapper for JPIP HTTP/1.1 transport.
+// Modelled after source/apps/rtp_recv/rtp_socket.hpp but for TCP
+// (stream-oriented, connection-based) instead of UDP (datagram).
+//
+// Provides two classes:
+//
+//   TcpListener  — server side: bind(), listen(), accept() → TcpStream.
+//   TcpStream    — bidirectional byte stream: connect(), send_all(),
+//                  recv_all(), recv_until().
+//
+// On Windows the caller must call tcp_wsa_init() once before creating
+// any socket and tcp_wsa_cleanup() before exit (mirroring UdpSocket's
+// pattern).  On POSIX these are no-ops.
+#pragma once
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+  #ifndef WIN32_LEAN_AND_MEAN
+    #define WIN32_LEAN_AND_MEAN
+  #endif
+  #include <winsock2.h>
+  #include <ws2tcpip.h>
+  using tcp_socket_t = SOCKET;
+  constexpr tcp_socket_t kTcpInvalidSocket = INVALID_SOCKET;
+#else
+  using tcp_socket_t = int;
+  constexpr tcp_socket_t kTcpInvalidSocket = -1;
+#endif
+
+#if defined(_MSC_VER) && !defined(OHTJ2K_STATIC)
+  #define OPENHTJ2K_JPIP_EXPORT __declspec(dllexport)
+#else
+  #define OPENHTJ2K_JPIP_EXPORT
+#endif
+
+namespace open_htj2k {
+namespace jpip {
+
+OPENHTJ2K_JPIP_EXPORT bool tcp_wsa_init();
+OPENHTJ2K_JPIP_EXPORT void tcp_wsa_cleanup();
+
+class TcpStream;
+
+class OPENHTJ2K_JPIP_EXPORT TcpListener {
+ public:
+  TcpListener() = default;
+  ~TcpListener();
+  TcpListener(const TcpListener &)            = delete;
+  TcpListener &operator=(const TcpListener &) = delete;
+
+  bool bind(uint16_t port, const std::string &host = "");
+  bool listen(int backlog = 8);
+  // Block until a client connects.  Returns a connected TcpStream.
+  // On error the returned stream is not open (check is_open()).
+  TcpStream accept();
+  void close();
+  bool is_open() const { return fd_ != kTcpInvalidSocket; }
+  const std::string &last_error() const { return err_; }
+
+ private:
+  tcp_socket_t fd_ = kTcpInvalidSocket;
+  std::string  err_;
+};
+
+class OPENHTJ2K_JPIP_EXPORT TcpStream {
+ public:
+  TcpStream() = default;
+  explicit TcpStream(tcp_socket_t fd) : fd_(fd) {}
+  ~TcpStream();
+  TcpStream(const TcpStream &)            = delete;
+  TcpStream &operator=(const TcpStream &) = delete;
+  TcpStream(TcpStream &&o) noexcept : fd_(o.fd_), err_(std::move(o.err_)) { o.fd_ = kTcpInvalidSocket; }
+  TcpStream &operator=(TcpStream &&o) noexcept;
+
+  bool connect(const std::string &host, uint16_t port);
+  // Send exactly `len` bytes.  Returns true on success.
+  bool send_all(const uint8_t *buf, std::size_t len);
+  bool send_all(const std::vector<uint8_t> &v) { return send_all(v.data(), v.size()); }
+  // Receive exactly `len` bytes.  Returns true on success.
+  bool recv_all(uint8_t *buf, std::size_t len);
+  // Read until the buffer contains the 4-byte pattern "\r\n\r\n" (HTTP
+  // header terminator) or `max_bytes` have been read.  Returns the total
+  // bytes accumulated in `buf`.  Returns 0 on EOF / error.
+  std::size_t recv_until_header_end(std::vector<uint8_t> &buf, std::size_t max_bytes = 65536);
+  void close();
+  bool is_open() const { return fd_ != kTcpInvalidSocket; }
+  const std::string &last_error() const { return err_; }
+
+ private:
+  tcp_socket_t fd_ = kTcpInvalidSocket;
+  std::string  err_;
+};
+
+}  // namespace jpip
+}  // namespace open_htj2k

--- a/tests/jpip_phase1.cmake
+++ b/tests/jpip_phase1.cmake
@@ -14,6 +14,9 @@ add_test(NAME jpip_vbas_codec COMMAND jpip_vbas_check)
 # ── JPIP HTTP request/response formatting (§C.1–C.4, §D.2) ──
 add_test(NAME jpip_http_format COMMAND jpip_http_check)
 
+# ── TCP socket loopback (Phase 3 transport layer) ──
+add_test(NAME jpip_tcp_loopback COMMAND jpip_tcp_check)
+
 # ── JPP-stream message header codec (§A.2 + Tables A.1, A.2) ──
 # Self-contained: round-trip + spec §A.3.2.2 byte-identical interop +
 # dependent-form behaviour + rejection cases.


### PR DESCRIPTION
## Summary

S2 of `PHASE3_PLAN.md`.  Cross-platform TCP socket wrapper: `TcpListener` (bind/listen/accept) + `TcpStream` (connect/send_all/recv_all/recv_until_header_end).  POSIX on Linux/macOS, Winsock2 on Windows.  RAII — sockets closed in destructors.

## Test plan

- [x] New ctest `jpip_tcp_loopback`: listener thread + client connect + send + recv echo, byte-identical.
- [x] **613/613 ctests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)