### PR TITLE
feat(wasm): JPIP large-image viewer (pan + zoom)

### DIFF
--- a/.github/workflows/deploy-wasm-demo.yml
+++ b/.github/workflows/deploy-wasm-demo.yml
@@ -42,6 +42,7 @@ jobs:
           cp subprojects/index.html                     deploy/
           cp subprojects/rtp_demo.html                  deploy/
           cp subprojects/jpip_demo.html                 deploy/
+          cp subprojects/jpip_viewer.html                deploy/
           cp subprojects/rtp_parser.js                  deploy/
           cp subprojects/coi-serviceworker.js           deploy/
           # Sample codestreams referenced by index.html's preset dropdown.

--- a/subprojects/index.html
+++ b/subprojects/index.html
@@ -382,6 +382,7 @@
     <a href="index.html"    class="active">Still Image</a>
     <a href="rtp_demo.html">RTP Replay</a>
     <a href="jpip_demo.html?server=https://jpip-demo.osamu620.dev">JPIP Foveation</a>
+    <a href="jpip_viewer.html?server=https://jpip-demo.osamu620.dev">JPIP Viewer</a>
   </nav>
   <!-- Original simd_message element (hidden; JS reads/writes innerText; badge synced below) -->
   <pre id="simd_message" style="display:none"></pre>

