### PR TITLE
feat(jpip): standalone JPIP HTTP/1.1 server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,6 +299,15 @@ if(WIN32)
   target_link_libraries(jpip_tcp_check PUBLIC ws2_32)
 endif()
 
+# JPIP Phase-3 standalone HTTP/1.1 server
+add_executable(open_htj2k_jpip_server)
+add_subdirectory(source/apps/jpip_server)
+target_link_libraries(open_htj2k_jpip_server PUBLIC open_htj2k)
+set_target_properties(
+  open_htj2k_jpip_server
+  PROPERTIES OUTPUT_NAME
+             $<IF:$<CONFIG:Debug>,open_htj2k_jpip_server_dbg,open_htj2k_jpip_server>)
+
 # JPIP Phase-2 precinct data-bin + packet-locator self-test
 add_executable(jpip_precinct_check)
 add_subdirectory(source/apps/jpip_precinct_check)

--- a/source/apps/jpip_server/CMakeLists.txt
+++ b/source/apps/jpip_server/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_policy(SET CMP0076 NEW)
+target_sources(open_htj2k_jpip_server
+    PRIVATE
+    main.cpp
+)
+target_include_directories(open_htj2k_jpip_server
+    PRIVATE
+    ${CMAKE_SOURCE_DIR}/source/core/jpip
+    ${CMAKE_SOURCE_DIR}/source/core/interface
+)

