### PR TITLE
revert(jpip): remove set_row_limit (visual output matters)

### DIFF
--- a/source/core/coding/coding_units.cpp
+++ b/source/core/coding/coding_units.cpp
@@ -4799,8 +4799,7 @@ void j2k_tile::decode_line_based(j2k_main_header &hdr, uint8_t reduce_NL_val,
 }
 
 void j2k_tile::decode_line_based_stream(j2k_main_header &hdr, uint8_t reduce_NL_val,
-                                        const std::function<void(uint32_t, int32_t *const *, uint16_t)> &cb,
-                                        uint32_t row_limit) {
+                                        const std::function<void(uint32_t, int32_t *const *, uint16_t)> &cb) {
   const uint16_t NC = num_components;
 
   struct CInfo {
@@ -4863,7 +4862,6 @@ void j2k_tile::decode_line_based_stream(j2k_main_header &hdr, uint8_t reduce_NL_
     tcomp[c].init_line_decode(/*ring_mode=*/true);
 
   const uint32_t H = ci[0].csize_y;
-  const uint32_t effective_H = std::min(H, row_limit);
 
   // ── Strip-granular pull driver ────────────────────────────────────────────
   // Batch row pulls for one outer strip per component at a time, then run
@@ -4919,10 +4917,10 @@ void j2k_tile::decode_line_based_stream(j2k_main_header &hdr, uint8_t reduce_NL_
       (pool != nullptr) && (pool->num_threads() > 1) && (NC > 1);
 #endif
 
-  for (uint32_t strip_y0 = 0; strip_y0 < effective_H; strip_y0 += strip_h_luma) {
-    const uint32_t strip_y1 = std::min(strip_y0 + strip_h_luma, effective_H);
+  for (uint32_t strip_y0 = 0; strip_y0 < H; strip_y0 += strip_h_luma) {
+    const uint32_t strip_y1 = std::min(strip_y0 + strip_h_luma, H);
 
-    // Pre-compute per-component pull counts (clipped to effective_H).
+    // Pre-compute per-component pull counts.
     uint32_t counts[16] = {};
     for (uint16_t c = 0; c < NC && c < 16; ++c) {
       if (do_mct && c < 3) {

--- a/source/core/coding/coding_units.hpp
+++ b/source/core/coding/coding_units.hpp
@@ -807,13 +807,9 @@ class j2k_tile : public j2k_tile_base {
   // a callback instead of writing to a pre-allocated full-image buffer.
   // The callback receives (y, row_ptrs[NC], NC) where row_ptrs[c] points to one
   // decoded int32_t row for component c.  Allocates only per-row scratch buffers.
-  // row_limit: stop decoding after this many luma rows (default = all).
-  // Used by Phase 4B spatial-region skip to avoid IDWT work for rows
-  // past the foveal region.  Normal decode passes UINT32_MAX.
   void decode_line_based_stream(
       j2k_main_header &main_header, uint8_t reduce_NL,
-      const std::function<void(uint32_t y, int32_t *const *, uint16_t nc)> &cb,
-      uint32_t row_limit = UINT32_MAX);
+      const std::function<void(uint32_t y, int32_t *const *, uint16_t nc)> &cb);
   // Direct-to-planar streaming decode.  Reads float from IDWT ring buffers and
   // writes uint8/uint16 directly to caller-provided plane buffers, bypassing
   // the strip scratch, out_rows int32 intermediate, and callback overhead.

--- a/source/core/interface/decoder.cpp
+++ b/source/core/interface/decoder.cpp
@@ -59,7 +59,6 @@ class openhtj2k_decoder_impl {
  private:
   j2c_src_memory in;
   uint8_t reduce_NL;
-  uint32_t row_limit_ = UINT32_MAX;
   bool is_codestream_set;
   bool is_parsed;
   j2k_main_header main_header;
@@ -123,7 +122,6 @@ class openhtj2k_decoder_impl {
                                     std::vector<uint32_t> &, std::vector<uint8_t> &,
                                     std::vector<bool> &);
   void enable_single_tile_reuse(bool on);
-  void set_row_limit(uint32_t limit) { row_limit_ = limit; }
   void set_precinct_filter(std::function<bool(uint16_t, uint16_t, uint8_t, uint32_t)> f);
   void set_packet_observer(
       std::function<void(uint16_t, uint16_t, uint8_t, uint32_t, uint16_t, uint64_t, uint64_t)> f);
@@ -672,7 +670,7 @@ void openhtj2k_decoder_impl::invoke_line_based_stream(
       tileSet[tile_idx].decode_line_based_stream(main_header, reduce_NL,
           [&](uint32_t y_local, int32_t *const *rows, uint16_t nc) {
             cb(global_y + y_local, rows, nc);
-          }, row_limit_);
+          });
       tileSet[tile_idx].destroy();
       global_y += band_h0;
     }
@@ -734,7 +732,7 @@ void openhtj2k_decoder_impl::invoke_line_based_stream(
         tileSet[tile_idx].destroy();
         throw std::runtime_error("Abort Decoding!");
       }
-      tileSet[tile_idx].decode_line_based_stream(main_header, reduce_NL, scatter, row_limit_);
+      tileSet[tile_idx].decode_line_based_stream(main_header, reduce_NL, scatter);
       tileSet[tile_idx].destroy();  // Release tile-internal buffers immediately
     }
 
@@ -780,10 +778,6 @@ void openhtj2k_decoder_impl::enable_single_tile_reuse(bool on) {
     cached_tileSet_.clear();
     cached_header_fingerprint_ = 0;
   }
-}
-
-void openhtj2k_decoder::set_row_limit(uint32_t limit) {
-  this->impl->set_row_limit(limit);
 }
 
 void openhtj2k_decoder::set_precinct_filter(
@@ -1032,7 +1026,7 @@ void openhtj2k_decoder_impl::invoke_line_based_stream_reuse(
     throw std::runtime_error("Abort Decoding!");
   }
 
-  cached_tileSet_[0].decode_line_based_stream(main_header, reduce_NL, cb, row_limit_);
+  cached_tileSet_[0].decode_line_based_stream(main_header, reduce_NL, cb);
 
   cached_header_fingerprint_ = fp;
 }

--- a/source/core/interface/decoder.hpp
+++ b/source/core/interface/decoder.hpp
@@ -113,15 +113,6 @@ class openhtj2k_decoder {
   // sequence for the stream you want to keep cached.  Passing false drops
   // any cached state and returns the decoder to the legacy per-frame path.
   OPENHTJ2K_EXPORT void enable_single_tile_reuse(bool on);
-  // Phase 4B spatial-region early exit.  When set, the line-based decode
-  // stops after this many luma rows instead of decoding the full canvas.
-  // The IDWT, MCT, and callback are skipped entirely for rows past the
-  // limit.  Default = UINT32_MAX (no limit, all rows decoded).
-  // Set to foveal_y1 for foveated rendering: rows 0..y0 benefit from
-  // Phase 4A zero-skip (absent precincts → near-zero cost), rows y0..y1
-  // are full decode, rows y1..H are skipped (zero cost).
-  OPENHTJ2K_EXPORT void set_row_limit(uint32_t limit);
-
   // JPIP partial-decode hook.  When set, every subsequent invoke*() call
   // consults this filter per-packet: precincts for which the filter returns
   // false have their body bytes dropped (not attached to codeblocks) while


### PR DESCRIPTION
Without LL background composite, skipped rows produce black regions. Revert until Phase 4B is implemented as a complete unit (LL decode + early exit + GPU composite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)