### PR TITLE
revert(jpip): remove --dual-res (corrupted output, no speedup)

### DIFF
--- a/source/apps/jpip_demo/main_jpip_demo.cpp
+++ b/source/apps/jpip_demo/main_jpip_demo.cpp
@@ -102,7 +102,6 @@ struct Options {
   bool        decode_on_move   = false;
   bool        vsync            = true;
   uint8_t     reduce           = 0;
-  bool        dual_res         = false;
   bool        use_filter       = false;
   // When non-empty, the demo fetches each frame's JPP-stream from the
   // given JPIP server instead of doing in-process round-trip.
@@ -131,7 +130,6 @@ bool parse_args(int argc, char **argv, Options &opt) {
     else if (a == "--parafovea-ratio" && i + 1 < argc) opt.parafovea_ratio = std::stof(argv[++i]);
     else if (a == "--periphery-ratio" && i + 1 < argc) opt.periphery_ratio = std::stof(argv[++i]);
     else if (a == "--reduce" && i + 1 < argc)        opt.reduce = static_cast<uint8_t>(std::stoul(argv[++i]));
-    else if (a == "--dual-res")                      opt.dual_res = true;
     else if (a == "--decode-on-move-only")          opt.decode_on_move = true;
     else if (a == "--use-filter")                   opt.use_filter = true;
     else if (a == "--no-vsync")                     opt.vsync = false;
@@ -408,11 +406,6 @@ int main(int argc, char **argv) {
               static_cast<double>(canvas_w) / opt.window_w,
               static_cast<double>(canvas_h) / opt.window_h);
 
-  if (opt.dual_res && bytes.empty()) {
-    std::fprintf(stderr, "WARNING: --dual-res requires a local codestream (not --server mode). Disabling.\n");
-    opt.dual_res = false;
-  }
-
   std::vector<uint8_t> rgb;
   open_htj2k::jpip::CacheModel client_cache;
   open_htj2k::jpip::DataBinSet header_cache;  // persistent: main header + tile headers + metadata
@@ -589,16 +582,13 @@ int main(int argc, char **argv) {
     }
 
     // Fresh decoder per frame — init() + parse() rewind the codestream cursor.
-    // dual-res mode needs the ORIGINAL codestream (not the sparse reassembled
-    // one) because the LL pass requires all precincts at the coarsest level.
     open_htj2k::openhtj2k_decoder dec;
-    const bool use_original = opt.use_filter || (opt.dual_res && !bytes.empty());
-    const uint8_t *dec_buf = use_original ? bytes.data() : frame_cs.data();
-    const std::size_t dec_len = use_original ? bytes.size() : frame_cs.size();
+    const uint8_t *dec_buf = opt.use_filter ? bytes.data() : frame_cs.data();
+    const std::size_t dec_len = opt.use_filter ? bytes.size() : frame_cs.size();
     dec.init(dec_buf, dec_len, opt.reduce, /*num_threads=*/1);
     dec.parse();
 
-    if (use_original) {
+    if (opt.use_filter) {
       auto *idx_ptr = idx.get();
       dec.set_precinct_filter(
           [idx_ptr, keep_moved = std::move(keep)](
@@ -607,102 +597,41 @@ int main(int argc, char **argv) {
           });
     }
 
+    // Line-based stream decode at full decoded resolution.
+    // The GPU texture scaler handles downsampling to window size with
+    // bilinear filtering — no CPU nearest-neighbour artifacts.
     std::vector<uint32_t> w, h;
     std::vector<uint8_t>  depth;
     std::vector<bool>     sgn;
     uint32_t tex_w = 0, tex_h = 0;
     bool ok      = true;
     bool dims_ok = true;
-
-    auto row_to_rgb = [](uint32_t y, int32_t *const *rows, uint16_t nc,
-                         int32_t shift, uint8_t *rgb_buf, uint32_t cw) {
-      uint8_t *dst = rgb_buf + static_cast<std::size_t>(y) * cw * 3u;
-      for (uint32_t x = 0; x < cw; ++x) {
-        auto to_u8 = [shift](int32_t v) -> uint8_t {
-          if (shift > 0) v >>= shift;
-          if (v < 0) return 0;
-          if (v > 255) return 255;
-          return static_cast<uint8_t>(v);
-        };
-        dst[3u * x + 0] = to_u8(rows[0][x]);
-        dst[3u * x + 1] = to_u8(rows[1][x]);
-        dst[3u * x + 2] = to_u8(rows[2][x]);
-      }
-    };
-
     try {
-      if (opt.dual_res) {
-        // ── Phase 4B dual-resolution decode ──────────────────────────
-        // Pass 1: LL at max reduce → tiny coarse background
-        // Pass 2: Full-res with precinct filter → sharp fovea overlay
-        const uint8_t max_red = dec.get_max_safe_reduce_NL();
-        std::vector<uint32_t> ll_w, ll_h, fov_w, fov_h;
-        std::vector<uint8_t> ll_rgb;
-        uint32_t ll_tw = 0, ll_th = 0;
-
-        dec.invoke_dual_resolution(
-            // LL callback: store coarse image
-            [&](uint32_t y, int32_t *const *rows, uint16_t nc) {
-              if (nc < 3 || ll_w.empty()) { dims_ok = false; return; }
-              const uint32_t cw = ll_w[0], ch = ll_h[0];
-              if (ll_tw != cw || ll_th != ch) {
-                ll_tw = cw; ll_th = ch;
-                ll_rgb.assign(static_cast<std::size_t>(cw) * ch * 3u, 0);
-              }
-              if (y >= ch) return;
-              const int32_t shift = (depth.empty() ? 0 : static_cast<int32_t>(depth[0]) - 8);
-              row_to_rgb(y, rows, nc, shift, ll_rgb.data(), cw);
-            },
-            // Foveal callback: overwrite onto upscaled LL
-            [&](uint32_t y, int32_t *const *rows, uint16_t nc) {
-              if (nc < 3 || fov_w.empty()) { dims_ok = false; return; }
-              const uint32_t cw = fov_w[0], ch = fov_h[0];
-              if (tex_w != cw || tex_h != ch) {
-                tex_w = cw; tex_h = ch;
-                // Upscale LL into the full-canvas RGB buffer
-                rgb.assign(static_cast<std::size_t>(cw) * ch * 3u, 0);
-                if (ll_tw > 0 && ll_th > 0) {
-                  for (uint32_t fy = 0; fy < ch; ++fy) {
-                    const uint32_t ly = static_cast<uint32_t>(
-                        static_cast<uint64_t>(fy) * ll_th / ch);
-                    const uint8_t *src = ll_rgb.data() + static_cast<size_t>(ly) * ll_tw * 3u;
-                    uint8_t *dst = rgb.data() + static_cast<size_t>(fy) * cw * 3u;
-                    for (uint32_t fx = 0; fx < cw; ++fx) {
-                      const uint32_t lx = static_cast<uint32_t>(
-                          static_cast<uint64_t>(fx) * ll_tw / cw);
-                      dst[3u * fx + 0] = src[3u * lx + 0];
-                      dst[3u * fx + 1] = src[3u * lx + 1];
-                      dst[3u * fx + 2] = src[3u * lx + 2];
-                    }
-                  }
-                }
-              }
-              if (y >= ch) return;
-              // Check if this row has data (non-zero from foveal precincts)
-              uint32_t acc = 0;
-              for (uint32_t x = 0; x < cw && acc == 0; ++x)
-                acc |= static_cast<uint32_t>(rows[0][x] | rows[1][x] | rows[2][x]);
-              if (acc == 0) return;  // absent-precinct row — keep LL background
-              const int32_t shift = (depth.empty() ? 0 : static_cast<int32_t>(depth[0]) - 8);
-              row_to_rgb(y, rows, nc, shift, rgb.data(), cw);
-            },
-            max_red, ll_w, ll_h, fov_w, fov_h, depth, sgn);
-      } else {
-        // ── Single-pass decode (original path) ──────────────────────
-        dec.invoke_line_based_stream(
-            [&](uint32_t y, int32_t *const *rows, uint16_t nc) {
-              if (nc < 3 || w.empty() || h.empty()) { dims_ok = false; return; }
-              const uint32_t cw = w[0], ch = h[0];
-              if (tex_w != cw || tex_h != ch) {
-                tex_w = cw; tex_h = ch;
-                rgb.assign(static_cast<std::size_t>(cw) * ch * 3u, 0);
-              }
-              if (y >= ch) return;
-              const int32_t shift = (depth.empty() ? 0 : static_cast<int32_t>(depth[0]) - 8);
-              row_to_rgb(y, rows, nc, shift, rgb.data(), cw);
-            },
-            w, h, depth, sgn);
-      }
+      dec.invoke_line_based_stream(
+          [&](uint32_t y, int32_t *const *rows, uint16_t nc) {
+            if (nc < 3 || w.empty() || h.empty()) { dims_ok = false; return; }
+            const uint32_t cw = w[0];
+            const uint32_t ch = h[0];
+            if (tex_w != cw || tex_h != ch) {
+              tex_w = cw; tex_h = ch;
+              rgb.assign(static_cast<std::size_t>(cw) * ch * 3u, 0);
+            }
+            if (y >= ch) return;
+            const int32_t shift = (depth.empty() ? 0 : static_cast<int32_t>(depth[0]) - 8);
+            uint8_t *dst = rgb.data() + static_cast<std::size_t>(y) * cw * 3u;
+            for (uint32_t x = 0; x < cw; ++x) {
+              auto to_u8 = [shift](int32_t v) -> uint8_t {
+                if (shift > 0) v >>= shift;
+                if (v < 0) return 0;
+                if (v > 255) return 255;
+                return static_cast<uint8_t>(v);
+              };
+              dst[3u * x + 0] = to_u8(rows[0][x]);
+              dst[3u * x + 1] = to_u8(rows[1][x]);
+              dst[3u * x + 2] = to_u8(rows[2][x]);
+            }
+          },
+          w, h, depth, sgn);
     } catch (std::exception &e) {
       std::fprintf(stderr, "decode failed: %s\n", e.what());
       break;

--- a/source/core/codestream/codestream.hpp
+++ b/source/core/codestream/codestream.hpp
@@ -67,7 +67,6 @@ class j2c_src_memory {
   int get_N_byte(uint8_t *buf, uint32_t length);
   uint16_t get_word();
   uint8_t *get_buf_pos() { return (buf + pos); }
-  void set_position(uint32_t p) { pos = p; }
   int rewind_2bytes();
   int forward_Nbytes(uint32_t N);
   uint32_t get_remaining() const { return len - pos; }

--- a/source/core/interface/decoder.cpp
+++ b/source/core/interface/decoder.cpp
@@ -118,13 +118,6 @@ class openhtj2k_decoder_impl {
   void invoke_line_based_direct(PlanarOutputDesc *descs, uint16_t nc,
                                 std::vector<uint32_t> &, std::vector<uint32_t> &,
                                 std::vector<uint8_t> &, std::vector<bool> &);
-  void invoke_dual_resolution(
-      std::function<void(uint32_t, int32_t *const *, uint16_t)> ll_cb,
-      std::function<void(uint32_t, int32_t *const *, uint16_t)> foveal_cb,
-      uint8_t max_reduce,
-      std::vector<uint32_t> &ll_w, std::vector<uint32_t> &ll_h,
-      std::vector<uint32_t> &fov_w, std::vector<uint32_t> &fov_h,
-      std::vector<uint8_t> &depth, std::vector<bool> &is_signed);
   void invoke_line_based_predecoded(std::vector<int32_t *> &, std::vector<uint32_t> &,
                                     std::vector<uint32_t> &, std::vector<uint8_t> &,
                                     std::vector<bool> &);
@@ -1244,52 +1237,6 @@ void openhtj2k_decoder_impl::invoke_line_based_direct(
   cached_header_fingerprint_ = fp;
 }
 
-void openhtj2k_decoder_impl::invoke_dual_resolution(
-    std::function<void(uint32_t, int32_t *const *, uint16_t)> ll_cb,
-    std::function<void(uint32_t, int32_t *const *, uint16_t)> foveal_cb,
-    uint8_t max_reduce,
-    std::vector<uint32_t> &ll_w, std::vector<uint32_t> &ll_h,
-    std::vector<uint32_t> &fov_w, std::vector<uint32_t> &fov_h,
-    std::vector<uint8_t> &depth, std::vector<bool> &is_signed) {
-  if (!is_codestream_set || !is_parsed) {
-    throw std::runtime_error("invoke_dual_resolution: decoder not initialized");
-  }
-
-  // Clamp max_reduce to the safe maximum for this codestream.
-  const uint8_t safe_max = get_max_safe_reduce_NL();
-  if (max_reduce > safe_max) max_reduce = safe_max;
-
-  // Save the caller's precinct filter (used for foveal pass only).
-  auto foveal_filter = precinct_filter_;
-
-  // ── Pass 1: LL (coarse periphery) ────────────────────────────────────
-  // Decode at max reduction with no precinct filter → all precincts at
-  // the coarsest resolution.  Output is tiny (e.g., 120x68 for NL=5).
-  const uint8_t orig_reduce = reduce_NL;
-  reduce_NL = max_reduce;
-  precinct_filter_ = {};
-  in.set_position(0);
-  main_header = {};
-  main_header.read(in);
-  in.rewind_2bytes();
-  invoke_line_based_stream(ll_cb, ll_w, ll_h, depth, is_signed);
-
-  // ── Pass 2: Foveal (full resolution, filtered precincts) ─────────────
-  // Decode at full resolution with the caller's precinct filter.  Absent
-  // precincts produce zero rows via Phase 4A IDWT zero-skip.
-  reduce_NL = 0;
-  precinct_filter_ = std::move(foveal_filter);
-  in.set_position(0);
-  main_header = {};
-  main_header.read(in);
-  in.rewind_2bytes();
-  invoke_line_based_stream(foveal_cb, fov_w, fov_h, depth, is_signed);
-
-  // Restore original reduce_NL.
-  reduce_NL = orig_reduce;
-  precinct_filter_ = {};
-}
-
 void openhtj2k_decoder_impl::invoke_line_based_predecoded(std::vector<int32_t *> &buf,
                                                           std::vector<uint32_t> &width,
                                                           std::vector<uint32_t> &height,
@@ -1367,17 +1314,6 @@ void openhtj2k_decoder_impl::invoke_line_based_predecoded(std::vector<int32_t *>
     }
     tileSet[i].decode_line_based_predecoded(main_header, reduce_NL, buf);
   }
-}
-
-void openhtj2k_decoder::invoke_dual_resolution(
-    std::function<void(uint32_t, int32_t *const *, uint16_t)> ll_cb,
-    std::function<void(uint32_t, int32_t *const *, uint16_t)> foveal_cb,
-    uint8_t max_reduce,
-    std::vector<uint32_t> &ll_w, std::vector<uint32_t> &ll_h,
-    std::vector<uint32_t> &fov_w, std::vector<uint32_t> &fov_h,
-    std::vector<uint8_t> &depth, std::vector<bool> &is_signed) {
-  this->impl->invoke_dual_resolution(ll_cb, foveal_cb, max_reduce,
-                                     ll_w, ll_h, fov_w, fov_h, depth, is_signed);
 }
 
 void openhtj2k_decoder::invoke_line_based_predecoded(std::vector<int32_t *> &buf,

--- a/source/core/interface/decoder.hpp
+++ b/source/core/interface/decoder.hpp
@@ -135,28 +135,6 @@ class openhtj2k_decoder {
   OPENHTJ2K_EXPORT void set_packet_observer(
       std::function<void(uint16_t t, uint16_t c, uint8_t r, uint32_t p_rc,
                          uint16_t layer, uint64_t offset, uint64_t length)> f);
-  // Phase 4B dual-resolution decode for foveated rendering.
-  //
-  // Two sequential decode passes from the same codestream:
-  //   Pass 1: reduce_NL = max_reduce → coarse output (tiny periphery)
-  //   Pass 2: reduce_NL = 0 → full resolution (uses the currently set
-  //           precinct filter to limit to the foveal region)
-  //
-  // The LL callback gets the coarse image (e.g., 120x68 for max_reduce=5).
-  // The foveal callback gets full-canvas rows but only foveal rows have
-  // non-zero data (absent precincts → zero via Phase 4A IDWT zero-skip).
-  //
-  // Caller must call set_precinct_filter() before this to define the
-  // foveal region.  The filter is used only for the foveal pass; the
-  // LL pass decodes all precincts at the reduced resolution.
-  OPENHTJ2K_EXPORT void invoke_dual_resolution(
-      std::function<void(uint32_t y, int32_t *const *, uint16_t nc)> ll_cb,
-      std::function<void(uint32_t y, int32_t *const *, uint16_t nc)> foveal_cb,
-      uint8_t max_reduce,
-      std::vector<uint32_t> &ll_width, std::vector<uint32_t> &ll_height,
-      std::vector<uint32_t> &fov_width, std::vector<uint32_t> &fov_height,
-      std::vector<uint8_t> &depth, std::vector<bool> &is_signed);
-
   // Diagnostic: pre-decodes codeblocks via the tile-at-a-time path, then runs
   // the line-based IDWT using those pre-decoded values.  If this matches invoke()
   // but invoke_line_based() does not, the bug is in decode_strip(); otherwise


### PR DESCRIPTION
Reverts PRs #270, #271, #272. The foveal pass still iterated all canvas rows, giving no speedup. Output was corrupted in some modes. The proper fix (spatial-region IDWT) will be implemented separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)