### PR TITLE
perf(jpip): H3Client::fetch_multi() for concurrent QUIC requests

### DIFF
--- a/source/apps/jpip_demo/main_jpip_demo.cpp
+++ b/source/apps/jpip_demo/main_jpip_demo.cpp
@@ -508,20 +508,27 @@ int main(int argc, char **argv) {
         }
         h3_connected = true;
       }
-      open_htj2k::jpip::DataBinSet set;
-      auto fetch_vw = [&](const open_htj2k::jpip::ViewWindow &vw) {
+      // Build 3 query paths and fetch concurrently on multiplexed QUIC streams.
+      auto make_query = [&](const open_htj2k::jpip::ViewWindow &vw) {
         std::string q = "/jpip?" + open_htj2k::jpip::format_view_window_query(vw);
         if (client_cache.size() > 0) q += "&model=" + client_cache.format();
-        auto body = h3c.fetch(q);
+        return q;
+      };
+      std::vector<std::string> paths = {
+        make_query(make_view_window(*idx, gx, gy, opt.fovea_radius, 1.00f, false)),
+        make_query(make_view_window(*idx, gx, gy, opt.parafovea_radius, opt.parafovea_ratio, false)),
+        make_query(make_view_window(*idx, gx, gy, 0, opt.periphery_ratio, true)),
+      };
+      auto bodies = h3c.fetch_multi(paths);
+
+      open_htj2k::jpip::DataBinSet set;
+      for (const auto &body : bodies) {
         if (!body.empty()) {
           open_htj2k::jpip::DataBinSet tmp;
           open_htj2k::jpip::parse_jpp_stream(body.data(), body.size(), &tmp);
           set.merge_from(tmp);
         }
-      };
-      fetch_vw(make_view_window(*idx, gx, gy, opt.fovea_radius, 1.00f, false));
-      fetch_vw(make_view_window(*idx, gx, gy, opt.parafovea_radius, opt.parafovea_ratio, false));
-      fetch_vw(make_view_window(*idx, gx, gy, 0, opt.periphery_ratio, true));
+      }
       merge_headers_only(header_cache, set);
       for (const auto &kv : set.keys()) {
         if (set.is_complete(kv.first, kv.second) && kv.first != open_htj2k::jpip::kMsgClassPrecinct)

--- a/source/core/jpip/h3_client.cpp
+++ b/source/core/jpip/h3_client.cpp
@@ -423,6 +423,79 @@ std::vector<uint8_t> H3Client::fetch(const std::string &path_and_query) {
   return body;
 }
 
+std::vector<std::vector<uint8_t>> H3Client::fetch_multi(const std::vector<std::string> &paths) {
+  auto *c = impl_->conn;
+  if (!c || !c->h3conn) { impl_->error = "not connected"; return {}; }
+
+  // Open all streams and submit all requests before flushing.
+  std::vector<int64_t> sids;
+  sids.reserve(paths.size());
+
+  for (const auto &path : paths) {
+    HQUIC stream = nullptr;
+    if (QUIC_FAILED(impl_->q->StreamOpen(c->conn, QUIC_STREAM_OPEN_FLAG_NONE,
+                                         client_stream_cb, c, &stream))) {
+      impl_->error = "StreamOpen failed";
+      return {};
+    }
+    if (QUIC_FAILED(impl_->q->StreamStart(stream, QUIC_STREAM_START_FLAG_IMMEDIATE))) {
+      impl_->q->StreamClose(stream);
+      impl_->error = "StreamStart failed";
+      return {};
+    }
+
+    int64_t sid = 4 * c->next_bidi_id++;
+    c->stream_ids[stream] = sid;
+    c->id_to_stream[sid]  = stream;
+    sids.push_back(sid);
+
+    nghttp3_nv nva[] = {
+      {(uint8_t *)":method", (uint8_t *)"GET", 7, 3, NGHTTP3_NV_FLAG_NONE},
+      {(uint8_t *)":scheme", (uint8_t *)"https", 7, 5, NGHTTP3_NV_FLAG_NONE},
+      {(uint8_t *)":authority", (uint8_t *)impl_->host.c_str(), 10,
+       impl_->host.size(), NGHTTP3_NV_FLAG_NO_COPY_VALUE},
+      {(uint8_t *)":path", (uint8_t *)path.c_str(), 5,
+       path.size(), NGHTTP3_NV_FLAG_NO_COPY_VALUE},
+    };
+
+    {
+      std::lock_guard<std::mutex> lk(c->mu);
+      c->responses[sid] = {};
+    }
+
+    nghttp3_conn_submit_request(c->h3conn, sid, nva, 4, nullptr, nullptr);
+  }
+
+  // Single flush sends all requests at once.
+  h3_client_flush(c);
+
+  // Wait for all responses.
+  {
+    std::unique_lock<std::mutex> lk(c->mu);
+    if (!c->cv.wait_for(lk, std::chrono::seconds(10), [c, &sids] {
+          for (int64_t sid : sids) {
+            auto it = c->responses.find(sid);
+            if (it == c->responses.end() || !it->second.done) return false;
+          }
+          return true;
+        })) {
+      impl_->error = "H3 fetch_multi timed out (10s)";
+      return {};
+    }
+  }
+
+  // Collect results in order.
+  std::vector<std::vector<uint8_t>> results;
+  results.reserve(sids.size());
+  std::lock_guard<std::mutex> lk(c->mu);
+  for (int64_t sid : sids) {
+    auto it = c->responses.find(sid);
+    results.push_back(std::move(it->second.body));
+    c->responses.erase(it);
+  }
+  return results;
+}
+
 std::string H3Client::last_error() const { return impl_->error; }
 
 }  // namespace jpip

--- a/source/core/jpip/h3_client.hpp
+++ b/source/core/jpip/h3_client.hpp
@@ -29,6 +29,12 @@ class H3Client {
   // Sends an HTTP/3 GET request and blocks until the response body is received.
   std::vector<uint8_t> fetch(const std::string &path_and_query);
 
+  // Submit multiple HTTP/3 GET requests concurrently on separate QUIC
+  // streams and block until all responses are received.  Each request is
+  // a standard JPIP view-window query.  Returns one response body per
+  // input path, in the same order.
+  std::vector<std::vector<uint8_t>> fetch_multi(const std::vector<std::string> &paths);
+
   std::string last_error() const;
 
  private:


### PR DESCRIPTION
## Summary
- Add `H3Client::fetch_multi()` — submits N requests atomically on separate QUIC streams, single flush, waits for all responses
- Demo's `--server-h3` path uses `fetch_multi()` instead of 3 serial `fetch()` calls
- Natural HTTP/3 multiplexing: 3 requests fly concurrently, no threads needed

## Test plan
- [x] Builds with QUIC=ON and QUIC=OFF
- [ ] Manual: `--server-h3` with fetch_multi shows improved fps

🤖 Generated with [Claude Code](https://claude.com/claude-code)