### PR TITLE
feat(wasm): Cloudflare Tunnel for JPIP browser demo

### DIFF
--- a/.github/workflows/deploy-wasm-demo.yml
+++ b/.github/workflows/deploy-wasm-demo.yml
@@ -41,6 +41,7 @@ jobs:
           cp subprojects/build/html/libopen_htj2k*.wasm deploy/
           cp subprojects/index.html                     deploy/
           cp subprojects/rtp_demo.html                  deploy/
+          cp subprojects/jpip_demo.html                 deploy/
           cp subprojects/rtp_parser.js                  deploy/
           cp subprojects/coi-serviceworker.js           deploy/
           # Sample codestreams referenced by index.html's preset dropdown.

--- a/scripts/jpip_tunnel.sh
+++ b/scripts/jpip_tunnel.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Expose a local JPIP server via Cloudflare Tunnel.
+#
+# Cloudflare terminates TLS and speaks HTTP/3 to browsers automatically.
+# The local server runs plain HTTP/1.1 — no certs needed.
+#
+# Prerequisites:
+#   brew install cloudflared    # macOS
+#   # or: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/
+#
+# Usage:
+#   # Terminal 1: start the JPIP server
+#   open_htj2k_jpip_server input.j2c --port 8080
+#
+#   # Terminal 2: expose it via tunnel
+#   ./scripts/jpip_tunnel.sh [port=8080]
+#
+#   # Open the WASM demo and paste the tunnel URL:
+#   https://htj2k-demo.pages.dev/jpip_demo.html
+#
+# The tunnel prints a URL like:
+#   https://random-words.trycloudflare.com
+# Paste that into the JPIP demo's "Server" field.
+
+set -e
+PORT="${1:-8080}"
+
+if ! command -v cloudflared >/dev/null 2>&1; then
+  echo "ERROR: cloudflared not found. Install with: brew install cloudflared"
+  exit 1
+fi
+
+echo "Exposing http://localhost:${PORT} via Cloudflare Tunnel..."
+echo "Paste the https://...trycloudflare.com URL into the JPIP demo."
+echo ""
+cloudflared tunnel --url "http://localhost:${PORT}"

--- a/subprojects/jpip_demo.html
+++ b/subprojects/jpip_demo.html
@@ -7,7 +7,7 @@
   body { margin: 0; background: #111; color: #eee; font-family: monospace; }
   #controls { padding: 8px; }
   #controls label { margin-right: 12px; }
-  #controls input { width: 200px; }
+  #controls input { width: 360px; }
   canvas { display: block; margin: 8px auto; cursor: crosshair; }
   #stats { padding: 4px 8px; font-size: 13px; }
 </style>
@@ -28,6 +28,13 @@
 import createModule from './libopen_htj2k_jpip.js';
 
 const $ = id => document.getElementById(id);
+
+// Allow ?server=URL to pre-fill the server field (useful for tunnel links).
+{
+  const params = new URLSearchParams(location.search);
+  const s = params.get('server');
+  if (s) document.addEventListener('DOMContentLoaded', () => $('server').value = s);
+}
 
 let M = null;   // WASM module
 let ctx = 0;    // jpip context handle (pointer)


### PR DESCRIPTION
## Summary
- Add `jpip_demo.html` to Cloudflare Pages deployment (`htj2k-demo.pages.dev/jpip_demo.html`)
- Add `scripts/jpip_tunnel.sh` — one-command Cloudflare Tunnel setup
- Add `?server=URL` parameter support for shareable links

## How it works
Cloudflare Tunnel handles TLS and HTTP/3 automatically:
- Browser ↔ Cloudflare: HTTP/3 over QUIC (automatic)
- Cloudflare ↔ local server: HTTP/1.1 over tunnel

No certs, no `--h3` flag needed — just plain HTTP/1.1 JPIP server.

## Usage
```bash
# Terminal 1: start JPIP server
open_htj2k_jpip_server input.j2c

# Terminal 2: expose via tunnel
./scripts/jpip_tunnel.sh
# → https://random-words.trycloudflare.com

# Browser:
# https://htj2k-demo.pages.dev/jpip_demo.html?server=https://random-words.trycloudflare.com
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)