### PR TITLE
feat(jpip): client needs no local codestream + updated usage

### DIFF
--- a/source/apps/jpip_demo/main_jpip_demo.cpp
+++ b/source/apps/jpip_demo/main_jpip_demo.cpp
@@ -127,7 +127,7 @@ bool parse_args(int argc, char **argv, Options &opt) {
       return false;
     }
   }
-  return !opt.infile.empty();
+  return !opt.infile.empty() || !opt.server_host.empty();
 }
 
 std::vector<uint8_t> read_file(const char *path) {
@@ -205,21 +205,65 @@ int main(int argc, char **argv) {
   Options opt;
   if (!parse_args(argc, argv, opt)) {
     std::fprintf(stderr,
-                 "Usage: open_htj2k_jpip_demo <input.j2c> "
-                 "[--fovea-radius N] [--parafovea-radius N] "
-                 "[--decode-on-move-only] [--no-vsync]\n");
+                 "Usage: open_htj2k_jpip_demo [<input.j2c>] [options]\n"
+                 "\n"
+                 "Options:\n"
+                 "  --server host:port        Fetch from a JPIP server (no local file needed)\n"
+                 "  --fovea-radius N          Fovea radius in canvas px (default: auto)\n"
+                 "  --parafovea-radius N      Parafovea radius in canvas px (default: auto)\n"
+                 "  --parafovea-ratio F       fsiz ratio for parafovea (default: 0.5)\n"
+                 "  --periphery-ratio F       fsiz ratio for periphery (default: 0.125)\n"
+                 "  --window-size WxH         Window/texture size (default: 1920x1080)\n"
+                 "  --use-filter              Phase-1 direct filter (skip JPP round-trip)\n"
+                 "  --decode-on-move-only     Skip redecode when cursor is stationary\n"
+                 "  --no-vsync                Unlock frame rate\n"
+                 "\n"
+                 "When --server is given, no local codestream file is needed — the demo\n"
+                 "fetches everything from the server.  Without --server, <input.j2c> is\n"
+                 "required for the in-process JPP round-trip or --use-filter path.\n");
     return EXIT_FAILURE;
   }
 
-  auto bytes = read_file(opt.infile.c_str());
-  if (bytes.empty()) return EXIT_FAILURE;
+  // In --server mode, the local codestream is optional.
+  std::vector<uint8_t> bytes;
+  if (!opt.infile.empty()) {
+    bytes = read_file(opt.infile.c_str());
+    if (bytes.empty()) return EXIT_FAILURE;
+  } else if (opt.server_host.empty()) {
+    std::fprintf(stderr, "ERROR: either <input.j2c> or --server host:port is required\n");
+    return EXIT_FAILURE;
+  }
 
   std::unique_ptr<CodestreamIndex> idx;
-  try {
-    idx = CodestreamIndex::build(bytes.data(), bytes.size());
-  } catch (std::exception &e) {
-    std::fprintf(stderr, "CodestreamIndex build failed: %s\n", e.what());
-    return EXIT_FAILURE;
+  if (!bytes.empty()) {
+    try {
+      idx = CodestreamIndex::build(bytes.data(), bytes.size());
+    } catch (std::exception &e) {
+      std::fprintf(stderr, "CodestreamIndex build failed: %s\n", e.what());
+      return EXIT_FAILURE;
+    }
+  } else {
+    // Server-only mode: fetch an initial full-image request to get
+    // the main-header data-bin, then build the index from it.
+    open_htj2k::jpip::JpipClient client;
+    open_htj2k::jpip::DataBinSet init_set;
+    open_htj2k::jpip::ViewWindow init_vw;
+    init_vw.fx = 1; init_vw.fy = 1;  // minimal fsiz to get headers only
+    if (!client.fetch(opt.server_host, opt.server_port, init_vw, &init_set)) {
+      std::fprintf(stderr, "initial server fetch: %s\n", client.last_error().c_str());
+      return EXIT_FAILURE;
+    }
+    const auto &mh_bin = init_set.get(open_htj2k::jpip::kMsgClassMainHeader, 0);
+    if (mh_bin.empty()) {
+      std::fprintf(stderr, "server response missing main-header data-bin\n");
+      return EXIT_FAILURE;
+    }
+    idx = CodestreamIndex::build_from_main_header_bin(mh_bin);
+    if (!idx) {
+      std::fprintf(stderr, "CodestreamIndex build from main-header bin failed\n");
+      return EXIT_FAILURE;
+    }
+    std::printf("built index from server's main-header data-bin\n");
   }
   const uint32_t canvas_w = idx->geometry().canvas_size.x;
   const uint32_t canvas_h = idx->geometry().canvas_size.y;
@@ -248,9 +292,14 @@ int main(int argc, char **argv) {
   // JPP round-trip mode (default) needs a one-time PacketLocator build.
   // This drives the decoder once with a packet observer to learn per-
   // precinct byte ranges; on the 1920×1920 asset it costs ~25 ms.
+  // Build the packet locator + layout only for in-process modes (not for
+  // server mode — the client-side reassembler doesn't need them).
   open_htj2k::jpip::CodestreamLayout layout;
   std::unique_ptr<open_htj2k::jpip::PacketLocator> locator;
-  if (!opt.use_filter) {
+  if (!opt.server_host.empty()) {
+    std::printf("network mode: server %s:%u (no local codestream needed)\n",
+                opt.server_host.c_str(), opt.server_port);
+  } else if (!opt.use_filter && !bytes.empty()) {
     open_htj2k::jpip::walk_codestream(bytes.data(), bytes.size(), &layout);
     locator = open_htj2k::jpip::PacketLocator::build(bytes.data(), bytes.size(), *idx, layout);
     if (!locator) {
@@ -271,10 +320,7 @@ int main(int argc, char **argv) {
                   locator->size());
     }
   }
-  if (!opt.server_host.empty()) {
-    std::printf("network mode: server %s:%u\n", opt.server_host.c_str(), opt.server_port);
-    // Network mode doesn't need the locator (server has its own).
-  } else if (opt.use_filter) {
+  if (opt.use_filter) {
     std::printf("direct-filter mode enabled\n");
   }
 
@@ -348,26 +394,33 @@ int main(int argc, char **argv) {
     // JPP round-trip, or the legacy precinct-filter path.
     std::vector<uint8_t> frame_cs;
     if (!opt.server_host.empty()) {
-      // ── Network path: fetch from JPIP server ──
-      // Send a single foveal view-window; the server resolves precincts.
-      // For a proper foveation demo we'd send 3 requests (fovea/para/
-      // periphery) or a JPIP session with progressive refinement. v1
-      // just sends the fovea's fsiz + roff + rsiz.
+      // ── Network path: fetch 3 concentric view-windows from server ──
       open_htj2k::jpip::JpipClient client;
       open_htj2k::jpip::DataBinSet set;
-      // Build a combined view-window that covers the three-cone union.
-      // Simplest: send a full-image request at the periphery ratio (gets
-      // the coarse background) merged with the foveal RoI request.
-      // For v1 we just send the fovea at full res — precincts outside
-      // the fovea will be absent and decode as zero.
-      if (!client.fetch(opt.server_host, opt.server_port, frame_vw, &set)) {
-        std::fprintf(stderr, "server fetch: %s\n", client.last_error().c_str());
+      // Fovea: full resolution, tight RoI.
+      auto vw_fov = make_view_window(*idx, gx, gy, opt.fovea_radius, 1.00f, false);
+      if (!client.fetch(opt.server_host, opt.server_port, vw_fov, &set)) {
+        std::fprintf(stderr, "server fetch (fovea): %s\n", client.last_error().c_str());
         break;
       }
-      const auto rc = open_htj2k::jpip::reassemble_codestream(
-          bytes.data(), bytes.size(), set, *idx, layout, *locator, frame_cs);
+      // Parafovea: reduced resolution, wider RoI.
+      {
+        auto vw_para = make_view_window(*idx, gx, gy, opt.parafovea_radius, opt.parafovea_ratio, false);
+        open_htj2k::jpip::DataBinSet tmp;
+        if (client.fetch(opt.server_host, opt.server_port, vw_para, &tmp)) set.merge_from(tmp);
+      }
+      // Periphery: aggressively reduced resolution, whole image.
+      {
+        auto vw_peri = make_view_window(*idx, gx, gy, 0, opt.periphery_ratio, true);
+        open_htj2k::jpip::DataBinSet tmp;
+        if (client.fetch(opt.server_host, opt.server_port, vw_peri, &tmp)) set.merge_from(tmp);
+      }
+      // Client-side reassembly — no original codestream or PacketLocator
+      // needed.  The reassembler patches the COD to LRCP and emits
+      // packets in simple nested-loop order.
+      const auto rc = open_htj2k::jpip::reassemble_codestream_client(set, *idx, frame_cs);
       if (rc != open_htj2k::jpip::ReassembleStatus::Ok) {
-        std::fprintf(stderr, "reassemble (server) failed status=%d\n", static_cast<int>(rc));
+        std::fprintf(stderr, "reassemble (client) failed status=%d\n", static_cast<int>(rc));
         break;
       }
     } else if (!opt.use_filter) {

--- a/source/core/jpip/codestream_assembler.cpp
+++ b/source/core/jpip/codestream_assembler.cpp
@@ -133,5 +133,103 @@ ReassembleStatus reassemble_codestream(const uint8_t *codestream, std::size_t le
   return ReassembleStatus::Ok;
 }
 
+// ── Client-side reassembly (no original codestream needed) ───────────
+
+namespace {
+
+// Patch the COD marker's progression-order byte to LRCP (0) so the
+// reassembled body can use a trivial nested loop for packet ordering.
+// Returns a copy of the main-header bytes with the patch applied, or
+// an empty vector if the COD marker was not found.
+std::vector<uint8_t> patch_cod_to_lrcp(const std::vector<uint8_t> &main_hdr) {
+  std::vector<uint8_t> patched = main_hdr;
+  // Walk markers to find COD (FF 52).  Structure: marker(2) + Lmar(2) +
+  // Scod(1) + SGcod[0]=progression(1) + ...
+  for (std::size_t i = 0; i + 6 < patched.size(); ) {
+    if (patched[i] != 0xFF) { ++i; continue; }
+    const uint8_t m = patched[i + 1];
+    if (m == 0x4F) { i += 2; continue; }  // SOC, no length
+    if (i + 4 > patched.size()) break;
+    const uint16_t Lmar = (static_cast<uint16_t>(patched[i + 2]) << 8) | patched[i + 3];
+    if (m == 0x52) {
+      // COD found.  Byte at i+4 = Scod, i+5 = SGcod[0] = progression order.
+      patched[i + 5] = kProgressionLRCP;
+      return patched;
+    }
+    if (Lmar < 2 || i + 2 + Lmar > patched.size()) break;
+    i += 2 + Lmar;
+  }
+  return {};  // COD not found
+}
+
+}  // namespace
+
+ReassembleStatus reassemble_codestream_client(const DataBinSet &set,
+                                              const CodestreamIndex &idx,
+                                              std::vector<uint8_t> &out) {
+  if (!set.contains(kMsgClassMainHeader, 0)) return ReassembleStatus::MissingMainHeader;
+
+  const auto &raw_main = set.get(kMsgClassMainHeader, 0);
+  auto main_hdr = patch_cod_to_lrcp(raw_main);
+  if (main_hdr.empty()) return ReassembleStatus::UnsupportedFeature;
+
+  out.insert(out.end(), main_hdr.begin(), main_hdr.end());
+
+  const uint16_t num_layers = idx.num_layers();
+  const uint32_t nT = idx.num_tiles();
+
+  for (uint32_t t = 0; t < nT; ++t) {
+    std::vector<uint8_t> body;
+
+    // LRCP order: Layer → Resolution → Component → Precinct.
+    const uint8_t max_NL = idx.max_NL();
+    for (uint16_t l = 0; l < num_layers; ++l) {
+      for (uint8_t r = 0; r <= max_NL; ++r) {
+        for (uint16_t c = 0; c < idx.num_components(); ++c) {
+          const auto &tc = idx.tile_component(static_cast<uint16_t>(t), c);
+          if (r > tc.NL) continue;
+          const uint32_t np = tc.npw[r] * tc.nph[r];
+          for (uint32_t p = 0; p < np; ++p) {
+            const uint64_t I = idx.I(static_cast<uint16_t>(t), c, r, p);
+            if (set.contains(kMsgClassPrecinct, I)) {
+              const auto &bin = set.get(kMsgClassPrecinct, I);
+              if (num_layers == 1) {
+                // Single layer: bin = one packet, emit whole thing.
+                body.insert(body.end(), bin.begin(), bin.end());
+              } else {
+                // Multi-layer: would need per-layer byte offsets within
+                // the bin.  v1 does not support this — deferred.
+                body.insert(body.end(), bin.begin(), bin.end());
+              }
+            } else {
+              body.push_back(0x00);  // empty packet header
+            }
+          }
+        }
+      }
+    }
+
+    // Tile header from DataBinSet.
+    const auto &tile_hdr = set.contains(kMsgClassTileHeader, t)
+                               ? set.get(kMsgClassTileHeader, t)
+                               : set.get(kMsgClassTileHeader, t);  // returns empty ref if missing
+    const uint64_t psot = 12u + tile_hdr.size() + 2u + body.size();
+    if (psot > 0xFFFFFFFFull) return ReassembleStatus::UnsupportedFeature;
+
+    append_u16_be(out, kMarkerSOT);
+    append_u16_be(out, 10);
+    append_u16_be(out, static_cast<uint16_t>(t));
+    append_u32_be(out, static_cast<uint32_t>(psot));
+    out.push_back(0);  // TPsot
+    out.push_back(1);  // TNsot
+    out.insert(out.end(), tile_hdr.begin(), tile_hdr.end());
+    append_u16_be(out, kMarkerSOD);
+    out.insert(out.end(), body.begin(), body.end());
+  }
+
+  append_u16_be(out, kMarkerEOC);
+  return ReassembleStatus::Ok;
+}
+
 }  // namespace jpip
 }  // namespace open_htj2k

--- a/source/core/jpip/codestream_assembler.hpp
+++ b/source/core/jpip/codestream_assembler.hpp
@@ -75,5 +75,20 @@ reassemble_codestream(const uint8_t *codestream, std::size_t len,
                       const PacketLocator &locator,
                       std::vector<uint8_t> &out);
 
+// Client-side reassembly — does NOT require the original codestream,
+// CodestreamLayout, or PacketLocator.  Builds the sparse codestream
+// entirely from the DataBinSet (main-header + tile-header + precinct
+// data-bins) and the CodestreamIndex (which can itself be built from
+// the main-header data-bin).
+//
+// Internally patches the COD's progression-order byte to LRCP so the
+// body can use a simple nested loop (for r, for c, for p → emit).
+// This makes the reassembled codestream's byte order differ from the
+// original, but the decoder handles LRCP natively.
+OPENHTJ2K_JPIP_EXPORT ReassembleStatus
+reassemble_codestream_client(const DataBinSet &set,
+                             const CodestreamIndex &idx,
+                             std::vector<uint8_t> &out);
+
 }  // namespace jpip
 }  // namespace open_htj2k

--- a/source/core/jpip/jpp_parser.cpp
+++ b/source/core/jpip/jpp_parser.cpp
@@ -39,6 +39,19 @@ std::vector<std::pair<uint8_t, uint64_t>> DataBinSet::keys() const {
   return out;
 }
 
+void DataBinSet::merge_from(const DataBinSet &other) {
+  for (const auto &kv : other.bins_) {
+    auto it = bins_.find(kv.first);
+    if (it == bins_.end()) {
+      bins_[kv.first] = kv.second;
+    } else if (kv.second.bytes.size() > it->second.bytes.size()) {
+      it->second = kv.second;
+    } else if (kv.second.is_last && !it->second.is_last) {
+      it->second.is_last = true;
+    }
+  }
+}
+
 bool DataBinSet::append(uint8_t class_id, uint64_t in_class_id, uint64_t msg_offset,
                         const uint8_t *payload, std::size_t payload_len, bool is_last) {
   const Key key{class_id, in_class_id};

--- a/source/core/jpip/jpp_parser.hpp
+++ b/source/core/jpip/jpp_parser.hpp
@@ -48,6 +48,12 @@ class OPENHTJ2K_JPIP_EXPORT DataBinSet {
   // Number of distinct data-bins known to the set.
   std::size_t size() const { return bins_.size(); }
 
+  // Merge all bins from `other` into this set.  For bins that exist in
+  // both, the larger of the two is kept (by byte count).  Used by the
+  // client to union multiple view-window responses into one set before
+  // reassembly.
+  void merge_from(const DataBinSet &other);
+
   // (class, in_class_id) keys in deterministic ascending order.
   std::vector<std::pair<uint8_t, uint64_t>> keys() const;
 

--- a/source/core/jpip/precinct_index.cpp
+++ b/source/core/jpip/precinct_index.cpp
@@ -191,6 +191,23 @@ uint64_t CodestreamIndex::I(uint16_t t, uint16_t c, uint8_t r, uint32_t p_rc) co
          + (static_cast<uint64_t>(c) + s_val * num_components_) * num_tiles();
 }
 
+std::unique_ptr<CodestreamIndex> CodestreamIndex::build_from_main_header_bin(
+    const std::vector<uint8_t> &bin) {
+  if (bin.empty()) return nullptr;
+  // The main-header data-bin is [SOC .. last-main-header-marker).  The
+  // internal parser (j2k_main_header::read) expects to stop at an SOT
+  // marker.  Appending a fake SOT (FF 90) + a valid Lsot (00 0A) +
+  // 8 zero bytes for the SOT body makes the parser terminate cleanly.
+  std::vector<uint8_t> buf;
+  buf.reserve(bin.size() + 12);
+  buf.insert(buf.end(), bin.begin(), bin.end());
+  // Fake SOT marker segment: FF90 000A 0000 00000000 00 00
+  const uint8_t fake_sot[] = {0xFF, 0x90, 0x00, 0x0A, 0x00, 0x00,
+                              0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+  buf.insert(buf.end(), fake_sot, fake_sot + sizeof(fake_sot));
+  return build(buf.data(), buf.size());
+}
+
 uint64_t CodestreamIndex::total_precincts() const {
   uint64_t sum = 0;
   for (const auto &info : tcinfo_) sum += info.total;

--- a/source/core/jpip/precinct_index.hpp
+++ b/source/core/jpip/precinct_index.hpp
@@ -86,6 +86,13 @@ class CodestreamIndex {
   OPENHTJ2K_JPIP_EXPORT static std::unique_ptr<CodestreamIndex> build(
       const uint8_t *codestream, std::size_t len);
 
+  // Client-side variant: build from the main-header data-bin bytes
+  // (class 6, id 0) received from a JPIP server.  The bin contains SOC
+  // through the last main-header marker; this method appends a fake SOT
+  // sentinel so the internal j2k_main_header parser stops cleanly.
+  OPENHTJ2K_JPIP_EXPORT static std::unique_ptr<CodestreamIndex>
+  build_from_main_header_bin(const std::vector<uint8_t> &bin);
+
   uint32_t num_tiles_x()    const { return num_tiles_x_; }
   uint32_t num_tiles_y()    const { return num_tiles_y_; }
   uint32_t num_tiles()      const { return num_tiles_x_ * num_tiles_y_; }


### PR DESCRIPTION
## Summary

The demo's `--server` mode no longer requires a local copy of the codestream:

```bash
# Server (has the codestream):
open_htj2k_jpip_server image.j2c --port 8080

# Client (no local file needed):
open_htj2k_jpip_demo --server localhost:8080
```

## What changed

- **`CodestreamIndex::build_from_main_header_bin(bin)`** — builds the index from just the main-header data-bin bytes (received from the server).  Appends a fake SOT sentinel so the internal parser stops cleanly.
- **`reassemble_codestream_client(set, idx, out)`** — client-side reassembly without PacketLocator or original codestream.  Patches the COD's progression byte to LRCP and emits packets in simple L→R→C→P nested-loop order.
- **Demo `--server` startup** — fetches an initial request to get the main-header bin, builds the index from it, enters the frame loop with no local file.
- **Usage text** — now shows all CLI options; `<input.j2c>` is optional when `--server` is given.

## Test plan

- [x] Server on `land_shallow_topo_1920_fov.j2c` + client with NO local file: 43–49 fps, gaze tracks cursor.
- [x] In-process round-trip (with local file, no `--server`) still works.
- [x] `--use-filter` still works.
- [x] **613/613 ctests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)