--- a/subprojects/jpip_viewer.html
+++ b/subprojects/jpip_viewer.html
@@ -1,0 +1,304 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>OpenHTJ2K JPIP Viewer — Large Image Browser</title>
+<style>
+  body { margin: 0; background: #111; color: #eee; font-family: monospace; overflow: hidden; }
+  #controls { padding: 8px; }
+  #controls label { margin-right: 12px; }
+  #controls input { width: 360px; }
+  canvas { display: block; cursor: grab; }
+  canvas.dragging { cursor: grabbing; }
+  #stats { padding: 4px 8px; font-size: 13px; position: fixed; bottom: 0; left: 0; right: 0;
+           background: rgba(0,0,0,0.7); }
+</style>
+</head>
+<body>
+
+<div id="controls">
+  <label>JPIP Server: <input id="server" value="http://localhost:8080" /></label>
+  <button id="connectBtn">Connect</button>
+  <span id="info"></span>
+</div>
+<canvas id="canvas"></canvas>
+<div id="stats">Scroll to zoom, drag to pan</div>
+<script>
+  (function() {
+    var p = new URLSearchParams(location.search);
+    var s = p.get('server'); if (s) document.getElementById('server').value = s;
+  })();
+</script>
+
+<script src="https://unpkg.com/wasm-feature-detect/dist/umd/index.js"></script>
+<script>
+  if (!window.crossOriginIsolated && window.isSecureContext) {
+    navigator.serviceWorker.register("coi-serviceworker.js").then(
+      function (reg) {
+        if (!window.crossOriginIsolated) {
+          reg.addEventListener("updatefound", function () {
+            reg.installing.addEventListener("statechange", function () {
+              if (this.state === "activated") location.reload();
+            });
+          });
+          if (reg.active && !navigator.serviceWorker.controller) location.reload();
+        }
+      },
+      function (err) { console.warn("COI service worker failed:", err); }
+    );
+  }
+</script>
+<script type="module">
+const hasSimd = await wasmFeatureDetect.simd();
+const hasMt = window.crossOriginIsolated && (typeof SharedArrayBuffer !== 'undefined');
+const forceVariant = new URLSearchParams(location.search).get('variant');
+const useMt = forceVariant === 'mt' ? true : forceVariant === 'st' ? false : (hasSimd && hasMt);
+const wasmFile = useMt ? './libopen_htj2k_jpip_mt_simd.js' : './libopen_htj2k_jpip.js';
+const {default: createModule} = await import(wasmFile);
+
+const $ = id => document.getElementById(id);
+
+let M = null;
+let ctx = 0;
+let canvasW = 0, canvasH = 0;
+let rgbPtr = 0;
+let serverUrl = '';
+let busy = false;
+
+// Viewport state
+let vpW = 0, vpH = 0;
+let panX = 0, panY = 0;   // top-left in canvas coordinates
+let zoom = 1.0;           // display scale: 1.0 = fit width, >1 = zoom in
+
+// WebGL2
+let gl = null, glTex = null, glProgram = null, texW = 0, texH = 0;
+
+function initWebGL(canvas, w, h) {
+  gl = canvas.getContext('webgl2', { antialias: false, alpha: false });
+  if (!gl) return false;
+  const vs = `#version 300 es
+    const vec2 pos[4] = vec2[](vec2(-1,-1),vec2(1,-1),vec2(-1,1),vec2(1,1));
+    const vec2 uv[4]  = vec2[](vec2(0,1),vec2(1,1),vec2(0,0),vec2(1,0));
+    out vec2 vUV;
+    void main() { vUV = uv[gl_VertexID]; gl_Position = vec4(pos[gl_VertexID],0,1); }`;
+  const fs = `#version 300 es
+    precision mediump float;
+    uniform sampler2D uTex;
+    in vec2 vUV;
+    out vec4 fragColor;
+    void main() { fragColor = texture(uTex, vUV); }`;
+  function compile(type, src) {
+    const s = gl.createShader(type);
+    gl.shaderSource(s, src); gl.compileShader(s);
+    if (!gl.getShaderParameter(s, gl.COMPILE_STATUS)) console.error(gl.getShaderInfoLog(s));
+    return s;
+  }
+  glProgram = gl.createProgram();
+  gl.attachShader(glProgram, compile(gl.VERTEX_SHADER, vs));
+  gl.attachShader(glProgram, compile(gl.FRAGMENT_SHADER, fs));
+  gl.linkProgram(glProgram); gl.useProgram(glProgram);
+  glTex = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, glTex);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, w, h, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+  texW = w; texH = h;
+  gl.bindVertexArray(gl.createVertexArray());
+  gl.viewport(0, 0, canvas.width, canvas.height);
+  return true;
+}
+
+function drawFrame(rgba, w, h) {
+  if (!gl) return;
+  if (w !== texW || h !== texH) {
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, w, h, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    texW = w; texH = h;
+  }
+  gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, w, h, gl.RGBA, gl.UNSIGNED_BYTE, rgba);
+  gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+}
+
+function buildQuery() {
+  const fW = Math.max(1, Math.round(canvasW * zoom));
+  const fH = Math.max(1, Math.round(canvasH * zoom));
+  const oX = Math.max(0, Math.round(panX * zoom));
+  const oY = Math.max(0, Math.round(panY * zoom));
+  const sW = Math.min(vpW, fW - oX);
+  const sH = Math.min(vpH, fH - oY);
+  let q = `fsiz=${fW},${fH}`;
+  if (oX > 0 || oY > 0) q += `&roff=${oX},${oY}`;
+  if (sW > 0 || sH > 0) q += `&rsiz=${sW},${sH}`;
+  q += '&type=jpp-stream';
+  return q;
+}
+
+async function fetchAndDecode() {
+  if (!M || !ctx || busy) return;
+  busy = true;
+  const q = buildQuery();
+  try {
+    const t0 = performance.now();
+    const resp = await fetch(`${serverUrl}/jpip?${q}`);
+    if (!resp.ok) { $('stats').textContent = `HTTP ${resp.status}`; busy = false; return; }
+    const buf = new Uint8Array(await resp.arrayBuffer());
+    const tFetch = performance.now();
+
+    M._jpip_begin_frame(ctx);
+    const ptr = M._malloc(buf.length);
+    M.HEAPU8.set(buf, ptr);
+    M._jpip_add_response(ctx, ptr, buf.length);
+    M._free(ptr);
+    const rc = M._jpip_end_frame(ctx, rgbPtr, vpW, vpH);
+    const tDecode = performance.now();
+
+    if (rc === 0) {
+      const rgba = new Uint8Array(M.HEAPU8.buffer, rgbPtr, vpW * vpH * 4);
+      drawFrame(rgba, vpW, vpH);
+    }
+
+    const pct = (zoom * 100).toFixed(0);
+    $('stats').textContent =
+      `${canvasW}×${canvasH} | zoom ${pct}% | pan (${Math.round(panX)}, ${Math.round(panY)}) | ` +
+      `fetch=${(tFetch - t0).toFixed(0)}ms decode=${(tDecode - tFetch).toFixed(0)}ms | ` +
+      `${(buf.length / 1024).toFixed(0)} KB`;
+  } catch (e) {
+    $('stats').textContent = `error: ${e.message}`;
+  }
+  busy = false;
+}
+
+async function init() {
+  $('info').textContent = 'Loading WASM…';
+  try {
+    M = await createModule();
+    $('info').textContent = `WASM ready (${useMt ? 'MT+SIMD' : 'SIMD'}). Enter server URL and click Connect.`;
+  } catch (e) {
+    $('info').textContent = 'WASM load failed: ' + e.message;
+  }
+  $('connectBtn').onclick = connect;
+}
+
+async function connect() {
+  if (!M) { $('info').textContent = 'WASM not loaded yet'; return; }
+  serverUrl = $('server').value.replace(/\/+$/, '');
+  $('info').textContent = 'Connecting…';
+
+  try {
+    const resp = await fetch(`${serverUrl}/jpip?fsiz=1,1&type=jpp-stream`);
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    const buf = new Uint8Array(await resp.arrayBuffer());
+    const binPtr = M._malloc(buf.length);
+    M.HEAPU8.set(buf, binPtr);
+    ctx = M._jpip_create_context(binPtr, buf.length);
+    M._free(binPtr);
+  } catch (e) {
+    $('info').textContent = `Connect failed: ${e.message}`;
+    return;
+  }
+  if (!ctx) { $('info').textContent = 'Failed to build index'; return; }
+
+  canvasW = M._jpip_get_canvas_width(ctx);
+  canvasH = M._jpip_get_canvas_height(ctx);
+  const totalP = M._jpip_get_total_precincts(ctx);
+
+  const c = $('canvas');
+  vpW = Math.min(window.innerWidth, 1920);
+  vpH = window.innerHeight - 40;
+  c.width = vpW;
+  c.height = vpH;
+
+  rgbPtr = M._malloc(vpW * vpH * 4);
+  initWebGL(c, vpW, vpH);
+
+  // Initial zoom: fit width
+  zoom = vpW / canvasW;
+  panX = 0;
+  panY = 0;
+
+  $('info').textContent = `${canvasW}×${canvasH}, ${totalP} precincts [WebGL2]`;
+
+  // Pan: mouse drag
+  let dragging = false, dragStartX = 0, dragStartY = 0, panStartX = 0, panStartY = 0;
+  c.addEventListener('mousedown', (e) => {
+    dragging = true; c.classList.add('dragging');
+    dragStartX = e.clientX; dragStartY = e.clientY;
+    panStartX = panX; panStartY = panY;
+  });
+  window.addEventListener('mousemove', (e) => {
+    if (!dragging) return;
+    const dx = (e.clientX - dragStartX) / zoom;
+    const dy = (e.clientY - dragStartY) / zoom;
+    panX = Math.max(0, Math.min(canvasW - vpW / zoom, panStartX - dx));
+    panY = Math.max(0, Math.min(canvasH - vpH / zoom, panStartY - dy));
+    fetchAndDecode();
+  });
+  window.addEventListener('mouseup', () => {
+    dragging = false; c.classList.remove('dragging');
+  });
+
+  // Zoom: scroll wheel (zoom toward cursor)
+  c.addEventListener('wheel', (e) => {
+    e.preventDefault();
+    const rect = c.getBoundingClientRect();
+    const mx = (e.clientX - rect.left) / vpW;
+    const my = (e.clientY - rect.top) / vpH;
+
+    const oldZoom = zoom;
+    const factor = e.deltaY < 0 ? 1.15 : 1 / 1.15;
+    zoom = Math.max(vpW / canvasW * 0.5, Math.min(4.0, zoom * factor));
+
+    // Adjust pan so the point under the cursor stays fixed
+    panX += (mx * vpW) * (1 / oldZoom - 1 / zoom);
+    panY += (my * vpH) * (1 / oldZoom - 1 / zoom);
+    panX = Math.max(0, panX);
+    panY = Math.max(0, panY);
+
+    fetchAndDecode();
+  }, { passive: false });
+
+  // Touch: pinch to zoom, single-finger drag to pan
+  let lastTouchDist = 0, lastTouchMid = null;
+  c.addEventListener('touchstart', (e) => {
+    if (e.touches.length === 1) {
+      dragging = true;
+      dragStartX = e.touches[0].clientX; dragStartY = e.touches[0].clientY;
+      panStartX = panX; panStartY = panY;
+    } else if (e.touches.length === 2) {
+      dragging = false;
+      const dx = e.touches[1].clientX - e.touches[0].clientX;
+      const dy = e.touches[1].clientY - e.touches[0].clientY;
+      lastTouchDist = Math.sqrt(dx * dx + dy * dy);
+      lastTouchMid = { x: (e.touches[0].clientX + e.touches[1].clientX) / 2,
+                        y: (e.touches[0].clientY + e.touches[1].clientY) / 2 };
+    }
+    e.preventDefault();
+  }, { passive: false });
+  c.addEventListener('touchmove', (e) => {
+    if (e.touches.length === 1 && dragging) {
+      const dx = (e.touches[0].clientX - dragStartX) / zoom;
+      const dy = (e.touches[0].clientY - dragStartY) / zoom;
+      panX = Math.max(0, panStartX - dx);
+      panY = Math.max(0, panStartY - dy);
+      fetchAndDecode();
+    } else if (e.touches.length === 2 && lastTouchDist > 0) {
+      const dx = e.touches[1].clientX - e.touches[0].clientX;
+      const dy = e.touches[1].clientY - e.touches[0].clientY;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      const factor = dist / lastTouchDist;
+      lastTouchDist = dist;
+      zoom = Math.max(vpW / canvasW * 0.5, Math.min(4.0, zoom * factor));
+      fetchAndDecode();
+    }
+    e.preventDefault();
+  }, { passive: false });
+  c.addEventListener('touchend', () => { dragging = false; lastTouchDist = 0; });
+
+  fetchAndDecode();
+}
+
+init();
+</script>
+</body>
+</html>

--- a/subprojects/rtp_demo.html
+++ b/subprojects/rtp_demo.html
@@ -347,6 +347,7 @@
     <a href="index.html">Still Image</a>
     <a href="rtp_demo.html" class="active">RTP Replay</a>
     <a href="jpip_demo.html?server=https://jpip-demo.osamu620.dev">JPIP Foveation</a>
+    <a href="jpip_viewer.html?server=https://jpip-demo.osamu620.dev">JPIP Viewer</a>
   </nav>
 
   <div class="privacy-notice">


### PR DESCRIPTION
## Summary
New `jpip_viewer.html` — interactive pan+zoom browser for gigapixel images via JPIP.

- Drag to pan, scroll to zoom (zoom toward cursor)
- Touch support: pinch to zoom, single-finger drag to pan
- One JPIP request per viewport change — bandwidth proportional to viewport size, not image size
- Status bar: zoom %, pan position, fetch/decode timing, data transferred

Tested with 42,208×9,870 (416 MP) ESA/Hubble image. No C++ changes — purely HTML/JS.

## Test plan
- [ ] Manual: connect to JPIP server with large image, pan and zoom smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)