### PR TITLE
feat(jpip): wire cache model into native demo clients

### DIFF
--- a/source/apps/jpip_demo/main_jpip_demo.cpp
+++ b/source/apps/jpip_demo/main_jpip_demo.cpp
@@ -53,6 +53,7 @@
 #include "codestream_walker.hpp"
 #include "data_bin_emitter.hpp"
 #include "decoder.hpp"
+#include "cache_model.hpp"
 #include "jpip_client.hpp"
 #include "jpp_parser.hpp"
 #include "packet_locator.hpp"
@@ -393,6 +394,7 @@ int main(int argc, char **argv) {
               static_cast<double>(canvas_h) / opt.window_h);
 
   std::vector<uint8_t> rgb;
+  open_htj2k::jpip::CacheModel client_cache;
   uint64_t frames = 0;
   int32_t  last_gx = -1, last_gy = -1;
 
@@ -442,25 +444,29 @@ int main(int argc, char **argv) {
     std::vector<uint8_t> frame_cs;
     if (!opt.server_host.empty()) {
       // ── Network path: fetch 3 concentric view-windows from server ──
+      // The cache model tells the server which data-bins we already have
+      // so it can skip redundant data (§C.9).
       open_htj2k::jpip::JpipClient client;
       open_htj2k::jpip::DataBinSet set;
-      // Fovea: full resolution, tight RoI.
       auto vw_fov = make_view_window(*idx, gx, gy, opt.fovea_radius, 1.00f, false);
-      if (!client.fetch(opt.server_host, opt.server_port, vw_fov, &set)) {
+      if (!client.fetch(opt.server_host, opt.server_port, vw_fov, &set, &client_cache)) {
         std::fprintf(stderr, "server fetch (fovea): %s\n", client.last_error().c_str());
         break;
       }
-      // Parafovea: reduced resolution, wider RoI.
       {
         auto vw_para = make_view_window(*idx, gx, gy, opt.parafovea_radius, opt.parafovea_ratio, false);
         open_htj2k::jpip::DataBinSet tmp;
-        if (client.fetch(opt.server_host, opt.server_port, vw_para, &tmp)) set.merge_from(tmp);
+        if (client.fetch(opt.server_host, opt.server_port, vw_para, &tmp, &client_cache)) set.merge_from(tmp);
       }
-      // Periphery: aggressively reduced resolution, whole image.
       {
         auto vw_peri = make_view_window(*idx, gx, gy, 0, opt.periphery_ratio, true);
         open_htj2k::jpip::DataBinSet tmp;
-        if (client.fetch(opt.server_host, opt.server_port, vw_peri, &tmp)) set.merge_from(tmp);
+        if (client.fetch(opt.server_host, opt.server_port, vw_peri, &tmp, &client_cache)) set.merge_from(tmp);
+      }
+      // Update the cache model with newly received data-bins.
+      for (const auto &kv : set.keys()) {
+        if (set.is_complete(kv.first, kv.second))
+          client_cache.mark(kv.first, kv.second);
       }
       // Client-side reassembly — no original codestream or PacketLocator
       // needed.  The reassembler patches the COD to LRCP and emits
@@ -486,6 +492,7 @@ int main(int argc, char **argv) {
       open_htj2k::jpip::DataBinSet set;
       auto fetch_vw = [&](const open_htj2k::jpip::ViewWindow &vw) {
         std::string q = "/jpip?" + open_htj2k::jpip::format_view_window_query(vw);
+        if (client_cache.size() > 0) q += "&model=" + client_cache.format();
         auto body = h3c.fetch(q);
         if (!body.empty()) {
           open_htj2k::jpip::DataBinSet tmp;
@@ -496,6 +503,10 @@ int main(int argc, char **argv) {
       fetch_vw(make_view_window(*idx, gx, gy, opt.fovea_radius, 1.00f, false));
       fetch_vw(make_view_window(*idx, gx, gy, opt.parafovea_radius, opt.parafovea_ratio, false));
       fetch_vw(make_view_window(*idx, gx, gy, 0, opt.periphery_ratio, true));
+      for (const auto &kv : set.keys()) {
+        if (set.is_complete(kv.first, kv.second))
+          client_cache.mark(kv.first, kv.second);
+      }
 
       const auto rc = open_htj2k::jpip::reassemble_codestream_client(set, *idx, frame_cs);
       if (rc != open_htj2k::jpip::ReassembleStatus::Ok) {

--- a/source/core/jpip/jpip_client.cpp
+++ b/source/core/jpip/jpip_client.cpp
@@ -5,6 +5,7 @@
 
 #include <cstdio>
 
+#include "cache_model.hpp"
 #include "jpip_response.hpp"
 #include "tcp_socket.hpp"
 
@@ -46,9 +47,10 @@ std::string format_view_window_query(const ViewWindow &vw) {
 }
 
 bool JpipClient::fetch(const std::string &host, uint16_t port,
-                       const ViewWindow &vw, DataBinSet *out) {
+                       const ViewWindow &vw, DataBinSet *out,
+                       const CacheModel *model) {
   if (!out) { err_ = "null DataBinSet"; return false; }
-  *out = {};  // v1: fresh set per request (no caching)
+  *out = {};
 
   TcpStream conn;
   if (!conn.connect(host, port)) {
@@ -56,8 +58,11 @@ bool JpipClient::fetch(const std::string &host, uint16_t port,
     return false;
   }
 
-  // Format the HTTP GET request.
-  const std::string query = format_view_window_query(vw);
+  std::string query = format_view_window_query(vw);
+  if (model && model->size() > 0) {
+    query += "&model=";
+    query += model->format();
+  }
   std::string request = "GET /jpip?" + query + " HTTP/1.1\r\n"
                         "Host: " + host + "\r\n"
                         "Connection: close\r\n"

--- a/source/core/jpip/jpip_client.hpp
+++ b/source/core/jpip/jpip_client.hpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <string>
 
+#include "cache_model.hpp"
 #include "jpp_parser.hpp"
 #include "view_window.hpp"
 
@@ -29,7 +30,8 @@ class OPENHTJ2K_JPIP_EXPORT JpipClient {
   // (last_error() holds the reason).  The DataBinSet is cleared at the
   // start of each call (v1 stateless — no incremental caching).
   bool fetch(const std::string &host, uint16_t port,
-             const ViewWindow &vw, DataBinSet *out);
+             const ViewWindow &vw, DataBinSet *out,
+             const CacheModel *model = nullptr);
 
   const std::string &last_error() const { return err_; }
 


### PR DESCRIPTION
## Summary
- `JpipClient::fetch()` accepts optional `CacheModel*` — appends `&model=...` to skip known data-bins
- Native demo maintains a persistent `CacheModel` across frames for both `--server` (HTTP/1.1) and `--server-h3` (HTTP/3)
- After each frame, received complete data-bins are marked in the cache
- Server skips headers + overlapping precincts on subsequent requests

## Test plan
- [x] 104 encoder/decoder/JPIP tests pass
- [ ] Manual: run server + demo, observe reduced JPP-stream sizes on frames 2+ in server log

🤖 Generated with [Claude Code](https://claude.com/claude-code)