--- a/source/apps/jpip_server/main.cpp
+++ b/source/apps/jpip_server/main.cpp
@@ -1,0 +1,220 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+//
+// open_htj2k_jpip_server: stateless JPIP HTTP/1.1 server.
+//
+// Loads a single JPEG 2000 codestream, builds the JPIP index + packet
+// locator once, then serves view-window requests over HTTP/1.1.
+//
+// Usage:
+//   open_htj2k_jpip_server <input.j2c> [--port N=8080]
+//
+// Each request is an HTTP GET with JPIP query parameters:
+//   GET /jpip?fsiz=W,H&roff=X,Y&rsiz=W,H&type=jpp-stream HTTP/1.1
+//
+// The server responds with a complete JPP-stream containing the
+// main-header, tile-header, metadata-bin-0, and every precinct data-bin
+// selected by the view-window resolver.  Stateless — no session, no
+// cache model, each request is self-contained.
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "codestream_walker.hpp"
+#include "data_bin_emitter.hpp"
+#include "jpp_message.hpp"
+#include "jpip_request.hpp"
+#include "jpip_response.hpp"
+#include "packet_locator.hpp"
+#include "precinct_index.hpp"
+#include "tcp_socket.hpp"
+#include "view_window.hpp"
+
+using namespace open_htj2k::jpip;
+
+namespace {
+
+std::vector<uint8_t> read_file(const char *path) {
+  FILE *f = std::fopen(path, "rb");
+  if (!f) { std::fprintf(stderr, "ERROR: cannot open %s\n", path); return {}; }
+  std::fseek(f, 0, SEEK_END);
+  auto sz = static_cast<std::size_t>(std::ftell(f));
+  std::fseek(f, 0, SEEK_SET);
+  std::vector<uint8_t> buf(sz);
+  std::size_t rd = std::fread(buf.data(), 1, sz, f);
+  std::fclose(f);
+  if (rd != sz) buf.clear();
+  return buf;
+}
+
+struct ServerState {
+  std::vector<uint8_t>              codestream;
+  std::unique_ptr<CodestreamIndex>  idx;
+  CodestreamLayout                  layout;
+  std::unique_ptr<PacketLocator>    locator;
+  std::string                       target_id;
+};
+
+// Build the JPP-stream for a given ViewWindow.
+std::vector<uint8_t> build_jpp_stream(const ServerState &st, const ViewWindow &vw) {
+  auto keys = resolve_view_window(*st.idx, vw);
+  std::unordered_set<uint64_t> keep;
+  keep.reserve(keys.size());
+  for (const auto &k : keys) keep.insert(st.idx->I(k.t, k.c, k.r, k.p_rc));
+
+  std::vector<uint8_t> stream;
+  MessageHeaderContext ctx;
+  emit_main_header_databin(st.codestream.data(), st.codestream.size(), st.layout, ctx, stream);
+  for (uint32_t t = 0; t < st.idx->num_tiles(); ++t) {
+    emit_tile_header_databin(st.codestream.data(), st.codestream.size(),
+                             static_cast<uint16_t>(t), st.layout, ctx, stream);
+  }
+  emit_metadata_bin_zero(ctx, stream);
+  for (uint32_t t = 0; t < st.idx->num_tiles(); ++t) {
+    for (uint16_t c = 0; c < st.idx->num_components(); ++c) {
+      const auto &info = st.idx->tile_component(static_cast<uint16_t>(t), c);
+      for (uint8_t r = 0; r <= info.NL; ++r) {
+        const uint32_t n = info.npw[r] * info.nph[r];
+        for (uint32_t p = 0; p < n; ++p) {
+          if (keep.count(st.idx->I(static_cast<uint16_t>(t), c, r, p))) {
+            emit_precinct_databin(st.codestream.data(), st.codestream.size(),
+                                  static_cast<uint16_t>(t), c, r, p,
+                                  *st.idx, *st.locator, ctx, stream);
+          }
+        }
+      }
+    }
+  }
+  return stream;
+}
+
+void handle_connection(TcpStream &conn, const ServerState &st) {
+  std::vector<uint8_t> raw;
+  const std::size_t hdr_bytes = conn.recv_until_header_end(raw, 65536);
+  if (hdr_bytes == 0) return;
+
+  std::string request_line;
+  {
+    const char *s = reinterpret_cast<const char *>(raw.data());
+    const char *eol = static_cast<const char *>(std::memchr(s, '\r', hdr_bytes));
+    if (!eol) eol = static_cast<const char *>(std::memchr(s, '\n', hdr_bytes));
+    if (!eol) { conn.send_all(format_error_response(400, "Bad Request")); return; }
+    request_line.assign(s, eol);
+  }
+
+  std::string path, query;
+  if (!split_http_get_line(request_line, &path, &query)) {
+    conn.send_all(format_error_response(405, "Method Not Allowed"));
+    return;
+  }
+
+  JpipRequest req;
+  const auto ps = parse_jpip_query(query, &req);
+  if (ps == RequestParseStatus::UnsupportedType) {
+    conn.send_all(format_error_response(501, "Unsupported Type"));
+    return;
+  }
+  if (ps == RequestParseStatus::MalformedField) {
+    conn.send_all(format_error_response(400, "Malformed Field"));
+    return;
+  }
+
+  // Default: full image if fsiz is omitted.
+  if (!req.has_fsiz) {
+    req.view_window.fx = st.idx->geometry().canvas_size.x;
+    req.view_window.fy = st.idx->geometry().canvas_size.y;
+  }
+  if (!req.has_rsiz) {
+    req.view_window.sx = req.view_window.fx;
+    req.view_window.sy = req.view_window.fy;
+  }
+
+  using Clock = std::chrono::steady_clock;
+  const auto t0 = Clock::now();
+
+  auto jpp = build_jpp_stream(st, req.view_window);
+
+  const auto t1 = Clock::now();
+  const double ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+
+  auto keys = resolve_view_window(*st.idx, req.view_window);
+  std::printf("  → %zu precincts (%.1f%%), %zu bytes JPP-stream, %.1f ms\n",
+              keys.size(),
+              st.idx->total_precincts()
+                  ? (100.0 * static_cast<double>(keys.size()) / static_cast<double>(st.idx->total_precincts()))
+                  : 0.0,
+              jpp.size(), ms);
+  std::fflush(stdout);
+
+  auto resp = format_jpp_response(jpp.data(), jpp.size(), st.target_id);
+  conn.send_all(resp);
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    std::fprintf(stderr, "Usage: open_htj2k_jpip_server <input.j2c> [--port N=8080]\n");
+    return EXIT_FAILURE;
+  }
+  std::string infile = argv[1];
+  uint16_t port = 8080;
+  for (int i = 2; i < argc; ++i) {
+    if (std::strcmp(argv[i], "--port") == 0 && i + 1 < argc) {
+      port = static_cast<uint16_t>(std::atoi(argv[++i]));
+    }
+  }
+
+  tcp_wsa_init();
+
+  ServerState st;
+  st.codestream = read_file(infile.c_str());
+  if (st.codestream.empty()) return EXIT_FAILURE;
+
+  st.idx = CodestreamIndex::build(st.codestream.data(), st.codestream.size());
+  if (!st.idx) { std::fprintf(stderr, "CodestreamIndex build failed\n"); return EXIT_FAILURE; }
+
+  walk_codestream(st.codestream.data(), st.codestream.size(), &st.layout);
+
+  st.locator = PacketLocator::build(st.codestream.data(), st.codestream.size(), *st.idx, st.layout);
+  if (!st.locator) { std::fprintf(stderr, "PacketLocator build failed\n"); return EXIT_FAILURE; }
+
+  st.target_id = infile;
+
+  std::printf("JPIP server: %s (%u×%u, %llu precincts)\n",
+              infile.c_str(),
+              st.idx->geometry().canvas_size.x, st.idx->geometry().canvas_size.y,
+              static_cast<unsigned long long>(st.idx->total_precincts()));
+
+  TcpListener listener;
+  if (!listener.bind(port)) {
+    std::fprintf(stderr, "bind port %u: %s\n", port, listener.last_error().c_str());
+    tcp_wsa_cleanup();
+    return EXIT_FAILURE;
+  }
+  if (!listener.listen()) {
+    std::fprintf(stderr, "listen: %s\n", listener.last_error().c_str());
+    tcp_wsa_cleanup();
+    return EXIT_FAILURE;
+  }
+  std::printf("listening on http://localhost:%u/jpip\n", port);
+  std::fflush(stdout);
+
+  while (true) {
+    TcpStream conn = listener.accept();
+    if (!conn.is_open()) {
+      std::fprintf(stderr, "accept: %s\n", listener.last_error().c_str());
+      continue;
+    }
+    handle_connection(conn, st);
+  }
+
+  tcp_wsa_cleanup();
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

S3 of `PHASE3_PLAN.md`.  Standalone JPIP HTTP/1.1 server — loads a codestream, builds index + locator once, serves stateless view-window requests.

```bash
open_htj2k_jpip_server u01_Books_4K_12bit_fov.j2c --port 8080

# In another terminal:
curl "http://localhost:8080/jpip?fsiz=960,960&rsiz=960,960&type=jpp-stream" -o response.bin
```

## How it works

1. HTTP GET with JPIP query params → `parse_jpip_query` (S1)
2. `resolve_view_window` → precinct set
3. Emit JPP-stream (main header + tile headers + metadata + selected precinct bins)
4. `format_jpp_response` (S1) → HTTP 200 with `Content-Type: image/jpp-stream`
5. Send via `TcpStream` (S2)

## Test plan

- [x] Smoke-tested via curl: 1920×1920 foveation asset at half-res → 930 precincts (25.6%), 280 KB JPP-stream, 0.3 ms server-side.
- [x] First JPP message byte: `bb=2, is_last=1, id=0` = valid main-header data-bin.
- [x] **613/613 ctests pass.**

## What's next

**S4**: HTTP client library + demo integration (`--server host:port`).  The demo sends each frame's view-window to the running server, receives the JPP-stream, reassembles, and decodes — completing the network round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)