### PR TITLE
feat(jpip): Phase 5a — HTTP/3 over QUIC (Annex P H3 transport)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ PHASE4_PLAN.md
 PHASE5_PLAN.md
 WASM_DEMO_PLAN.md
 WEBGL_NOTES.md
+
+# Generated TLS certificates for QUIC localhost testing
+server.key
+server.cert

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,35 @@ if (NOT EMSCRIPTEN)
   endif()
 endif()
 
+# ── QUIC / HTTP/3 support (Phase 5) ─────────────────────────────────────────
+# Requires MsQuic (QUIC transport) and nghttp3 (HTTP/3 framing).
+# On macOS: brew install libmsquic libnghttp3
+# On Linux: install from packages or build from source.
+option(OPENHTJ2K_QUIC "Build HTTP/3 QUIC transport for JPIP (requires MsQuic + nghttp3)" OFF)
+if(OPENHTJ2K_QUIC AND NOT EMSCRIPTEN)
+  find_library(MSQUIC_LIBRARY NAMES msquic)
+  find_path(MSQUIC_INCLUDE_DIR NAMES msquic.h)
+  find_library(NGHTTP3_LIBRARY NAMES nghttp3)
+  find_path(NGHTTP3_INCLUDE_DIR NAMES nghttp3/nghttp3.h)
+
+  if(MSQUIC_LIBRARY AND MSQUIC_INCLUDE_DIR AND NGHTTP3_LIBRARY AND NGHTTP3_INCLUDE_DIR)
+    message(STATUS "OPENHTJ2K_QUIC: MsQuic found: ${MSQUIC_LIBRARY}")
+    message(STATUS "OPENHTJ2K_QUIC: nghttp3 found: ${NGHTTP3_LIBRARY}")
+    target_compile_definitions(open_htj2k PUBLIC "OPENHTJ2K_ENABLE_QUIC")
+    target_include_directories(open_htj2k PUBLIC ${MSQUIC_INCLUDE_DIR} ${NGHTTP3_INCLUDE_DIR})
+    target_link_libraries(open_htj2k PUBLIC ${MSQUIC_LIBRARY} ${NGHTTP3_LIBRARY})
+  else()
+    message(WARNING "OPENHTJ2K_QUIC requested but libraries not found:")
+    if(NOT MSQUIC_LIBRARY OR NOT MSQUIC_INCLUDE_DIR)
+      message(WARNING "  MsQuic not found (brew install libmsquic)")
+    endif()
+    if(NOT NGHTTP3_LIBRARY OR NOT NGHTTP3_INCLUDE_DIR)
+      message(WARNING "  nghttp3 not found (brew install libnghttp3)")
+    endif()
+    set(OPENHTJ2K_QUIC OFF)
+  endif()
+endif()
+
 # Compiler optimization settings
 if(NOT MSVC)
   set(CMAKE_CXX_FLAGS

--- a/scripts/gen_localhost_cert.sh
+++ b/scripts/gen_localhost_cert.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Generate a self-signed TLS certificate for localhost QUIC testing.
+# Usage: ./scripts/gen_localhost_cert.sh [output_dir]
+#
+# Produces server.key and server.cert in the output directory (default: cwd).
+# The certificate is valid for 365 days and covers localhost + 127.0.0.1.
+
+set -e
+OUT="${1:-.}"
+openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 \
+    -keyout "$OUT/server.key" -out "$OUT/server.cert" \
+    -days 365 -nodes \
+    -subj "/CN=localhost" \
+    -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+echo "Created $OUT/server.key and $OUT/server.cert"

--- a/source/apps/jpip_demo/main_jpip_demo.cpp
+++ b/source/apps/jpip_demo/main_jpip_demo.cpp
@@ -247,8 +247,8 @@ int main(int argc, char **argv) {
   if (!opt.infile.empty()) {
     bytes = read_file(opt.infile.c_str());
     if (bytes.empty()) return EXIT_FAILURE;
-  } else if (opt.server_host.empty()) {
-    std::fprintf(stderr, "ERROR: either <input.j2c> or --server host:port is required\n");
+  } else if (opt.server_host.empty() && opt.server_h3_host.empty()) {
+    std::fprintf(stderr, "ERROR: either <input.j2c> or --server/--server-h3 host:port is required\n");
     return EXIT_FAILURE;
   }
 
@@ -260,8 +260,37 @@ int main(int argc, char **argv) {
       std::fprintf(stderr, "CodestreamIndex build failed: %s\n", e.what());
       return EXIT_FAILURE;
     }
-  } else {
-    // Server-only mode: fetch an initial full-image request to get
+  }
+#ifdef OPENHTJ2K_ENABLE_QUIC
+  else if (!opt.server_h3_host.empty()) {
+    // H3 server-only mode: fetch initial main-header over HTTP/3.
+    open_htj2k::jpip::H3Client h3_init;
+    if (!h3_init.connect(opt.server_h3_host, opt.server_h3_port, false)) {
+      std::fprintf(stderr, "H3 initial connect: %s\n", h3_init.last_error().c_str());
+      return EXIT_FAILURE;
+    }
+    auto init_body = h3_init.fetch("/jpip?fsiz=1,1&type=jpp-stream");
+    if (init_body.empty()) {
+      std::fprintf(stderr, "H3 initial fetch empty\n");
+      return EXIT_FAILURE;
+    }
+    open_htj2k::jpip::DataBinSet init_set;
+    open_htj2k::jpip::parse_jpp_stream(init_body.data(), init_body.size(), &init_set);
+    const auto &mh_bin = init_set.get(open_htj2k::jpip::kMsgClassMainHeader, 0);
+    if (mh_bin.empty()) {
+      std::fprintf(stderr, "H3 server response missing main-header data-bin\n");
+      return EXIT_FAILURE;
+    }
+    idx = CodestreamIndex::build_from_main_header_bin(mh_bin);
+    if (!idx) {
+      std::fprintf(stderr, "CodestreamIndex build from H3 main-header bin failed\n");
+      return EXIT_FAILURE;
+    }
+    std::printf("built index from H3 server's main-header data-bin\n");
+  }
+#endif
+  else {
+    // HTTP/1.1 server-only mode: fetch an initial full-image request to get
     // the main-header data-bin, then build the index from it.
     open_htj2k::jpip::JpipClient client;
     open_htj2k::jpip::DataBinSet init_set;
@@ -298,7 +327,7 @@ int main(int argc, char **argv) {
               static_cast<double>(opt.parafovea_ratio),
               static_cast<double>(opt.periphery_ratio));
   std::printf("loaded %s: canvas %u×%u, %u components, %llu precincts\n",
-              opt.infile.c_str(), canvas_w, canvas_h, idx->num_components(),
+              opt.infile.empty() ? "(server)" : opt.infile.c_str(), canvas_w, canvas_h, idx->num_components(),
               static_cast<unsigned long long>(total_p));
 
   // The decoder's codestream cursor advances during each invoke(), so every

--- a/source/apps/jpip_demo/main_jpip_demo.cpp
+++ b/source/apps/jpip_demo/main_jpip_demo.cpp
@@ -31,6 +31,7 @@
 //       [--periphery-ratio F=0.125] (fsiz ratio; default drops 3 of 5 DWT levels)
 //       [--window-size WxH=1920x1080]
 //       [--reduce N=0]             (DWT reduce levels; trades resolution for speed)
+//       [--server-h3 host:port]     (HTTP/3 QUIC server mode)
 //       [--use-filter]              (Phase-1 direct filter, skip JPP round-trip)
 //       [--decode-on-move-only] [--no-vsync]
 //
@@ -57,6 +58,9 @@
 #include "packet_locator.hpp"
 #include "precinct_index.hpp"
 #include "view_window.hpp"
+#ifdef OPENHTJ2K_ENABLE_QUIC
+#include "h3_client.hpp"
+#endif
 #include "renderer.hpp"
 
 using open_htj2k::rtp_recv::Renderer;
@@ -89,6 +93,8 @@ struct Options {
   // given JPIP server instead of doing in-process round-trip.
   std::string server_host;
   uint16_t    server_port      = 8080;
+  std::string server_h3_host;
+  uint16_t    server_h3_port   = 8080;
 };
 
 bool parse_args(int argc, char **argv, Options &opt) {
@@ -114,7 +120,6 @@ bool parse_args(int argc, char **argv, Options &opt) {
     else if (a == "--use-filter")                   opt.use_filter = true;
     else if (a == "--no-vsync")                     opt.vsync = false;
     else if (a == "--server" && i + 1 < argc) {
-      // "host:port" or "host" (default port 8080).
       const std::string hp = argv[++i];
       const auto colon = hp.rfind(':');
       if (colon == std::string::npos) {
@@ -124,13 +129,23 @@ bool parse_args(int argc, char **argv, Options &opt) {
         opt.server_port = static_cast<uint16_t>(std::stoul(hp.substr(colon + 1)));
       }
     }
+    else if (a == "--server-h3" && i + 1 < argc) {
+      const std::string hp = argv[++i];
+      const auto colon = hp.rfind(':');
+      if (colon == std::string::npos) {
+        opt.server_h3_host = hp;
+      } else {
+        opt.server_h3_host = hp.substr(0, colon);
+        opt.server_h3_port = static_cast<uint16_t>(std::stoul(hp.substr(colon + 1)));
+      }
+    }
     else if (a.size() > 0 && a[0] != '-' && opt.infile.empty()) opt.infile = a;
     else {
       std::fprintf(stderr, "ERROR: unknown arg '%s'\n", a.c_str());
       return false;
     }
   }
-  return !opt.infile.empty() || !opt.server_host.empty();
+  return !opt.infile.empty() || !opt.server_host.empty() || !opt.server_h3_host.empty();
 }
 
 std::vector<uint8_t> read_file(const char *path) {
@@ -426,7 +441,41 @@ int main(int argc, char **argv) {
         std::fprintf(stderr, "reassemble (client) failed status=%d\n", static_cast<int>(rc));
         break;
       }
-    } else if (!opt.use_filter) {
+    }
+#ifdef OPENHTJ2K_ENABLE_QUIC
+    else if (!opt.server_h3_host.empty()) {
+      // ── HTTP/3 network path ──
+      static open_htj2k::jpip::H3Client h3c;
+      static bool h3_connected = false;
+      if (!h3_connected) {
+        if (!h3c.connect(opt.server_h3_host, opt.server_h3_port, false)) {
+          std::fprintf(stderr, "H3 connect failed: %s\n", h3c.last_error().c_str());
+          break;
+        }
+        h3_connected = true;
+      }
+      open_htj2k::jpip::DataBinSet set;
+      auto fetch_vw = [&](const open_htj2k::jpip::ViewWindow &vw) {
+        std::string q = "/jpip?" + open_htj2k::jpip::format_view_window_query(vw);
+        auto body = h3c.fetch(q);
+        if (!body.empty()) {
+          open_htj2k::jpip::DataBinSet tmp;
+          open_htj2k::jpip::parse_jpp_stream(body.data(), body.size(), &tmp);
+          set.merge_from(tmp);
+        }
+      };
+      fetch_vw(make_view_window(*idx, gx, gy, opt.fovea_radius, 1.00f, false));
+      fetch_vw(make_view_window(*idx, gx, gy, opt.parafovea_radius, opt.parafovea_ratio, false));
+      fetch_vw(make_view_window(*idx, gx, gy, 0, opt.periphery_ratio, true));
+
+      const auto rc = open_htj2k::jpip::reassemble_codestream_client(set, *idx, frame_cs);
+      if (rc != open_htj2k::jpip::ReassembleStatus::Ok) {
+        std::fprintf(stderr, "reassemble (H3 client) failed status=%d\n", static_cast<int>(rc));
+        break;
+      }
+    }
+#endif
+    else if (!opt.use_filter) {
       // ── In-process JPP round-trip: emit → parse → reassemble ──
       std::vector<uint8_t> stream;
       open_htj2k::jpip::MessageHeaderContext enc_ctx;

--- a/source/apps/jpip_server/main.cpp
+++ b/source/apps/jpip_server/main.cpp
@@ -1,13 +1,14 @@
 // Copyright (c) 2026, Osamu Watanabe
 // All rights reserved.
 //
-// open_htj2k_jpip_server: stateless JPIP HTTP/1.1 server.
+// open_htj2k_jpip_server: stateless JPIP server (HTTP/1.1 or HTTP/3).
 //
 // Loads a single JPEG 2000 codestream, builds the JPIP index + packet
-// locator once, then serves view-window requests over HTTP/1.1.
+// locator once, then serves view-window requests.
 //
 // Usage:
 //   open_htj2k_jpip_server <input.j2c> [--port N=8080]
+//       [--h3 --cert server.cert --key server.key]
 //
 // Each request is an HTTP GET with JPIP query parameters:
 //   GET /jpip?fsiz=W,H&roff=X,Y&rsiz=W,H&type=jpp-stream HTTP/1.1
@@ -35,6 +36,9 @@
 #include "precinct_index.hpp"
 #include "tcp_socket.hpp"
 #include "view_window.hpp"
+#ifdef OPENHTJ2K_ENABLE_QUIC
+#include "h3_server.hpp"
+#endif
 
 using namespace open_htj2k::jpip;
 
@@ -171,22 +175,66 @@ void handle_connection(TcpStream &conn, const ServerState &st) {
   conn.send_all(resp);
 }
 
+#ifdef OPENHTJ2K_ENABLE_QUIC
+// H3 request handler — parses the JPIP query from the HTTP/3 :path pseudo-header
+// and builds the same JPP-stream as the HTTP/1.1 path.
+std::vector<uint8_t> handle_h3_request(const ServerState &st,
+                                       const open_htj2k::jpip::H3Request &req) {
+  JpipRequest jpip_req;
+  const auto ps = parse_jpip_query(req.query, &jpip_req);
+  if (ps != RequestParseStatus::Ok) return {};
+
+  if (!jpip_req.has_fsiz) {
+    jpip_req.view_window.fx = st.idx->geometry().canvas_size.x;
+    jpip_req.view_window.fy = st.idx->geometry().canvas_size.y;
+  }
+  if (!jpip_req.has_rsiz) {
+    jpip_req.view_window.sx = jpip_req.view_window.fx;
+    jpip_req.view_window.sy = jpip_req.view_window.fy;
+  }
+
+  using Clock = std::chrono::steady_clock;
+  const auto t0 = Clock::now();
+  auto jpp = build_jpp_stream(st, jpip_req.view_window);
+  const auto t1 = Clock::now();
+  const double ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+
+  auto keys = resolve_view_window(*st.idx, jpip_req.view_window);
+  std::printf("  [H3] → %zu precincts (%.1f%%), %zu bytes, %.1f ms\n",
+              keys.size(),
+              st.idx->total_precincts()
+                  ? (100.0 * static_cast<double>(keys.size()) / static_cast<double>(st.idx->total_precincts()))
+                  : 0.0,
+              jpp.size(), ms);
+  std::fflush(stdout);
+  return jpp;
+}
+#endif
+
 }  // namespace
 
 int main(int argc, char **argv) {
   if (argc < 2) {
-    std::fprintf(stderr, "Usage: open_htj2k_jpip_server <input.j2c> [--port N=8080]\n");
+    std::fprintf(stderr,
+        "Usage: open_htj2k_jpip_server <input.j2c> [--port N=8080]\n"
+        "       [--h3 --cert server.cert --key server.key]\n");
     return EXIT_FAILURE;
   }
   std::string infile = argv[1];
   uint16_t port = 8080;
+  bool use_h3 = false;
+  std::string cert_file, key_file;
   for (int i = 2; i < argc; ++i) {
     if (std::strcmp(argv[i], "--port") == 0 && i + 1 < argc) {
       port = static_cast<uint16_t>(std::atoi(argv[++i]));
+    } else if (std::strcmp(argv[i], "--h3") == 0) {
+      use_h3 = true;
+    } else if (std::strcmp(argv[i], "--cert") == 0 && i + 1 < argc) {
+      cert_file = argv[++i];
+    } else if (std::strcmp(argv[i], "--key") == 0 && i + 1 < argc) {
+      key_file = argv[++i];
     }
   }
-
-  tcp_wsa_init();
 
   ServerState st;
   st.codestream = read_file(infile.c_str());
@@ -206,6 +254,35 @@ int main(int argc, char **argv) {
               infile.c_str(),
               st.idx->geometry().canvas_size.x, st.idx->geometry().canvas_size.y,
               static_cast<unsigned long long>(st.idx->total_precincts()));
+
+#ifdef OPENHTJ2K_ENABLE_QUIC
+  if (use_h3) {
+    if (cert_file.empty() || key_file.empty()) {
+      std::fprintf(stderr, "ERROR: --h3 requires --cert and --key\n");
+      return EXIT_FAILURE;
+    }
+    open_htj2k::jpip::TlsCertConfig tls{cert_file, key_file};
+    open_htj2k::jpip::H3Server h3;
+    if (!h3.start(port, tls, [&st](const open_htj2k::jpip::H3Request &req) {
+          return handle_h3_request(st, req);
+        })) {
+      std::fprintf(stderr, "H3 server start failed: %s\n", h3.last_error().c_str());
+      return EXIT_FAILURE;
+    }
+    std::printf("listening on https://localhost:%u/jpip (HTTP/3 over QUIC)\n", port);
+    std::fflush(stdout);
+    // Block until interrupted — MsQuic handles connections on its own threads.
+    std::printf("Press Enter to stop.\n");
+    std::fflush(stdout);
+    std::getchar();
+    h3.stop();
+    return EXIT_SUCCESS;
+  }
+#else
+  (void)use_h3; (void)cert_file; (void)key_file;
+#endif
+
+  tcp_wsa_init();
 
   TcpListener listener;
   if (!listener.bind(port)) {

--- a/source/core/jpip/CMakeLists.txt
+++ b/source/core/jpip/CMakeLists.txt
@@ -14,4 +14,6 @@ target_sources(open_htj2k
     jpip_response.cpp
     tcp_socket.cpp
     jpip_client.cpp
+    h3_server.cpp
+    h3_client.cpp
 )

--- a/source/core/jpip/h3_client.cpp
+++ b/source/core/jpip/h3_client.cpp
@@ -92,12 +92,14 @@ static int64_t client_open_uni(ClientConn *c) {
   HQUIC stream = nullptr;
   QUIC_STATUS s = c->q->StreamOpen(c->conn, QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL,
                                    client_stream_cb, c, &stream);
-  if (QUIC_FAILED(s)) return -1;
+  if (QUIC_FAILED(s)) { std::fprintf(stderr, "H3 client: uni StreamOpen failed 0x%x\n", s); return -1; }
   s = c->q->StreamStart(stream, QUIC_STREAM_START_FLAG_NONE);
-  if (QUIC_FAILED(s)) { c->q->StreamClose(stream); return -1; }
+  if (QUIC_FAILED(s)) { std::fprintf(stderr, "H3 client: uni StreamStart failed 0x%x\n", s); c->q->StreamClose(stream); return -1; }
 
-  // Client-initiated unidirectional: 0x02, 0x06, 0x0A, ...
-  int64_t id = 0x02 + 4 * c->next_uni_id++;
+  QUIC_UINT62 qid = 0;
+  uint32_t sz = sizeof(qid);
+  c->q->GetParam(stream, QUIC_PARAM_STREAM_ID, &sz, &qid);
+  int64_t id = static_cast<int64_t>(qid);
   c->stream_ids[stream] = id;
   c->id_to_stream[id]   = stream;
   return id;
@@ -146,16 +148,22 @@ static bool setup_h3_client(ClientConn *c) {
   nghttp3_settings_default(&settings);
 
   int rv = nghttp3_conn_client_new(&c->h3conn, &cb, &settings, nghttp3_mem_default(), c);
-  if (rv != 0) return false;
+  if (rv != 0) { std::fprintf(stderr, "H3 client: nghttp3_conn_client_new failed: %d\n", rv); return false; }
 
   int64_t ctrl = client_open_uni(c);
   int64_t qenc = client_open_uni(c);
   int64_t qdec = client_open_uni(c);
-  if (ctrl < 0 || qenc < 0 || qdec < 0) return false;
+  if (ctrl < 0 || qenc < 0 || qdec < 0) { std::fprintf(stderr, "H3 client: failed to open uni streams\n"); return false; }
 
-  nghttp3_conn_bind_control_stream(c->h3conn, ctrl);
-  nghttp3_conn_bind_qpack_streams(c->h3conn, qenc, qdec);
+  std::fprintf(stderr, "H3 client: control=%lld qenc=%lld qdec=%lld\n",
+               (long long)ctrl, (long long)qenc, (long long)qdec);
+
+  rv = nghttp3_conn_bind_control_stream(c->h3conn, ctrl);
+  if (rv != 0) { std::fprintf(stderr, "H3 client: bind_control_stream: %d\n", rv); return false; }
+  rv = nghttp3_conn_bind_qpack_streams(c->h3conn, qenc, qdec);
+  if (rv != 0) { std::fprintf(stderr, "H3 client: bind_qpack_streams: %d\n", rv); return false; }
   h3_client_flush(c);
+  std::fprintf(stderr, "H3 client: HTTP/3 setup complete\n");
   return true;
 }
 
@@ -307,12 +315,22 @@ bool H3Client::connect(const std::string &host, uint16_t port, bool validate_cer
     return false;
   }
 
-  // Wait for connection to complete
+  std::fprintf(stderr, "H3 client: waiting for QUIC handshake...\n");
   {
     std::unique_lock<std::mutex> lk(c->mu);
-    c->cv.wait(lk, [c] { return c->connected || c->conn_failed; });
-    if (c->conn_failed) { impl_->error = "QUIC handshake failed"; return false; }
+    if (!c->cv.wait_for(lk, std::chrono::seconds(5),
+                        [c] { return c->connected || c->conn_failed; })) {
+      impl_->error = "QUIC handshake timed out (5s)";
+      std::fprintf(stderr, "H3 client: %s\n", impl_->error.c_str());
+      return false;
+    }
+    if (c->conn_failed) {
+      impl_->error = "QUIC handshake failed";
+      std::fprintf(stderr, "H3 client: %s\n", impl_->error.c_str());
+      return false;
+    }
   }
+  std::fprintf(stderr, "H3 client: QUIC connected\n");
 
   if (!setup_h3_client(c)) {
     impl_->error = "HTTP/3 setup failed";
@@ -383,13 +401,16 @@ std::vector<uint8_t> H3Client::fetch(const std::string &path_and_query) {
   nghttp3_conn_submit_request(c->h3conn, sid, nva, 4, nullptr, nullptr);
   h3_client_flush(c);
 
-  // Wait for response to complete
   {
     std::unique_lock<std::mutex> lk(c->mu);
-    c->cv.wait(lk, [c, sid] {
-      auto it = c->responses.find(sid);
-      return it != c->responses.end() && it->second.done;
-    });
+    if (!c->cv.wait_for(lk, std::chrono::seconds(10), [c, sid] {
+          auto it = c->responses.find(sid);
+          return it != c->responses.end() && it->second.done;
+        })) {
+      impl_->error = "H3 fetch timed out (10s)";
+      std::fprintf(stderr, "H3 client: %s for stream %lld\n", impl_->error.c_str(), (long long)sid);
+      return {};
+    }
   }
 
   std::lock_guard<std::mutex> lk(c->mu);

--- a/source/core/jpip/h3_client.cpp
+++ b/source/core/jpip/h3_client.cpp
@@ -1,0 +1,407 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+
+#ifdef OPENHTJ2K_ENABLE_QUIC
+
+#include "h3_client.hpp"
+
+#include <cstdio>
+#include <cstring>
+#include <condition_variable>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <msquic.h>
+#include <nghttp3/nghttp3.h>
+
+namespace open_htj2k {
+namespace jpip {
+
+// ── Per-connection state ────────────────────────────────────────────────────
+
+struct ClientConn {
+  const QUIC_API_TABLE *q      = nullptr;
+  HQUIC                 conn   = nullptr;
+  HQUIC                 config = nullptr;
+  nghttp3_conn         *h3conn = nullptr;
+
+  std::unordered_map<HQUIC, int64_t> stream_ids;
+  std::unordered_map<int64_t, HQUIC> id_to_stream;
+  int64_t next_uni_id = 0;
+
+  // Synchronisation for blocking fetch()
+  std::mutex              mu;
+  std::condition_variable cv;
+  bool connected   = false;
+  bool conn_failed = false;
+
+  // Per-request response accumulator
+  struct RespState {
+    std::vector<uint8_t> body;
+    bool                 done = false;
+  };
+  std::unordered_map<int64_t, RespState> responses;
+};
+
+// ── Forward declarations ────────────────────────────────────────────────────
+
+static QUIC_STATUS QUIC_API client_conn_cb(HQUIC, void *, QUIC_CONNECTION_EVENT *);
+static QUIC_STATUS QUIC_API client_stream_cb(HQUIC, void *, QUIC_STREAM_EVENT *);
+
+// ── nghttp3 flush writes ────────────────────────────────────────────────────
+
+static void h3_client_flush(ClientConn *c) {
+  for (;;) {
+    nghttp3_vec vec[16];
+    int         fin = 0;
+    int64_t     sid = -1;
+    nghttp3_ssize n = nghttp3_conn_writev_stream(c->h3conn, &sid, &fin, vec, 16);
+    if (n < 0 || sid < 0) break;
+    if (n == 0 && !fin) break;
+
+    auto it = c->id_to_stream.find(sid);
+    if (it == c->id_to_stream.end()) break;
+    HQUIC stream = it->second;
+
+    size_t total = 0;
+    for (nghttp3_ssize i = 0; i < n; ++i) total += vec[i].len;
+
+    if (total > 0 || fin) {
+      auto *buf = new uint8_t[total];
+      size_t off = 0;
+      for (nghttp3_ssize i = 0; i < n; ++i) {
+        std::memcpy(buf + off, vec[i].base, vec[i].len);
+        off += vec[i].len;
+      }
+      QUIC_BUFFER qb;
+      qb.Length = static_cast<uint32_t>(total);
+      qb.Buffer = buf;
+      QUIC_SEND_FLAGS flags = fin ? QUIC_SEND_FLAG_FIN : QUIC_SEND_FLAG_NONE;
+      c->q->StreamSend(stream, &qb, 1, flags, buf);
+      nghttp3_conn_add_write_offset(c->h3conn, sid, static_cast<int64_t>(total));
+    }
+    if (n == 0) break;
+  }
+}
+
+// ── Open client unidirectional stream ───────────────────────────────────────
+
+static int64_t client_open_uni(ClientConn *c) {
+  HQUIC stream = nullptr;
+  QUIC_STATUS s = c->q->StreamOpen(c->conn, QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL,
+                                   client_stream_cb, c, &stream);
+  if (QUIC_FAILED(s)) return -1;
+  s = c->q->StreamStart(stream, QUIC_STREAM_START_FLAG_NONE);
+  if (QUIC_FAILED(s)) { c->q->StreamClose(stream); return -1; }
+
+  // Client-initiated unidirectional: 0x02, 0x06, 0x0A, ...
+  int64_t id = 0x02 + 4 * c->next_uni_id++;
+  c->stream_ids[stream] = id;
+  c->id_to_stream[id]   = stream;
+  return id;
+}
+
+// ── nghttp3 client callbacks ────────────────────────────────────────────────
+
+static int h3c_recv_data(nghttp3_conn *, int64_t stream_id, const uint8_t *data,
+                         size_t datalen, void *conn_data, void *) {
+  auto *c = static_cast<ClientConn *>(conn_data);
+  std::lock_guard<std::mutex> lk(c->mu);
+  auto &resp = c->responses[stream_id];
+  resp.body.insert(resp.body.end(), data, data + datalen);
+  return 0;
+}
+
+static int h3c_end_stream(nghttp3_conn *, int64_t stream_id, void *conn_data, void *) {
+  auto *c = static_cast<ClientConn *>(conn_data);
+  {
+    std::lock_guard<std::mutex> lk(c->mu);
+    c->responses[stream_id].done = true;
+  }
+  c->cv.notify_all();
+  return 0;
+}
+
+static int h3c_deferred_consume(nghttp3_conn *, int64_t stream_id, size_t consumed,
+                                void *conn_data, void *) {
+  auto *c = static_cast<ClientConn *>(conn_data);
+  auto it = c->id_to_stream.find(stream_id);
+  if (it != c->id_to_stream.end()) {
+    c->q->StreamReceiveComplete(it->second, consumed);
+  }
+  return 0;
+}
+
+// ── Setup nghttp3 client connection ─────────────────────────────────────────
+
+static bool setup_h3_client(ClientConn *c) {
+  nghttp3_callbacks cb = {};
+  cb.recv_data        = h3c_recv_data;
+  cb.end_stream       = h3c_end_stream;
+  cb.deferred_consume = h3c_deferred_consume;
+
+  nghttp3_settings settings;
+  nghttp3_settings_default(&settings);
+
+  int rv = nghttp3_conn_client_new(&c->h3conn, &cb, &settings, nghttp3_mem_default(), c);
+  if (rv != 0) return false;
+
+  int64_t ctrl = client_open_uni(c);
+  int64_t qenc = client_open_uni(c);
+  int64_t qdec = client_open_uni(c);
+  if (ctrl < 0 || qenc < 0 || qdec < 0) return false;
+
+  nghttp3_conn_bind_control_stream(c->h3conn, ctrl);
+  nghttp3_conn_bind_qpack_streams(c->h3conn, qenc, qdec);
+  h3_client_flush(c);
+  return true;
+}
+
+// ── MsQuic client callbacks ─────────────────────────────────────────────────
+
+static QUIC_STATUS QUIC_API client_stream_cb(HQUIC stream, void *context,
+                                             QUIC_STREAM_EVENT *event) {
+  auto *c = static_cast<ClientConn *>(context);
+  switch (event->Type) {
+    case QUIC_STREAM_EVENT_RECEIVE: {
+      auto it = c->stream_ids.find(stream);
+      if (it == c->stream_ids.end()) break;
+      int64_t sid = it->second;
+      for (uint32_t i = 0; i < event->RECEIVE.BufferCount; ++i) {
+        nghttp3_conn_read_stream(c->h3conn, sid,
+                                 event->RECEIVE.Buffers[i].Buffer,
+                                 event->RECEIVE.Buffers[i].Length, 0);
+      }
+      if (event->RECEIVE.Flags & QUIC_RECEIVE_FLAG_FIN) {
+        nghttp3_conn_read_stream(c->h3conn, sid, nullptr, 0, 1);
+      }
+      h3_client_flush(c);
+      break;
+    }
+    case QUIC_STREAM_EVENT_SEND_COMPLETE: {
+      delete[] static_cast<uint8_t *>(event->SEND_COMPLETE.ClientContext);
+      break;
+    }
+    case QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE: {
+      auto it = c->stream_ids.find(stream);
+      if (it != c->stream_ids.end()) {
+        c->id_to_stream.erase(it->second);
+        c->stream_ids.erase(it);
+      }
+      c->q->StreamClose(stream);
+      break;
+    }
+    default:
+      break;
+  }
+  return QUIC_STATUS_SUCCESS;
+}
+
+static QUIC_STATUS QUIC_API client_conn_cb(HQUIC conn, void *context,
+                                           QUIC_CONNECTION_EVENT *event) {
+  auto *c = static_cast<ClientConn *>(context);
+  switch (event->Type) {
+    case QUIC_CONNECTION_EVENT_CONNECTED: {
+      std::lock_guard<std::mutex> lk(c->mu);
+      c->connected = true;
+      c->cv.notify_all();
+      break;
+    }
+    case QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_TRANSPORT:
+    case QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_PEER: {
+      std::lock_guard<std::mutex> lk(c->mu);
+      c->conn_failed = true;
+      c->cv.notify_all();
+      break;
+    }
+    case QUIC_CONNECTION_EVENT_PEER_STREAM_STARTED: {
+      HQUIC stream = event->PEER_STREAM_STARTED.Stream;
+      c->q->SetCallbackHandler(stream, (void *)client_stream_cb, c);
+      QUIC_UINT62 sid = 0;
+      uint32_t sz = sizeof(sid);
+      c->q->GetParam(stream, QUIC_PARAM_STREAM_ID, &sz, &sid);
+      c->stream_ids[stream]                        = static_cast<int64_t>(sid);
+      c->id_to_stream[static_cast<int64_t>(sid)]   = stream;
+      break;
+    }
+    case QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE:
+      break;
+    default:
+      break;
+  }
+  return QUIC_STATUS_SUCCESS;
+}
+
+// ── H3Client::Impl ──────────────────────────────────────────────────────────
+
+struct H3Client::Impl {
+  const QUIC_API_TABLE *q    = nullptr;
+  HQUIC                 reg  = nullptr;
+  HQUIC                 cfg  = nullptr;
+  ClientConn           *conn = nullptr;
+  std::string           host;
+  std::string           error;
+};
+
+H3Client::H3Client() : impl_(new Impl()) {}
+
+H3Client::~H3Client() {
+  disconnect();
+  delete impl_;
+}
+
+bool H3Client::connect(const std::string &host, uint16_t port, bool validate_cert) {
+  impl_->host = host;
+
+  if (QUIC_FAILED(MsQuicOpen2(&impl_->q))) {
+    impl_->error = "MsQuicOpen2 failed";
+    return false;
+  }
+
+  QUIC_REGISTRATION_CONFIG rc = {"jpip-h3-client", QUIC_EXECUTION_PROFILE_LOW_LATENCY};
+  if (QUIC_FAILED(impl_->q->RegistrationOpen(&rc, &impl_->reg))) {
+    impl_->error = "RegistrationOpen failed";
+    return false;
+  }
+
+  const QUIC_BUFFER alpn = {2, (uint8_t *)"h3"};
+  QUIC_SETTINGS settings = {};
+  settings.IdleTimeoutMs = 30000;
+  settings.IsSet.IdleTimeoutMs = TRUE;
+  settings.PeerBidiStreamCount = 128;
+  settings.IsSet.PeerBidiStreamCount = TRUE;
+  settings.PeerUnidiStreamCount = 8;
+  settings.IsSet.PeerUnidiStreamCount = TRUE;
+
+  if (QUIC_FAILED(impl_->q->ConfigurationOpen(impl_->reg, &alpn, 1, &settings,
+                                               sizeof(settings), nullptr, &impl_->cfg))) {
+    impl_->error = "ConfigurationOpen failed";
+    return false;
+  }
+
+  QUIC_CREDENTIAL_CONFIG cred = {};
+  cred.Type  = QUIC_CREDENTIAL_TYPE_NONE;
+  cred.Flags = QUIC_CREDENTIAL_FLAG_CLIENT;
+  if (!validate_cert) {
+    cred.Flags = (QUIC_CREDENTIAL_FLAGS)(cred.Flags | QUIC_CREDENTIAL_FLAG_NO_CERTIFICATE_VALIDATION);
+  }
+  if (QUIC_FAILED(impl_->q->ConfigurationLoadCredential(impl_->cfg, &cred))) {
+    impl_->error = "ConfigurationLoadCredential failed";
+    return false;
+  }
+
+  auto *c = new ClientConn();
+  c->q = impl_->q;
+  impl_->conn = c;
+
+  if (QUIC_FAILED(impl_->q->ConnectionOpen(impl_->reg, client_conn_cb, c, &c->conn))) {
+    impl_->error = "ConnectionOpen failed";
+    return false;
+  }
+  if (QUIC_FAILED(impl_->q->ConnectionStart(c->conn, impl_->cfg,
+                                             QUIC_ADDRESS_FAMILY_UNSPEC,
+                                             host.c_str(), port))) {
+    impl_->error = "ConnectionStart failed";
+    return false;
+  }
+
+  // Wait for connection to complete
+  {
+    std::unique_lock<std::mutex> lk(c->mu);
+    c->cv.wait(lk, [c] { return c->connected || c->conn_failed; });
+    if (c->conn_failed) { impl_->error = "QUIC handshake failed"; return false; }
+  }
+
+  if (!setup_h3_client(c)) {
+    impl_->error = "HTTP/3 setup failed";
+    return false;
+  }
+
+  return true;
+}
+
+void H3Client::disconnect() {
+  if (impl_->conn) {
+    if (impl_->conn->h3conn) {
+      nghttp3_conn_del(impl_->conn->h3conn);
+      impl_->conn->h3conn = nullptr;
+    }
+    if (impl_->conn->conn) {
+      impl_->q->ConnectionShutdown(impl_->conn->conn, QUIC_CONNECTION_SHUTDOWN_FLAG_NONE, 0);
+      impl_->q->ConnectionClose(impl_->conn->conn);
+    }
+    delete impl_->conn;
+    impl_->conn = nullptr;
+  }
+  if (impl_->cfg) { impl_->q->ConfigurationClose(impl_->cfg); impl_->cfg = nullptr; }
+  if (impl_->reg) { impl_->q->RegistrationClose(impl_->reg); impl_->reg = nullptr; }
+  if (impl_->q)   { MsQuicClose(impl_->q); impl_->q = nullptr; }
+}
+
+std::vector<uint8_t> H3Client::fetch(const std::string &path_and_query) {
+  auto *c = impl_->conn;
+  if (!c || !c->h3conn) { impl_->error = "not connected"; return {}; }
+
+  // Open a new bidirectional stream
+  HQUIC stream = nullptr;
+  if (QUIC_FAILED(impl_->q->StreamOpen(c->conn, QUIC_STREAM_OPEN_FLAG_NONE,
+                                       client_stream_cb, c, &stream))) {
+    impl_->error = "StreamOpen failed";
+    return {};
+  }
+  if (QUIC_FAILED(impl_->q->StreamStart(stream, QUIC_STREAM_START_FLAG_NONE))) {
+    impl_->error = "StreamStart failed";
+    impl_->q->StreamClose(stream);
+    return {};
+  }
+
+  // Get the QUIC-assigned stream ID
+  QUIC_UINT62 qid = 0;
+  uint32_t sz = sizeof(qid);
+  impl_->q->GetParam(stream, QUIC_PARAM_STREAM_ID, &sz, &qid);
+  int64_t sid = static_cast<int64_t>(qid);
+  c->stream_ids[stream] = sid;
+  c->id_to_stream[sid]  = stream;
+
+  // Submit HTTP/3 request headers
+  nghttp3_nv nva[] = {
+    {(uint8_t *)":method", (uint8_t *)"GET", 7, 3, NGHTTP3_NV_FLAG_NONE},
+    {(uint8_t *)":scheme", (uint8_t *)"https", 7, 5, NGHTTP3_NV_FLAG_NONE},
+    {(uint8_t *)":authority", (uint8_t *)impl_->host.c_str(), 10,
+     impl_->host.size(), NGHTTP3_NV_FLAG_NO_COPY_VALUE},
+    {(uint8_t *)":path", (uint8_t *)path_and_query.c_str(), 5,
+     path_and_query.size(), NGHTTP3_NV_FLAG_NO_COPY_VALUE},
+  };
+
+  {
+    std::lock_guard<std::mutex> lk(c->mu);
+    c->responses[sid] = {};
+  }
+
+  nghttp3_conn_submit_request(c->h3conn, sid, nva, 4, nullptr, nullptr);
+  h3_client_flush(c);
+
+  // Wait for response to complete
+  {
+    std::unique_lock<std::mutex> lk(c->mu);
+    c->cv.wait(lk, [c, sid] {
+      auto it = c->responses.find(sid);
+      return it != c->responses.end() && it->second.done;
+    });
+  }
+
+  std::lock_guard<std::mutex> lk(c->mu);
+  auto it = c->responses.find(sid);
+  std::vector<uint8_t> body = std::move(it->second.body);
+  c->responses.erase(it);
+  return body;
+}
+
+std::string H3Client::last_error() const { return impl_->error; }
+
+}  // namespace jpip
+}  // namespace open_htj2k
+
+#endif  // OPENHTJ2K_ENABLE_QUIC

--- a/source/core/jpip/h3_client.cpp
+++ b/source/core/jpip/h3_client.cpp
@@ -54,20 +54,27 @@ static QUIC_STATUS QUIC_API client_stream_cb(HQUIC, void *, QUIC_STREAM_EVENT *)
 // ── nghttp3 flush writes ────────────────────────────────────────────────────
 
 static void h3_client_flush(ClientConn *c) {
+  int rounds = 0;
   for (;;) {
     nghttp3_vec vec[16];
     int         fin = 0;
     int64_t     sid = -1;
     nghttp3_ssize n = nghttp3_conn_writev_stream(c->h3conn, &sid, &fin, vec, 16);
-    if (n < 0 || sid < 0) break;
+    if (n < 0) { std::fprintf(stderr, "H3 client flush: writev error %lld\n", (long long)n); break; }
+    if (sid < 0) break;
     if (n == 0 && !fin) break;
 
     auto it = c->id_to_stream.find(sid);
-    if (it == c->id_to_stream.end()) break;
+    if (it == c->id_to_stream.end()) {
+      std::fprintf(stderr, "H3 client flush: no QUIC stream for nghttp3 sid=%lld\n", (long long)sid);
+      break;
+    }
     HQUIC stream = it->second;
 
     size_t total = 0;
     for (nghttp3_ssize i = 0; i < n; ++i) total += vec[i].len;
+
+    std::fprintf(stderr, "H3 client flush: sid=%lld %zu bytes fin=%d\n", (long long)sid, total, fin);
 
     if (total > 0 || fin) {
       auto *buf = new uint8_t[total];
@@ -80,10 +87,15 @@ static void h3_client_flush(ClientConn *c) {
       qb.Length = static_cast<uint32_t>(total);
       qb.Buffer = buf;
       QUIC_SEND_FLAGS flags = fin ? QUIC_SEND_FLAG_FIN : QUIC_SEND_FLAG_NONE;
-      c->q->StreamSend(stream, &qb, 1, flags, buf);
+      QUIC_STATUS s = c->q->StreamSend(stream, &qb, 1, flags, buf);
+      if (QUIC_FAILED(s)) {
+        std::fprintf(stderr, "H3 client flush: StreamSend failed 0x%x sid=%lld\n", s, (long long)sid);
+        delete[] buf;
+      }
       nghttp3_conn_add_write_offset(c->h3conn, sid, static_cast<int64_t>(total));
     }
     if (n == 0) break;
+    if (++rounds > 100) break;
   }
 }
 

--- a/source/core/jpip/h3_client.cpp
+++ b/source/core/jpip/h3_client.cpp
@@ -93,7 +93,7 @@ static int64_t client_open_uni(ClientConn *c) {
   QUIC_STATUS s = c->q->StreamOpen(c->conn, QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL,
                                    client_stream_cb, c, &stream);
   if (QUIC_FAILED(s)) { std::fprintf(stderr, "H3 client: uni StreamOpen failed 0x%x\n", s); return -1; }
-  s = c->q->StreamStart(stream, QUIC_STREAM_START_FLAG_NONE);
+  s = c->q->StreamStart(stream, QUIC_STREAM_START_FLAG_IMMEDIATE);
   if (QUIC_FAILED(s)) { std::fprintf(stderr, "H3 client: uni StreamStart failed 0x%x\n", s); c->q->StreamClose(stream); return -1; }
 
   QUIC_UINT62 qid = 0;
@@ -369,7 +369,7 @@ std::vector<uint8_t> H3Client::fetch(const std::string &path_and_query) {
     impl_->error = "StreamOpen failed";
     return {};
   }
-  if (QUIC_FAILED(impl_->q->StreamStart(stream, QUIC_STREAM_START_FLAG_NONE))) {
+  if (QUIC_FAILED(impl_->q->StreamStart(stream, QUIC_STREAM_START_FLAG_IMMEDIATE))) {
     impl_->error = "StreamStart failed";
     impl_->q->StreamClose(stream);
     return {};

--- a/source/core/jpip/h3_client.cpp
+++ b/source/core/jpip/h3_client.cpp
@@ -119,6 +119,15 @@ static int64_t client_open_uni(ClientConn *c) {
 
 // ── nghttp3 client callbacks ────────────────────────────────────────────────
 
+static int h3c_recv_header(nghttp3_conn *, int64_t stream_id, int32_t,
+                           nghttp3_rcbuf *name, nghttp3_rcbuf *value, uint8_t, void *, void *) {
+  auto nv = nghttp3_rcbuf_get_buf(name);
+  auto vv = nghttp3_rcbuf_get_buf(value);
+  std::fprintf(stderr, "H3 client recv_header: sid=%lld %.*s: %.*s\n",
+               (long long)stream_id, (int)nv.len, nv.base, (int)vv.len, vv.base);
+  return 0;
+}
+
 static int h3c_recv_data(nghttp3_conn *, int64_t stream_id, const uint8_t *data,
                          size_t datalen, void *conn_data, void *) {
   auto *c = static_cast<ClientConn *>(conn_data);
@@ -152,6 +161,7 @@ static int h3c_deferred_consume(nghttp3_conn *, int64_t stream_id, size_t consum
 
 static bool setup_h3_client(ClientConn *c) {
   nghttp3_callbacks cb = {};
+  cb.recv_header      = h3c_recv_header;
   cb.recv_data        = h3c_recv_data;
   cb.end_stream       = h3c_end_stream;
   cb.deferred_consume = h3c_deferred_consume;
@@ -194,9 +204,16 @@ static QUIC_STATUS QUIC_API client_stream_cb(HQUIC stream, void *context,
       int64_t sid = it->second;
       uint64_t total = 0;
       for (uint32_t i = 0; i < event->RECEIVE.BufferCount; ++i) total += event->RECEIVE.Buffers[i].Length;
-      std::fprintf(stderr, "H3 client recv: sid=%lld %llu bytes fin=%d\n",
+      std::fprintf(stderr, "H3 client recv: sid=%lld %llu bytes fin=%d",
                    (long long)sid, (unsigned long long)total,
                    (event->RECEIVE.Flags & QUIC_RECEIVE_FLAG_FIN) ? 1 : 0);
+      if (total > 0 && total <= 32 && event->RECEIVE.BufferCount > 0) {
+        std::fprintf(stderr, " hex=");
+        const uint8_t *p = event->RECEIVE.Buffers[0].Buffer;
+        for (uint32_t j = 0; j < event->RECEIVE.Buffers[0].Length && j < 32; ++j)
+          std::fprintf(stderr, "%02x", p[j]);
+      }
+      std::fprintf(stderr, "\n");
       for (uint32_t i = 0; i < event->RECEIVE.BufferCount; ++i) {
         nghttp3_ssize consumed = nghttp3_conn_read_stream(c->h3conn, sid,
                                  event->RECEIVE.Buffers[i].Buffer,

--- a/source/core/jpip/h3_client.cpp
+++ b/source/core/jpip/h3_client.cpp
@@ -398,7 +398,14 @@ std::vector<uint8_t> H3Client::fetch(const std::string &path_and_query) {
     c->responses[sid] = {};
   }
 
-  nghttp3_conn_submit_request(c->h3conn, sid, nva, 4, nullptr, nullptr);
+  std::fprintf(stderr, "H3 client: submit_request stream=%lld path=%s\n",
+               (long long)sid, path_and_query.c_str());
+  int rv = nghttp3_conn_submit_request(c->h3conn, sid, nva, 4, nullptr, nullptr);
+  if (rv != 0) {
+    std::fprintf(stderr, "H3 client: submit_request failed: %d\n", rv);
+    impl_->error = "submit_request failed";
+    return {};
+  }
   h3_client_flush(c);
 
   {

--- a/source/core/jpip/h3_client.cpp
+++ b/source/core/jpip/h3_client.cpp
@@ -29,8 +29,9 @@ struct ClientConn {
 
   std::unordered_map<HQUIC, int64_t> stream_ids;
   std::unordered_map<int64_t, HQUIC> id_to_stream;
-  int64_t next_uni_id  = 0;
-  int64_t next_bidi_id = 0;
+  int64_t next_uni_id       = 0;  // client-initiated uni: 2, 6, 10, ...
+  int64_t next_bidi_id      = 0;  // client-initiated bidi: 0, 4, 8, ...
+  int64_t next_peer_uni_id  = 0;  // server-initiated uni: 3, 7, 11, ...
 
   // Synchronisation for blocking fetch()
   std::mutex              mu;
@@ -238,11 +239,10 @@ static QUIC_STATUS QUIC_API client_conn_cb(HQUIC conn, void *context,
     case QUIC_CONNECTION_EVENT_PEER_STREAM_STARTED: {
       HQUIC stream = event->PEER_STREAM_STARTED.Stream;
       c->q->SetCallbackHandler(stream, (void *)client_stream_cb, c);
-      QUIC_UINT62 sid = 0;
-      uint32_t sz = sizeof(sid);
-      c->q->GetParam(stream, QUIC_PARAM_STREAM_ID, &sz, &sid);
-      c->stream_ids[stream]                        = static_cast<int64_t>(sid);
-      c->id_to_stream[static_cast<int64_t>(sid)]   = stream;
+      // Server-initiated uni streams: 3, 7, 11, ...
+      int64_t sid = 0x03 + 4 * c->next_peer_uni_id++;
+      c->stream_ids[stream]  = sid;
+      c->id_to_stream[sid]   = stream;
       break;
     }
     case QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE:

--- a/source/core/jpip/h3_client.cpp
+++ b/source/core/jpip/h3_client.cpp
@@ -29,7 +29,8 @@ struct ClientConn {
 
   std::unordered_map<HQUIC, int64_t> stream_ids;
   std::unordered_map<int64_t, HQUIC> id_to_stream;
-  int64_t next_uni_id = 0;
+  int64_t next_uni_id  = 0;
+  int64_t next_bidi_id = 0;
 
   // Synchronisation for blocking fetch()
   std::mutex              mu;
@@ -96,10 +97,8 @@ static int64_t client_open_uni(ClientConn *c) {
   s = c->q->StreamStart(stream, QUIC_STREAM_START_FLAG_IMMEDIATE);
   if (QUIC_FAILED(s)) { std::fprintf(stderr, "H3 client: uni StreamStart failed 0x%x\n", s); c->q->StreamClose(stream); return -1; }
 
-  QUIC_UINT62 qid = 0;
-  uint32_t sz = sizeof(qid);
-  c->q->GetParam(stream, QUIC_PARAM_STREAM_ID, &sz, &qid);
-  int64_t id = static_cast<int64_t>(qid);
+  // Client-initiated unidirectional stream IDs: 0x02, 0x06, 0x0A, ...
+  int64_t id = 0x02 + 4 * c->next_uni_id++;
   c->stream_ids[stream] = id;
   c->id_to_stream[id]   = stream;
   return id;
@@ -375,11 +374,8 @@ std::vector<uint8_t> H3Client::fetch(const std::string &path_and_query) {
     return {};
   }
 
-  // Get the QUIC-assigned stream ID
-  QUIC_UINT62 qid = 0;
-  uint32_t sz = sizeof(qid);
-  impl_->q->GetParam(stream, QUIC_PARAM_STREAM_ID, &sz, &qid);
-  int64_t sid = static_cast<int64_t>(qid);
+  // Client-initiated bidirectional stream IDs: 0x00, 0x04, 0x08, ...
+  int64_t sid = 4 * c->next_bidi_id++;
   c->stream_ids[stream] = sid;
   c->id_to_stream[sid]  = stream;
 

--- a/source/core/jpip/h3_client.cpp
+++ b/source/core/jpip/h3_client.cpp
@@ -5,7 +5,6 @@
 
 #include "h3_client.hpp"
 
-#include <cstdio>
 #include <cstring>
 #include <condition_variable>
 #include <mutex>
@@ -60,27 +59,21 @@ struct SendCtx {
 };
 
 static void h3_client_flush(ClientConn *c) {
-  int rounds = 0;
   for (;;) {
     nghttp3_vec vec[16];
     int         fin = 0;
     int64_t     sid = -1;
     nghttp3_ssize n = nghttp3_conn_writev_stream(c->h3conn, &sid, &fin, vec, 16);
-    if (n < 0) { std::fprintf(stderr, "H3 client flush: writev error %lld\n", (long long)n); break; }
+    if (n < 0) break;
     if (sid < 0) break;
     if (n == 0 && !fin) break;
 
     auto it = c->id_to_stream.find(sid);
-    if (it == c->id_to_stream.end()) {
-      std::fprintf(stderr, "H3 client flush: no QUIC stream for nghttp3 sid=%lld\n", (long long)sid);
-      break;
-    }
+    if (it == c->id_to_stream.end()) break;
     HQUIC stream = it->second;
 
     size_t total = 0;
     for (nghttp3_ssize i = 0; i < n; ++i) total += vec[i].len;
-
-    std::fprintf(stderr, "H3 client flush: sid=%lld %zu bytes fin=%d\n", (long long)sid, total, fin);
 
     if (total > 0 || fin) {
       auto *sc = static_cast<SendCtx *>(std::malloc(sizeof(SendCtx) + total));
@@ -94,13 +87,11 @@ static void h3_client_flush(ClientConn *c) {
       QUIC_SEND_FLAGS flags = fin ? QUIC_SEND_FLAG_FIN : QUIC_SEND_FLAG_NONE;
       QUIC_STATUS s = c->q->StreamSend(stream, &sc->qb, 1, flags, sc);
       if (QUIC_FAILED(s)) {
-        std::fprintf(stderr, "H3 client flush: StreamSend failed 0x%x sid=%lld\n", s, (long long)sid);
         std::free(sc);
       }
       nghttp3_conn_add_write_offset(c->h3conn, sid, static_cast<int64_t>(total));
     }
     if (n == 0) break;
-    if (++rounds > 100) break;
   }
 }
 
@@ -110,9 +101,9 @@ static int64_t client_open_uni(ClientConn *c) {
   HQUIC stream = nullptr;
   QUIC_STATUS s = c->q->StreamOpen(c->conn, QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL,
                                    client_stream_cb, c, &stream);
-  if (QUIC_FAILED(s)) { std::fprintf(stderr, "H3 client: uni StreamOpen failed 0x%x\n", s); return -1; }
+  if (QUIC_FAILED(s)) return -1;
   s = c->q->StreamStart(stream, QUIC_STREAM_START_FLAG_IMMEDIATE);
-  if (QUIC_FAILED(s)) { std::fprintf(stderr, "H3 client: uni StreamStart failed 0x%x\n", s); c->q->StreamClose(stream); return -1; }
+  if (QUIC_FAILED(s)) { c->q->StreamClose(stream); return -1; }
 
   // Client-initiated unidirectional stream IDs: 0x02, 0x06, 0x0A, ...
   int64_t id = 0x02 + 4 * c->next_uni_id++;
@@ -123,12 +114,8 @@ static int64_t client_open_uni(ClientConn *c) {
 
 // ── nghttp3 client callbacks ────────────────────────────────────────────────
 
-static int h3c_recv_header(nghttp3_conn *, int64_t stream_id, int32_t,
-                           nghttp3_rcbuf *name, nghttp3_rcbuf *value, uint8_t, void *, void *) {
-  auto nv = nghttp3_rcbuf_get_buf(name);
-  auto vv = nghttp3_rcbuf_get_buf(value);
-  std::fprintf(stderr, "H3 client recv_header: sid=%lld %.*s: %.*s\n",
-               (long long)stream_id, (int)nv.len, nv.base, (int)vv.len, vv.base);
+static int h3c_recv_header(nghttp3_conn *, int64_t, int32_t,
+                           nghttp3_rcbuf *, nghttp3_rcbuf *, uint8_t, void *, void *) {
   return 0;
 }
 
@@ -174,22 +161,18 @@ static bool setup_h3_client(ClientConn *c) {
   nghttp3_settings_default(&settings);
 
   int rv = nghttp3_conn_client_new(&c->h3conn, &cb, &settings, nghttp3_mem_default(), c);
-  if (rv != 0) { std::fprintf(stderr, "H3 client: nghttp3_conn_client_new failed: %d\n", rv); return false; }
+  if (rv != 0) return false;
 
   int64_t ctrl = client_open_uni(c);
   int64_t qenc = client_open_uni(c);
   int64_t qdec = client_open_uni(c);
-  if (ctrl < 0 || qenc < 0 || qdec < 0) { std::fprintf(stderr, "H3 client: failed to open uni streams\n"); return false; }
-
-  std::fprintf(stderr, "H3 client: control=%lld qenc=%lld qdec=%lld\n",
-               (long long)ctrl, (long long)qenc, (long long)qdec);
+  if (ctrl < 0 || qenc < 0 || qdec < 0) return false;
 
   rv = nghttp3_conn_bind_control_stream(c->h3conn, ctrl);
-  if (rv != 0) { std::fprintf(stderr, "H3 client: bind_control_stream: %d\n", rv); return false; }
+  if (rv != 0) return false;
   rv = nghttp3_conn_bind_qpack_streams(c->h3conn, qenc, qdec);
-  if (rv != 0) { std::fprintf(stderr, "H3 client: bind_qpack_streams: %d\n", rv); return false; }
+  if (rv != 0) return false;
   h3_client_flush(c);
-  std::fprintf(stderr, "H3 client: HTTP/3 setup complete\n");
   return true;
 }
 
@@ -201,31 +184,12 @@ static QUIC_STATUS QUIC_API client_stream_cb(HQUIC stream, void *context,
   switch (event->Type) {
     case QUIC_STREAM_EVENT_RECEIVE: {
       auto it = c->stream_ids.find(stream);
-      if (it == c->stream_ids.end()) {
-        std::fprintf(stderr, "H3 client recv: unknown stream handle\n");
-        break;
-      }
+      if (it == c->stream_ids.end()) break;
       int64_t sid = it->second;
-      uint64_t total = 0;
-      for (uint32_t i = 0; i < event->RECEIVE.BufferCount; ++i) total += event->RECEIVE.Buffers[i].Length;
-      std::fprintf(stderr, "H3 client recv: sid=%lld %llu bytes fin=%d",
-                   (long long)sid, (unsigned long long)total,
-                   (event->RECEIVE.Flags & QUIC_RECEIVE_FLAG_FIN) ? 1 : 0);
-      if (total > 0 && total <= 32 && event->RECEIVE.BufferCount > 0) {
-        std::fprintf(stderr, " hex=");
-        const uint8_t *p = event->RECEIVE.Buffers[0].Buffer;
-        for (uint32_t j = 0; j < event->RECEIVE.Buffers[0].Length && j < 32; ++j)
-          std::fprintf(stderr, "%02x", p[j]);
-      }
-      std::fprintf(stderr, "\n");
       for (uint32_t i = 0; i < event->RECEIVE.BufferCount; ++i) {
-        nghttp3_ssize consumed = nghttp3_conn_read_stream(c->h3conn, sid,
+        nghttp3_conn_read_stream(c->h3conn, sid,
                                  event->RECEIVE.Buffers[i].Buffer,
                                  event->RECEIVE.Buffers[i].Length, 0);
-        if (consumed < 0) {
-          std::fprintf(stderr, "H3 client recv: read_stream error %lld sid=%lld\n",
-                       (long long)consumed, (long long)sid);
-        }
       }
       if (event->RECEIVE.Flags & QUIC_RECEIVE_FLAG_FIN) {
         nghttp3_conn_read_stream(c->h3conn, sid, nullptr, 0, 1);
@@ -359,23 +323,18 @@ bool H3Client::connect(const std::string &host, uint16_t port, bool validate_cer
     return false;
   }
 
-  std::fprintf(stderr, "H3 client: waiting for QUIC handshake...\n");
   {
     std::unique_lock<std::mutex> lk(c->mu);
     if (!c->cv.wait_for(lk, std::chrono::seconds(5),
                         [c] { return c->connected || c->conn_failed; })) {
       impl_->error = "QUIC handshake timed out (5s)";
-      std::fprintf(stderr, "H3 client: %s\n", impl_->error.c_str());
       return false;
     }
     if (c->conn_failed) {
       impl_->error = "QUIC handshake failed";
-      std::fprintf(stderr, "H3 client: %s\n", impl_->error.c_str());
       return false;
     }
   }
-  std::fprintf(stderr, "H3 client: QUIC connected\n");
-
   if (!setup_h3_client(c)) {
     impl_->error = "HTTP/3 setup failed";
     return false;
@@ -439,11 +398,8 @@ std::vector<uint8_t> H3Client::fetch(const std::string &path_and_query) {
     c->responses[sid] = {};
   }
 
-  std::fprintf(stderr, "H3 client: submit_request stream=%lld path=%s\n",
-               (long long)sid, path_and_query.c_str());
   int rv = nghttp3_conn_submit_request(c->h3conn, sid, nva, 4, nullptr, nullptr);
   if (rv != 0) {
-    std::fprintf(stderr, "H3 client: submit_request failed: %d\n", rv);
     impl_->error = "submit_request failed";
     return {};
   }
@@ -456,7 +412,6 @@ std::vector<uint8_t> H3Client::fetch(const std::string &path_and_query) {
           return it != c->responses.end() && it->second.done;
         })) {
       impl_->error = "H3 fetch timed out (10s)";
-      std::fprintf(stderr, "H3 client: %s for stream %lld\n", impl_->error.c_str(), (long long)sid);
       return {};
     }
   }

--- a/source/core/jpip/h3_client.cpp
+++ b/source/core/jpip/h3_client.cpp
@@ -54,6 +54,11 @@ static QUIC_STATUS QUIC_API client_stream_cb(HQUIC, void *, QUIC_STREAM_EVENT *)
 
 // ── nghttp3 flush writes ────────────────────────────────────────────────────
 
+struct SendCtx {
+  QUIC_BUFFER qb;
+  uint8_t     data[];
+};
+
 static void h3_client_flush(ClientConn *c) {
   int rounds = 0;
   for (;;) {
@@ -78,20 +83,19 @@ static void h3_client_flush(ClientConn *c) {
     std::fprintf(stderr, "H3 client flush: sid=%lld %zu bytes fin=%d\n", (long long)sid, total, fin);
 
     if (total > 0 || fin) {
-      auto *buf = new uint8_t[total];
+      auto *sc = static_cast<SendCtx *>(std::malloc(sizeof(SendCtx) + total));
+      sc->qb.Length = static_cast<uint32_t>(total);
+      sc->qb.Buffer = sc->data;
       size_t off = 0;
       for (nghttp3_ssize i = 0; i < n; ++i) {
-        std::memcpy(buf + off, vec[i].base, vec[i].len);
+        std::memcpy(sc->data + off, vec[i].base, vec[i].len);
         off += vec[i].len;
       }
-      QUIC_BUFFER qb;
-      qb.Length = static_cast<uint32_t>(total);
-      qb.Buffer = buf;
       QUIC_SEND_FLAGS flags = fin ? QUIC_SEND_FLAG_FIN : QUIC_SEND_FLAG_NONE;
-      QUIC_STATUS s = c->q->StreamSend(stream, &qb, 1, flags, buf);
+      QUIC_STATUS s = c->q->StreamSend(stream, &sc->qb, 1, flags, sc);
       if (QUIC_FAILED(s)) {
         std::fprintf(stderr, "H3 client flush: StreamSend failed 0x%x sid=%lld\n", s, (long long)sid);
-        delete[] buf;
+        std::free(sc);
       }
       nghttp3_conn_add_write_offset(c->h3conn, sid, static_cast<int64_t>(total));
     }
@@ -230,7 +234,7 @@ static QUIC_STATUS QUIC_API client_stream_cb(HQUIC stream, void *context,
       break;
     }
     case QUIC_STREAM_EVENT_SEND_COMPLETE: {
-      delete[] static_cast<uint8_t *>(event->SEND_COMPLETE.ClientContext);
+      std::free(event->SEND_COMPLETE.ClientContext);
       break;
     }
     case QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE: {

--- a/source/core/jpip/h3_client.cpp
+++ b/source/core/jpip/h3_client.cpp
@@ -187,12 +187,24 @@ static QUIC_STATUS QUIC_API client_stream_cb(HQUIC stream, void *context,
   switch (event->Type) {
     case QUIC_STREAM_EVENT_RECEIVE: {
       auto it = c->stream_ids.find(stream);
-      if (it == c->stream_ids.end()) break;
+      if (it == c->stream_ids.end()) {
+        std::fprintf(stderr, "H3 client recv: unknown stream handle\n");
+        break;
+      }
       int64_t sid = it->second;
+      uint64_t total = 0;
+      for (uint32_t i = 0; i < event->RECEIVE.BufferCount; ++i) total += event->RECEIVE.Buffers[i].Length;
+      std::fprintf(stderr, "H3 client recv: sid=%lld %llu bytes fin=%d\n",
+                   (long long)sid, (unsigned long long)total,
+                   (event->RECEIVE.Flags & QUIC_RECEIVE_FLAG_FIN) ? 1 : 0);
       for (uint32_t i = 0; i < event->RECEIVE.BufferCount; ++i) {
-        nghttp3_conn_read_stream(c->h3conn, sid,
+        nghttp3_ssize consumed = nghttp3_conn_read_stream(c->h3conn, sid,
                                  event->RECEIVE.Buffers[i].Buffer,
                                  event->RECEIVE.Buffers[i].Length, 0);
+        if (consumed < 0) {
+          std::fprintf(stderr, "H3 client recv: read_stream error %lld sid=%lld\n",
+                       (long long)consumed, (long long)sid);
+        }
       }
       if (event->RECEIVE.Flags & QUIC_RECEIVE_FLAG_FIN) {
         nghttp3_conn_read_stream(c->h3conn, sid, nullptr, 0, 1);

--- a/source/core/jpip/h3_client.hpp
+++ b/source/core/jpip/h3_client.hpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+//
+// HTTP/3 JPIP client — wraps MsQuic (QUIC transport) + nghttp3 (HTTP/3 framing).
+
+#ifndef OPENHTJ2K_H3_CLIENT_HPP
+#define OPENHTJ2K_H3_CLIENT_HPP
+
+#ifdef OPENHTJ2K_ENABLE_QUIC
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace open_htj2k {
+namespace jpip {
+
+class H3Client {
+ public:
+  H3Client();
+  ~H3Client();
+
+  H3Client(const H3Client &) = delete;
+  H3Client &operator=(const H3Client &) = delete;
+
+  bool connect(const std::string &host, uint16_t port, bool validate_cert = false);
+  void disconnect();
+
+  // Sends an HTTP/3 GET request and blocks until the response body is received.
+  std::vector<uint8_t> fetch(const std::string &path_and_query);
+
+  std::string last_error() const;
+
+ private:
+  struct Impl;
+  Impl *impl_;
+};
+
+}  // namespace jpip
+}  // namespace open_htj2k
+
+#endif  // OPENHTJ2K_ENABLE_QUIC
+#endif  // OPENHTJ2K_H3_CLIENT_HPP

--- a/source/core/jpip/h3_common.hpp
+++ b/source/core/jpip/h3_common.hpp
@@ -1,0 +1,37 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+//
+// Shared types for the HTTP/3 JPIP transport (Phase 5, Annex P).
+
+#ifndef OPENHTJ2K_H3_COMMON_HPP
+#define OPENHTJ2K_H3_COMMON_HPP
+
+#ifdef OPENHTJ2K_ENABLE_QUIC
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace open_htj2k {
+namespace jpip {
+
+struct TlsCertConfig {
+  std::string cert_file;
+  std::string key_file;
+};
+
+struct H3Request {
+  std::string method;
+  std::string path;
+  std::string query;
+  int64_t     stream_id = -1;
+};
+
+using H3RequestHandler = std::function<std::vector<uint8_t>(const H3Request &req)>;
+
+}  // namespace jpip
+}  // namespace open_htj2k
+
+#endif  // OPENHTJ2K_ENABLE_QUIC
+#endif  // OPENHTJ2K_H3_COMMON_HPP

--- a/source/core/jpip/h3_server.cpp
+++ b/source/core/jpip/h3_server.cpp
@@ -104,7 +104,7 @@ static int64_t open_uni_stream(H3ConnCtx *ctx) {
 
 // ── nghttp3 callbacks ──���────────────────────────────────────────────────────
 
-static int h3_recv_header(nghttp3_conn *, int64_t stream_id, int32_t,
+static int h3_recv_header(nghttp3_conn *, int64_t stream_id, int32_t token,
                           nghttp3_rcbuf *name, nghttp3_rcbuf *value, uint8_t, void *conn_data,
                           void *) {
   auto *ctx = static_cast<H3ConnCtx *>(conn_data);
@@ -113,6 +113,8 @@ static int h3_recv_header(nghttp3_conn *, int64_t stream_id, int32_t,
   std::string n(reinterpret_cast<const char *>(nv.base), nv.len);
   std::string v(reinterpret_cast<const char *>(vv.base), vv.len);
 
+  std::fprintf(stderr, "H3 server: recv_header stream=%lld %s: %s\n",
+               (long long)stream_id, n.c_str(), v.c_str());
   auto &req = ctx->requests[stream_id];
   if (n == ":method")    req.method = v;
   else if (n == ":path") req.path   = v;
@@ -120,10 +122,16 @@ static int h3_recv_header(nghttp3_conn *, int64_t stream_id, int32_t,
   return 0;
 }
 
+static int h3_end_headers(nghttp3_conn *, int64_t stream_id, int, void *conn_data, void *) {
+  std::fprintf(stderr, "H3 server: end_headers stream=%lld\n", (long long)stream_id);
+  return 0;
+}
+
 static int h3_end_stream(nghttp3_conn *, int64_t stream_id, void *conn_data, void *) {
+  std::fprintf(stderr, "H3 server: end_stream stream=%lld\n", (long long)stream_id);
   auto *ctx = static_cast<H3ConnCtx *>(conn_data);
   auto it = ctx->requests.find(stream_id);
-  if (it == ctx->requests.end()) return 0;
+  if (it == ctx->requests.end()) { std::fprintf(stderr, "H3 server: no request for stream %lld\n", (long long)stream_id); return 0; }
 
   H3Request req;
   req.stream_id = stream_id;
@@ -209,6 +217,7 @@ static int h3_deferred_consume(nghttp3_conn *, int64_t stream_id, size_t consume
 static bool setup_h3(H3ConnCtx *ctx) {
   nghttp3_callbacks cb = {};
   cb.recv_header       = h3_recv_header;
+  cb.end_headers       = h3_end_headers;
   cb.end_stream        = h3_end_stream;
   cb.acked_stream_data = h3_acked_stream_data;
   cb.stream_close      = h3_stream_close;

--- a/source/core/jpip/h3_server.cpp
+++ b/source/core/jpip/h3_server.cpp
@@ -30,7 +30,9 @@ struct H3ConnCtx {
   // Stream map: QUIC stream handle → stream ID (for nghttp3)
   std::unordered_map<HQUIC, int64_t> stream_ids;
   std::unordered_map<int64_t, HQUIC> id_to_stream;
-  int64_t next_uni_id = 0;
+  int64_t next_uni_id       = 0;  // server-initiated uni: 3, 7, 11, ...
+  int64_t next_peer_bidi_id = 0;  // client-initiated bidi: 0, 4, 8, ...
+  int64_t next_peer_uni_id  = 0;  // client-initiated uni: 2, 6, 10, ...
 
   // Per-request accumulator
   struct ReqState {
@@ -297,13 +299,17 @@ static QUIC_STATUS QUIC_API connection_cb(HQUIC conn, void *context,
     case QUIC_CONNECTION_EVENT_PEER_STREAM_STARTED: {
       HQUIC stream = event->PEER_STREAM_STARTED.Stream;
       ctx->q->SetCallbackHandler(stream, (void *)stream_cb, ctx);
-      // Client bidi streams have IDs 0x00, 0x04, 0x08, ...
-      // Client uni streams have IDs 0x02, 0x06, 0x0A, ...
-      QUIC_UINT62 sid = 0;
-      uint32_t sz = sizeof(sid);
-      ctx->q->GetParam(stream, QUIC_PARAM_STREAM_ID, &sz, &sid);
-      ctx->stream_ids[stream]     = static_cast<int64_t>(sid);
-      ctx->id_to_stream[static_cast<int64_t>(sid)] = stream;
+      int64_t sid;
+      if (event->PEER_STREAM_STARTED.Flags & QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL) {
+        sid = 0x02 + 4 * ctx->next_peer_uni_id++;
+      } else {
+        sid = 4 * ctx->next_peer_bidi_id++;
+      }
+      std::fprintf(stderr, "H3 server: peer stream started sid=%lld uni=%d\n",
+                   (long long)sid,
+                   (event->PEER_STREAM_STARTED.Flags & QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL) ? 1 : 0);
+      ctx->stream_ids[stream]  = sid;
+      ctx->id_to_stream[sid]   = stream;
       break;
     }
     case QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE:

--- a/source/core/jpip/h3_server.cpp
+++ b/source/core/jpip/h3_server.cpp
@@ -52,20 +52,27 @@ static QUIC_STATUS QUIC_API stream_cb(HQUIC, void *, QUIC_STREAM_EVENT *);
 // ── nghttp3 → MsQuic glue: flush pending writes ────────────────────────────
 
 static void h3_flush_writes(H3ConnCtx *ctx) {
+  int rounds = 0;
   for (;;) {
     nghttp3_vec vec[16];
     int         fin  = 0;
     int64_t     sid  = -1;
     nghttp3_ssize n = nghttp3_conn_writev_stream(ctx->h3conn, &sid, &fin, vec, 16);
-    if (n < 0 || sid < 0) break;
+    if (n < 0) { std::fprintf(stderr, "H3 server flush: writev error %lld\n", (long long)n); break; }
+    if (sid < 0) break;
     if (n == 0 && !fin) break;
 
     auto it = ctx->id_to_stream.find(sid);
-    if (it == ctx->id_to_stream.end()) break;
+    if (it == ctx->id_to_stream.end()) {
+      std::fprintf(stderr, "H3 server flush: no QUIC stream for sid=%lld\n", (long long)sid);
+      break;
+    }
     HQUIC stream = it->second;
 
     size_t total = 0;
     for (nghttp3_ssize i = 0; i < n; ++i) total += vec[i].len;
+
+    std::fprintf(stderr, "H3 server flush: sid=%lld %zu bytes fin=%d\n", (long long)sid, total, fin);
 
     if (total > 0 || fin) {
       auto *buf = new uint8_t[total];
@@ -78,10 +85,15 @@ static void h3_flush_writes(H3ConnCtx *ctx) {
       qb.Length = static_cast<uint32_t>(total);
       qb.Buffer = buf;
       QUIC_SEND_FLAGS flags = fin ? QUIC_SEND_FLAG_FIN : QUIC_SEND_FLAG_NONE;
-      ctx->q->StreamSend(stream, &qb, 1, flags, buf);
+      QUIC_STATUS s = ctx->q->StreamSend(stream, &qb, 1, flags, buf);
+      if (QUIC_FAILED(s)) {
+        std::fprintf(stderr, "H3 server flush: StreamSend FAILED 0x%x sid=%lld\n", s, (long long)sid);
+        delete[] buf;
+      }
       nghttp3_conn_add_write_offset(ctx->h3conn, sid, static_cast<int64_t>(total));
     }
     if (n == 0) break;
+    if (++rounds > 200) break;
   }
 }
 

--- a/source/core/jpip/h3_server.cpp
+++ b/source/core/jpip/h3_server.cpp
@@ -49,7 +49,12 @@ static QUIC_STATUS QUIC_API listener_cb(HQUIC, void *, QUIC_LISTENER_EVENT *);
 static QUIC_STATUS QUIC_API connection_cb(HQUIC, void *, QUIC_CONNECTION_EVENT *);
 static QUIC_STATUS QUIC_API stream_cb(HQUIC, void *, QUIC_STREAM_EVENT *);
 
-// ── nghttp3 → MsQuic glue: flush pending writes ────────────────────────────
+// StreamSend context: both the QUIC_BUFFER and the data must remain valid
+// until QUIC_STREAM_EVENT_SEND_COMPLETE fires.
+struct SendCtx {
+  QUIC_BUFFER qb;
+  uint8_t     data[];
+};
 
 static void h3_flush_writes(H3ConnCtx *ctx) {
   int rounds = 0;
@@ -75,20 +80,19 @@ static void h3_flush_writes(H3ConnCtx *ctx) {
     std::fprintf(stderr, "H3 server flush: sid=%lld %zu bytes fin=%d\n", (long long)sid, total, fin);
 
     if (total > 0 || fin) {
-      auto *buf = new uint8_t[total];
+      auto *sc = static_cast<SendCtx *>(std::malloc(sizeof(SendCtx) + total));
+      sc->qb.Length = static_cast<uint32_t>(total);
+      sc->qb.Buffer = sc->data;
       size_t off = 0;
       for (nghttp3_ssize i = 0; i < n; ++i) {
-        std::memcpy(buf + off, vec[i].base, vec[i].len);
+        std::memcpy(sc->data + off, vec[i].base, vec[i].len);
         off += vec[i].len;
       }
-      QUIC_BUFFER qb;
-      qb.Length = static_cast<uint32_t>(total);
-      qb.Buffer = buf;
       QUIC_SEND_FLAGS flags = fin ? QUIC_SEND_FLAG_FIN : QUIC_SEND_FLAG_NONE;
-      QUIC_STATUS s = ctx->q->StreamSend(stream, &qb, 1, flags, buf);
+      QUIC_STATUS s = ctx->q->StreamSend(stream, &sc->qb, 1, flags, sc);
       if (QUIC_FAILED(s)) {
         std::fprintf(stderr, "H3 server flush: StreamSend FAILED 0x%x sid=%lld\n", s, (long long)sid);
-        delete[] buf;
+        std::free(sc);
       }
       nghttp3_conn_add_write_offset(ctx->h3conn, sid, static_cast<int64_t>(total));
     }
@@ -279,8 +283,7 @@ static QUIC_STATUS QUIC_API stream_cb(HQUIC stream, void *context, QUIC_STREAM_E
       break;
     }
     case QUIC_STREAM_EVENT_SEND_COMPLETE: {
-      auto *buf = static_cast<uint8_t *>(event->SEND_COMPLETE.ClientContext);
-      delete[] buf;
+      std::free(event->SEND_COMPLETE.ClientContext);
       break;
     }
     case QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE: {

--- a/source/core/jpip/h3_server.cpp
+++ b/source/core/jpip/h3_server.cpp
@@ -93,10 +93,8 @@ static int64_t open_uni_stream(H3ConnCtx *ctx) {
   s = ctx->q->StreamStart(stream, QUIC_STREAM_START_FLAG_IMMEDIATE);
   if (QUIC_FAILED(s)) { std::fprintf(stderr, "H3 server: uni StreamStart failed 0x%x\n", s); ctx->q->StreamClose(stream); return -1; }
 
-  QUIC_UINT62 qid = 0;
-  uint32_t sz = sizeof(qid);
-  ctx->q->GetParam(stream, QUIC_PARAM_STREAM_ID, &sz, &qid);
-  int64_t id = static_cast<int64_t>(qid);
+  // Server-initiated unidirectional stream IDs: 0x03, 0x07, 0x0B, ...
+  int64_t id = 0x03 + 4 * ctx->next_uni_id++;
   ctx->stream_ids[stream] = id;
   ctx->id_to_stream[id]   = stream;
   return id;

--- a/source/core/jpip/h3_server.cpp
+++ b/source/core/jpip/h3_server.cpp
@@ -90,7 +90,7 @@ static int64_t open_uni_stream(H3ConnCtx *ctx) {
   QUIC_STATUS s = ctx->q->StreamOpen(ctx->conn, QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL,
                                      stream_cb, ctx, &stream);
   if (QUIC_FAILED(s)) { std::fprintf(stderr, "H3 server: uni StreamOpen failed 0x%x\n", s); return -1; }
-  s = ctx->q->StreamStart(stream, QUIC_STREAM_START_FLAG_NONE);
+  s = ctx->q->StreamStart(stream, QUIC_STREAM_START_FLAG_IMMEDIATE);
   if (QUIC_FAILED(s)) { std::fprintf(stderr, "H3 server: uni StreamStart failed 0x%x\n", s); ctx->q->StreamClose(stream); return -1; }
 
   QUIC_UINT62 qid = 0;

--- a/source/core/jpip/h3_server.cpp
+++ b/source/core/jpip/h3_server.cpp
@@ -1,0 +1,409 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+
+#ifdef OPENHTJ2K_ENABLE_QUIC
+
+#include "h3_server.hpp"
+
+#include <cstdio>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <msquic.h>
+#include <nghttp3/nghttp3.h>
+
+namespace open_htj2k {
+namespace jpip {
+
+// ── Per-connection state ────────────────────────────────────────────────────
+
+struct H3ConnCtx {
+  const QUIC_API_TABLE *q       = nullptr;
+  HQUIC                 conn    = nullptr;
+  nghttp3_conn         *h3conn  = nullptr;
+  H3RequestHandler      handler;
+  std::string           error;
+
+  // Stream map: QUIC stream handle → stream ID (for nghttp3)
+  std::unordered_map<HQUIC, int64_t> stream_ids;
+  std::unordered_map<int64_t, HQUIC> id_to_stream;
+  int64_t next_uni_id = 0;
+
+  // Per-request accumulator
+  struct ReqState {
+    std::string method;
+    std::string path;
+    std::string authority;
+  };
+  std::unordered_map<int64_t, ReqState> requests;
+};
+
+// ── Forward declarations ────────────────────────────────────────────────────
+
+static QUIC_STATUS QUIC_API listener_cb(HQUIC, void *, QUIC_LISTENER_EVENT *);
+static QUIC_STATUS QUIC_API connection_cb(HQUIC, void *, QUIC_CONNECTION_EVENT *);
+static QUIC_STATUS QUIC_API stream_cb(HQUIC, void *, QUIC_STREAM_EVENT *);
+
+// ── nghttp3 → MsQuic glue: flush pending writes ────────────────────────────
+
+static void h3_flush_writes(H3ConnCtx *ctx) {
+  for (;;) {
+    nghttp3_vec vec[16];
+    int         fin  = 0;
+    int64_t     sid  = -1;
+    nghttp3_ssize n = nghttp3_conn_writev_stream(ctx->h3conn, &sid, &fin, vec, 16);
+    if (n < 0 || sid < 0) break;
+    if (n == 0 && !fin) break;
+
+    auto it = ctx->id_to_stream.find(sid);
+    if (it == ctx->id_to_stream.end()) break;
+    HQUIC stream = it->second;
+
+    size_t total = 0;
+    for (nghttp3_ssize i = 0; i < n; ++i) total += vec[i].len;
+
+    if (total > 0 || fin) {
+      auto *buf = new uint8_t[total];
+      size_t off = 0;
+      for (nghttp3_ssize i = 0; i < n; ++i) {
+        std::memcpy(buf + off, vec[i].base, vec[i].len);
+        off += vec[i].len;
+      }
+      QUIC_BUFFER qb;
+      qb.Length = static_cast<uint32_t>(total);
+      qb.Buffer = buf;
+      QUIC_SEND_FLAGS flags = fin ? QUIC_SEND_FLAG_FIN : QUIC_SEND_FLAG_NONE;
+      ctx->q->StreamSend(stream, &qb, 1, flags, buf);
+      nghttp3_conn_add_write_offset(ctx->h3conn, sid, static_cast<int64_t>(total));
+    }
+    if (n == 0) break;
+  }
+}
+
+// ── nghttp3 server-side open unidirectional stream helper ───────────────────
+
+static int64_t open_uni_stream(H3ConnCtx *ctx) {
+  HQUIC stream = nullptr;
+  QUIC_STATUS s = ctx->q->StreamOpen(ctx->conn, QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL,
+                                     stream_cb, ctx, &stream);
+  if (QUIC_FAILED(s)) return -1;
+  s = ctx->q->StreamStart(stream, QUIC_STREAM_START_FLAG_NONE);
+  if (QUIC_FAILED(s)) { ctx->q->StreamClose(stream); return -1; }
+
+  // MsQuic assigns stream IDs: server-initiated unidirectional = 0x03, 0x07, 0x0B, ...
+  int64_t id = 0x03 + 4 * ctx->next_uni_id++;
+  ctx->stream_ids[stream] = id;
+  ctx->id_to_stream[id]   = stream;
+  return id;
+}
+
+// ── nghttp3 callbacks ──���────────────────────────────────────────────────────
+
+static int h3_recv_header(nghttp3_conn *, int64_t stream_id, int32_t,
+                          nghttp3_rcbuf *name, nghttp3_rcbuf *value, uint8_t, void *conn_data,
+                          void *) {
+  auto *ctx = static_cast<H3ConnCtx *>(conn_data);
+  auto nv = nghttp3_rcbuf_get_buf(name);
+  auto vv = nghttp3_rcbuf_get_buf(value);
+  std::string n(reinterpret_cast<const char *>(nv.base), nv.len);
+  std::string v(reinterpret_cast<const char *>(vv.base), vv.len);
+
+  auto &req = ctx->requests[stream_id];
+  if (n == ":method")    req.method = v;
+  else if (n == ":path") req.path   = v;
+  else if (n == ":authority") req.authority = v;
+  return 0;
+}
+
+static int h3_end_stream(nghttp3_conn *, int64_t stream_id, void *conn_data, void *) {
+  auto *ctx = static_cast<H3ConnCtx *>(conn_data);
+  auto it = ctx->requests.find(stream_id);
+  if (it == ctx->requests.end()) return 0;
+
+  H3Request req;
+  req.stream_id = stream_id;
+  req.method    = it->second.method;
+  auto qpos = it->second.path.find('?');
+  if (qpos != std::string::npos) {
+    req.path  = it->second.path.substr(0, qpos);
+    req.query = it->second.path.substr(qpos + 1);
+  } else {
+    req.path = it->second.path;
+  }
+  ctx->requests.erase(it);
+
+  std::vector<uint8_t> body = ctx->handler(req);
+
+  // Submit HTTP/3 response
+  char content_length[32];
+  std::snprintf(content_length, sizeof(content_length), "%zu", body.size());
+  nghttp3_nv nva[] = {
+    {(uint8_t *)":status", (uint8_t *)"200", 7, 3, NGHTTP3_NV_FLAG_NONE},
+    {(uint8_t *)"content-type", (uint8_t *)"image/jpp-stream", 12, 16, NGHTTP3_NV_FLAG_NONE},
+    {(uint8_t *)"access-control-allow-origin", (uint8_t *)"*", 27, 1, NGHTTP3_NV_FLAG_NONE},
+    {(uint8_t *)"content-length", (uint8_t *)content_length, 14,
+     std::strlen(content_length), NGHTTP3_NV_FLAG_NO_COPY_NAME | NGHTTP3_NV_FLAG_NO_COPY_VALUE},
+  };
+
+  // Store body for the data provider
+  struct BodyCtx { std::vector<uint8_t> data; size_t offset = 0; };
+  auto *bc = new BodyCtx{std::move(body), 0};
+
+  nghttp3_data_reader dr;
+  dr.read_data = [](nghttp3_conn *, int64_t, nghttp3_vec *vec, size_t veccnt,
+                     uint32_t *pflags, void *conn_data, void *stream_data) -> nghttp3_ssize {
+    (void)conn_data;
+    auto *b = static_cast<BodyCtx *>(stream_data);
+    if (veccnt == 0) return 0;
+    size_t remain = b->data.size() - b->offset;
+    if (remain == 0) {
+      *pflags = NGHTTP3_DATA_FLAG_EOF;
+      return 0;
+    }
+    vec[0].base = b->data.data() + b->offset;
+    vec[0].len  = remain;
+    b->offset  += remain;
+    *pflags = NGHTTP3_DATA_FLAG_EOF;
+    return 1;
+  };
+
+  nghttp3_conn_set_stream_user_data(ctx->h3conn, stream_id, bc);
+  nghttp3_conn_submit_response(ctx->h3conn, stream_id, nva, 4, &dr);
+  h3_flush_writes(ctx);
+  return 0;
+}
+
+static int h3_acked_stream_data(nghttp3_conn *, int64_t, uint64_t, void *, void *stream_data) {
+  // Body fully acknowledged — free the BodyCtx
+  // Note: we keep the BodyCtx alive until stream close for simplicity
+  (void)stream_data;
+  return 0;
+}
+
+static int h3_stream_close(nghttp3_conn *, int64_t, uint64_t, void *, void *stream_data) {
+  // Free per-stream body context
+  if (stream_data) {
+    struct BodyCtx { std::vector<uint8_t> data; size_t offset; };
+    delete static_cast<BodyCtx *>(stream_data);
+  }
+  return 0;
+}
+
+static int h3_deferred_consume(nghttp3_conn *, int64_t stream_id, size_t consumed,
+                               void *conn_data, void *) {
+  auto *ctx = static_cast<H3ConnCtx *>(conn_data);
+  auto it = ctx->id_to_stream.find(stream_id);
+  if (it != ctx->id_to_stream.end()) {
+    ctx->q->StreamReceiveComplete(it->second, consumed);
+  }
+  return 0;
+}
+
+// ── Setup nghttp3 on a new connection ───────────────────────────────────────
+
+static bool setup_h3(H3ConnCtx *ctx) {
+  nghttp3_callbacks cb = {};
+  cb.recv_header       = h3_recv_header;
+  cb.end_stream        = h3_end_stream;
+  cb.acked_stream_data = h3_acked_stream_data;
+  cb.stream_close      = h3_stream_close;
+  cb.deferred_consume  = h3_deferred_consume;
+
+  nghttp3_settings settings;
+  nghttp3_settings_default(&settings);
+
+  int rv = nghttp3_conn_server_new(&ctx->h3conn, &cb, &settings, nghttp3_mem_default(), ctx);
+  if (rv != 0) { ctx->error = "nghttp3_conn_server_new failed"; return false; }
+
+  int64_t ctrl = open_uni_stream(ctx);
+  int64_t qenc = open_uni_stream(ctx);
+  int64_t qdec = open_uni_stream(ctx);
+  if (ctrl < 0 || qenc < 0 || qdec < 0) { ctx->error = "failed to open uni streams"; return false; }
+
+  nghttp3_conn_bind_control_stream(ctx->h3conn, ctrl);
+  nghttp3_conn_bind_qpack_streams(ctx->h3conn, qenc, qdec);
+  h3_flush_writes(ctx);
+  return true;
+}
+
+// ── MsQuic stream callback ─────────────────────────────────────────────────
+
+static QUIC_STATUS QUIC_API stream_cb(HQUIC stream, void *context, QUIC_STREAM_EVENT *event) {
+  auto *ctx = static_cast<H3ConnCtx *>(context);
+  switch (event->Type) {
+    case QUIC_STREAM_EVENT_RECEIVE: {
+      auto it = ctx->stream_ids.find(stream);
+      if (it == ctx->stream_ids.end()) break;
+      int64_t sid = it->second;
+      for (uint32_t i = 0; i < event->RECEIVE.BufferCount; ++i) {
+        nghttp3_conn_read_stream(ctx->h3conn, sid,
+                                 event->RECEIVE.Buffers[i].Buffer,
+                                 event->RECEIVE.Buffers[i].Length, 0);
+      }
+      if (event->RECEIVE.Flags & QUIC_RECEIVE_FLAG_FIN) {
+        nghttp3_conn_read_stream(ctx->h3conn, sid, nullptr, 0, 1);
+      }
+      h3_flush_writes(ctx);
+      break;
+    }
+    case QUIC_STREAM_EVENT_SEND_COMPLETE: {
+      auto *buf = static_cast<uint8_t *>(event->SEND_COMPLETE.ClientContext);
+      delete[] buf;
+      break;
+    }
+    case QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE: {
+      auto it = ctx->stream_ids.find(stream);
+      if (it != ctx->stream_ids.end()) {
+        ctx->id_to_stream.erase(it->second);
+        ctx->stream_ids.erase(it);
+      }
+      ctx->q->StreamClose(stream);
+      break;
+    }
+    default:
+      break;
+  }
+  return QUIC_STATUS_SUCCESS;
+}
+
+// ── MsQuic connection callback ──────────────────────────────────────────────
+
+static QUIC_STATUS QUIC_API connection_cb(HQUIC conn, void *context,
+                                          QUIC_CONNECTION_EVENT *event) {
+  auto *ctx = static_cast<H3ConnCtx *>(context);
+  switch (event->Type) {
+    case QUIC_CONNECTION_EVENT_CONNECTED:
+      setup_h3(ctx);
+      break;
+    case QUIC_CONNECTION_EVENT_PEER_STREAM_STARTED: {
+      HQUIC stream = event->PEER_STREAM_STARTED.Stream;
+      ctx->q->SetCallbackHandler(stream, (void *)stream_cb, ctx);
+      // Client bidi streams have IDs 0x00, 0x04, 0x08, ...
+      // Client uni streams have IDs 0x02, 0x06, 0x0A, ...
+      QUIC_UINT62 sid = 0;
+      uint32_t sz = sizeof(sid);
+      ctx->q->GetParam(stream, QUIC_PARAM_STREAM_ID, &sz, &sid);
+      ctx->stream_ids[stream]     = static_cast<int64_t>(sid);
+      ctx->id_to_stream[static_cast<int64_t>(sid)] = stream;
+      break;
+    }
+    case QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE:
+      if (ctx->h3conn) { nghttp3_conn_del(ctx->h3conn); ctx->h3conn = nullptr; }
+      ctx->q->ConnectionClose(conn);
+      delete ctx;
+      break;
+    default:
+      break;
+  }
+  return QUIC_STATUS_SUCCESS;
+}
+
+// ── H3Server::Impl ──────────────────────────────────────────────────────────
+
+struct H3Server::Impl {
+  const QUIC_API_TABLE *q      = nullptr;
+  HQUIC                 reg    = nullptr;
+  HQUIC                 config = nullptr;
+  HQUIC                 listener = nullptr;
+  H3RequestHandler      handler;
+  std::string           error;
+};
+
+static QUIC_STATUS QUIC_API listener_cb(HQUIC listener, void *context,
+                                        QUIC_LISTENER_EVENT *event) {
+  auto *impl = static_cast<H3Server::Impl *>(context);
+  if (event->Type == QUIC_LISTENER_EVENT_NEW_CONNECTION) {
+    auto *ctx     = new H3ConnCtx();
+    ctx->q        = impl->q;
+    ctx->conn     = event->NEW_CONNECTION.Connection;
+    ctx->handler  = impl->handler;
+    impl->q->SetCallbackHandler(event->NEW_CONNECTION.Connection,
+                                (void *)connection_cb, ctx);
+    return impl->q->ConnectionSetConfiguration(event->NEW_CONNECTION.Connection,
+                                               impl->config);
+  }
+  return QUIC_STATUS_NOT_SUPPORTED;
+}
+
+// ── H3Server public API ─────────────────────────────────────────────────────
+
+H3Server::H3Server() : impl_(new Impl()) {}
+
+H3Server::~H3Server() {
+  stop();
+  delete impl_;
+}
+
+bool H3Server::start(uint16_t port, const TlsCertConfig &tls, H3RequestHandler handler) {
+  impl_->handler = std::move(handler);
+
+  if (QUIC_FAILED(MsQuicOpen2(&impl_->q))) {
+    impl_->error = "MsQuicOpen2 failed";
+    return false;
+  }
+
+  QUIC_REGISTRATION_CONFIG rc = {"jpip-h3-server", QUIC_EXECUTION_PROFILE_LOW_LATENCY};
+  if (QUIC_FAILED(impl_->q->RegistrationOpen(&rc, &impl_->reg))) {
+    impl_->error = "RegistrationOpen failed";
+    return false;
+  }
+
+  const QUIC_BUFFER alpn = {2, (uint8_t *)"h3"};
+  QUIC_SETTINGS settings = {};
+  settings.IdleTimeoutMs = 30000;
+  settings.IsSet.IdleTimeoutMs = TRUE;
+  settings.PeerBidiStreamCount = 128;
+  settings.IsSet.PeerBidiStreamCount = TRUE;
+  settings.PeerUnidiStreamCount = 8;
+  settings.IsSet.PeerUnidiStreamCount = TRUE;
+
+  if (QUIC_FAILED(impl_->q->ConfigurationOpen(impl_->reg, &alpn, 1, &settings,
+                                               sizeof(settings), nullptr, &impl_->config))) {
+    impl_->error = "ConfigurationOpen failed";
+    return false;
+  }
+
+  QUIC_CERTIFICATE_FILE cert_file = {};
+  cert_file.CertificateFile = tls.cert_file.c_str();
+  cert_file.PrivateKeyFile  = tls.key_file.c_str();
+  QUIC_CREDENTIAL_CONFIG cred = {};
+  cred.Type = QUIC_CREDENTIAL_TYPE_CERTIFICATE_FILE;
+  cred.CertificateFile = &cert_file;
+
+  if (QUIC_FAILED(impl_->q->ConfigurationLoadCredential(impl_->config, &cred))) {
+    impl_->error = "ConfigurationLoadCredential failed";
+    return false;
+  }
+
+  if (QUIC_FAILED(impl_->q->ListenerOpen(impl_->reg, listener_cb, impl_, &impl_->listener))) {
+    impl_->error = "ListenerOpen failed";
+    return false;
+  }
+
+  QUIC_ADDR addr = {};
+  QuicAddrSetFamily(&addr, QUIC_ADDRESS_FAMILY_UNSPEC);
+  QuicAddrSetPort(&addr, port);
+  if (QUIC_FAILED(impl_->q->ListenerStart(impl_->listener, &alpn, 1, &addr))) {
+    impl_->error = "ListenerStart failed";
+    return false;
+  }
+
+  return true;
+}
+
+void H3Server::stop() {
+  if (impl_->listener) { impl_->q->ListenerClose(impl_->listener); impl_->listener = nullptr; }
+  if (impl_->config)   { impl_->q->ConfigurationClose(impl_->config); impl_->config = nullptr; }
+  if (impl_->reg)      { impl_->q->RegistrationClose(impl_->reg); impl_->reg = nullptr; }
+  if (impl_->q)        { MsQuicClose(impl_->q); impl_->q = nullptr; }
+}
+
+std::string H3Server::last_error() const { return impl_->error; }
+
+}  // namespace jpip
+}  // namespace open_htj2k
+
+#endif  // OPENHTJ2K_ENABLE_QUIC

--- a/source/core/jpip/h3_server.cpp
+++ b/source/core/jpip/h3_server.cpp
@@ -57,27 +57,21 @@ struct SendCtx {
 };
 
 static void h3_flush_writes(H3ConnCtx *ctx) {
-  int rounds = 0;
   for (;;) {
     nghttp3_vec vec[16];
     int         fin  = 0;
     int64_t     sid  = -1;
     nghttp3_ssize n = nghttp3_conn_writev_stream(ctx->h3conn, &sid, &fin, vec, 16);
-    if (n < 0) { std::fprintf(stderr, "H3 server flush: writev error %lld\n", (long long)n); break; }
+    if (n < 0) break;
     if (sid < 0) break;
     if (n == 0 && !fin) break;
 
     auto it = ctx->id_to_stream.find(sid);
-    if (it == ctx->id_to_stream.end()) {
-      std::fprintf(stderr, "H3 server flush: no QUIC stream for sid=%lld\n", (long long)sid);
-      break;
-    }
+    if (it == ctx->id_to_stream.end()) break;
     HQUIC stream = it->second;
 
     size_t total = 0;
     for (nghttp3_ssize i = 0; i < n; ++i) total += vec[i].len;
-
-    std::fprintf(stderr, "H3 server flush: sid=%lld %zu bytes fin=%d\n", (long long)sid, total, fin);
 
     if (total > 0 || fin) {
       auto *sc = static_cast<SendCtx *>(std::malloc(sizeof(SendCtx) + total));
@@ -91,13 +85,11 @@ static void h3_flush_writes(H3ConnCtx *ctx) {
       QUIC_SEND_FLAGS flags = fin ? QUIC_SEND_FLAG_FIN : QUIC_SEND_FLAG_NONE;
       QUIC_STATUS s = ctx->q->StreamSend(stream, &sc->qb, 1, flags, sc);
       if (QUIC_FAILED(s)) {
-        std::fprintf(stderr, "H3 server flush: StreamSend FAILED 0x%x sid=%lld\n", s, (long long)sid);
         std::free(sc);
       }
       nghttp3_conn_add_write_offset(ctx->h3conn, sid, static_cast<int64_t>(total));
     }
     if (n == 0) break;
-    if (++rounds > 200) break;
   }
 }
 
@@ -107,9 +99,9 @@ static int64_t open_uni_stream(H3ConnCtx *ctx) {
   HQUIC stream = nullptr;
   QUIC_STATUS s = ctx->q->StreamOpen(ctx->conn, QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL,
                                      stream_cb, ctx, &stream);
-  if (QUIC_FAILED(s)) { std::fprintf(stderr, "H3 server: uni StreamOpen failed 0x%x\n", s); return -1; }
+  if (QUIC_FAILED(s)) return -1;
   s = ctx->q->StreamStart(stream, QUIC_STREAM_START_FLAG_IMMEDIATE);
-  if (QUIC_FAILED(s)) { std::fprintf(stderr, "H3 server: uni StreamStart failed 0x%x\n", s); ctx->q->StreamClose(stream); return -1; }
+  if (QUIC_FAILED(s)) { ctx->q->StreamClose(stream); return -1; }
 
   // Server-initiated unidirectional stream IDs: 0x03, 0x07, 0x0B, ...
   int64_t id = 0x03 + 4 * ctx->next_uni_id++;
@@ -129,8 +121,6 @@ static int h3_recv_header(nghttp3_conn *, int64_t stream_id, int32_t token,
   std::string n(reinterpret_cast<const char *>(nv.base), nv.len);
   std::string v(reinterpret_cast<const char *>(vv.base), vv.len);
 
-  std::fprintf(stderr, "H3 server: recv_header stream=%lld %s: %s\n",
-               (long long)stream_id, n.c_str(), v.c_str());
   auto &req = ctx->requests[stream_id];
   if (n == ":method")    req.method = v;
   else if (n == ":path") req.path   = v;
@@ -138,16 +128,14 @@ static int h3_recv_header(nghttp3_conn *, int64_t stream_id, int32_t token,
   return 0;
 }
 
-static int h3_end_headers(nghttp3_conn *, int64_t stream_id, int, void *conn_data, void *) {
-  std::fprintf(stderr, "H3 server: end_headers stream=%lld\n", (long long)stream_id);
+static int h3_end_headers(nghttp3_conn *, int64_t, int, void *, void *) {
   return 0;
 }
 
 static int h3_end_stream(nghttp3_conn *, int64_t stream_id, void *conn_data, void *) {
-  std::fprintf(stderr, "H3 server: end_stream stream=%lld\n", (long long)stream_id);
   auto *ctx = static_cast<H3ConnCtx *>(conn_data);
   auto it = ctx->requests.find(stream_id);
-  if (it == ctx->requests.end()) { std::fprintf(stderr, "H3 server: no request for stream %lld\n", (long long)stream_id); return 0; }
+  if (it == ctx->requests.end()) return 0;
 
   H3Request req;
   req.stream_id = stream_id;
@@ -243,22 +231,18 @@ static bool setup_h3(H3ConnCtx *ctx) {
   nghttp3_settings_default(&settings);
 
   int rv = nghttp3_conn_server_new(&ctx->h3conn, &cb, &settings, nghttp3_mem_default(), ctx);
-  if (rv != 0) { std::fprintf(stderr, "H3 server: nghttp3_conn_server_new failed: %d\n", rv); return false; }
+  if (rv != 0) return false;
 
   int64_t ctrl = open_uni_stream(ctx);
   int64_t qenc = open_uni_stream(ctx);
   int64_t qdec = open_uni_stream(ctx);
-  if (ctrl < 0 || qenc < 0 || qdec < 0) { std::fprintf(stderr, "H3 server: failed to open uni streams\n"); return false; }
-
-  std::fprintf(stderr, "H3 server: control=%lld qenc=%lld qdec=%lld\n",
-               (long long)ctrl, (long long)qenc, (long long)qdec);
+  if (ctrl < 0 || qenc < 0 || qdec < 0) return false;
 
   rv = nghttp3_conn_bind_control_stream(ctx->h3conn, ctrl);
-  if (rv != 0) { std::fprintf(stderr, "H3 server: bind_control_stream: %d\n", rv); return false; }
+  if (rv != 0) return false;
   rv = nghttp3_conn_bind_qpack_streams(ctx->h3conn, qenc, qdec);
-  if (rv != 0) { std::fprintf(stderr, "H3 server: bind_qpack_streams: %d\n", rv); return false; }
+  if (rv != 0) return false;
   h3_flush_writes(ctx);
-  std::fprintf(stderr, "H3 server: connection setup complete\n");
   return true;
 }
 
@@ -308,7 +292,6 @@ static QUIC_STATUS QUIC_API connection_cb(HQUIC conn, void *context,
   auto *ctx = static_cast<H3ConnCtx *>(context);
   switch (event->Type) {
     case QUIC_CONNECTION_EVENT_CONNECTED:
-      std::fprintf(stderr, "H3 server: QUIC connected\n");
       setup_h3(ctx);
       break;
     case QUIC_CONNECTION_EVENT_PEER_STREAM_STARTED: {
@@ -320,9 +303,6 @@ static QUIC_STATUS QUIC_API connection_cb(HQUIC conn, void *context,
       } else {
         sid = 4 * ctx->next_peer_bidi_id++;
       }
-      std::fprintf(stderr, "H3 server: peer stream started sid=%lld uni=%d\n",
-                   (long long)sid,
-                   (event->PEER_STREAM_STARTED.Flags & QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL) ? 1 : 0);
       ctx->stream_ids[stream]  = sid;
       ctx->id_to_stream[sid]   = stream;
       break;

--- a/source/core/jpip/h3_server.cpp
+++ b/source/core/jpip/h3_server.cpp
@@ -89,12 +89,14 @@ static int64_t open_uni_stream(H3ConnCtx *ctx) {
   HQUIC stream = nullptr;
   QUIC_STATUS s = ctx->q->StreamOpen(ctx->conn, QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL,
                                      stream_cb, ctx, &stream);
-  if (QUIC_FAILED(s)) return -1;
+  if (QUIC_FAILED(s)) { std::fprintf(stderr, "H3 server: uni StreamOpen failed 0x%x\n", s); return -1; }
   s = ctx->q->StreamStart(stream, QUIC_STREAM_START_FLAG_NONE);
-  if (QUIC_FAILED(s)) { ctx->q->StreamClose(stream); return -1; }
+  if (QUIC_FAILED(s)) { std::fprintf(stderr, "H3 server: uni StreamStart failed 0x%x\n", s); ctx->q->StreamClose(stream); return -1; }
 
-  // MsQuic assigns stream IDs: server-initiated unidirectional = 0x03, 0x07, 0x0B, ...
-  int64_t id = 0x03 + 4 * ctx->next_uni_id++;
+  QUIC_UINT62 qid = 0;
+  uint32_t sz = sizeof(qid);
+  ctx->q->GetParam(stream, QUIC_PARAM_STREAM_ID, &sz, &qid);
+  int64_t id = static_cast<int64_t>(qid);
   ctx->stream_ids[stream] = id;
   ctx->id_to_stream[id]   = stream;
   return id;
@@ -216,16 +218,22 @@ static bool setup_h3(H3ConnCtx *ctx) {
   nghttp3_settings_default(&settings);
 
   int rv = nghttp3_conn_server_new(&ctx->h3conn, &cb, &settings, nghttp3_mem_default(), ctx);
-  if (rv != 0) { ctx->error = "nghttp3_conn_server_new failed"; return false; }
+  if (rv != 0) { std::fprintf(stderr, "H3 server: nghttp3_conn_server_new failed: %d\n", rv); return false; }
 
   int64_t ctrl = open_uni_stream(ctx);
   int64_t qenc = open_uni_stream(ctx);
   int64_t qdec = open_uni_stream(ctx);
-  if (ctrl < 0 || qenc < 0 || qdec < 0) { ctx->error = "failed to open uni streams"; return false; }
+  if (ctrl < 0 || qenc < 0 || qdec < 0) { std::fprintf(stderr, "H3 server: failed to open uni streams\n"); return false; }
 
-  nghttp3_conn_bind_control_stream(ctx->h3conn, ctrl);
-  nghttp3_conn_bind_qpack_streams(ctx->h3conn, qenc, qdec);
+  std::fprintf(stderr, "H3 server: control=%lld qenc=%lld qdec=%lld\n",
+               (long long)ctrl, (long long)qenc, (long long)qdec);
+
+  rv = nghttp3_conn_bind_control_stream(ctx->h3conn, ctrl);
+  if (rv != 0) { std::fprintf(stderr, "H3 server: bind_control_stream: %d\n", rv); return false; }
+  rv = nghttp3_conn_bind_qpack_streams(ctx->h3conn, qenc, qdec);
+  if (rv != 0) { std::fprintf(stderr, "H3 server: bind_qpack_streams: %d\n", rv); return false; }
   h3_flush_writes(ctx);
+  std::fprintf(stderr, "H3 server: connection setup complete\n");
   return true;
 }
 
@@ -276,6 +284,7 @@ static QUIC_STATUS QUIC_API connection_cb(HQUIC conn, void *context,
   auto *ctx = static_cast<H3ConnCtx *>(context);
   switch (event->Type) {
     case QUIC_CONNECTION_EVENT_CONNECTED:
+      std::fprintf(stderr, "H3 server: QUIC connected\n");
       setup_h3(ctx);
       break;
     case QUIC_CONNECTION_EVENT_PEER_STREAM_STARTED: {

--- a/source/core/jpip/h3_server.hpp
+++ b/source/core/jpip/h3_server.hpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+//
+// HTTP/3 JPIP server — wraps MsQuic (QUIC transport) + nghttp3 (HTTP/3 framing).
+
+#ifndef OPENHTJ2K_H3_SERVER_HPP
+#define OPENHTJ2K_H3_SERVER_HPP
+
+#ifdef OPENHTJ2K_ENABLE_QUIC
+
+#include <cstdint>
+#include <string>
+
+#include "h3_common.hpp"
+
+namespace open_htj2k {
+namespace jpip {
+
+class H3Server {
+ public:
+  H3Server();
+  ~H3Server();
+
+  H3Server(const H3Server &) = delete;
+  H3Server &operator=(const H3Server &) = delete;
+
+  bool start(uint16_t port, const TlsCertConfig &tls, H3RequestHandler handler);
+  void stop();
+  std::string last_error() const;
+
+  struct Impl;
+ private:
+  Impl *impl_;
+};
+
+}  // namespace jpip
+}  // namespace open_htj2k
+
+#endif  // OPENHTJ2K_ENABLE_QUIC
+#endif  // OPENHTJ2K_H3_SERVER_HPP


### PR DESCRIPTION
## Summary
- **P5a-1**: `OPENHTJ2K_QUIC` CMake option — finds system-installed MsQuic + nghttp3 (`brew install libmsquic libnghttp3`)
- **P5a-2**: `H3Server` and `H3Client` wrappers (938 LOC) — full MsQuic↔nghttp3 glue layer for HTTP/3 framing over QUIC transport
- **P5a-3**: Wire into JPIP executables — `--h3 --cert --key` on the server, `--server-h3 host:port` on the demo

### Usage
```bash
# Generate self-signed cert for localhost
./scripts/gen_localhost_cert.sh

# Terminal 1: H3 server
open_htj2k_jpip_server input.j2c --h3 --cert server.cert --key server.key

# Terminal 2: H3 client demo
open_htj2k_jpip_demo --server-h3 localhost:8080
```

### Dependencies
- macOS: `brew install libmsquic libnghttp3`
- Ubuntu 24.04: `libmsquic` from packages.microsoft.com + `libnghttp3-dev`

## Test plan
- [x] 86 decode + JPIP + LBS tests pass with QUIC linked
- [x] Default build (QUIC=OFF) unaffected
- [ ] Manual: server + demo loopback over HTTP/3 on localhost

🤖 Generated with [Claude Code](https://claude.com/claude-code)