### PR TITLE
fix(wasm): refresh HEAPU8 view after malloc for memory growth

### DIFF
--- a/subprojects/jpip_demo.html
+++ b/subprojects/jpip_demo.html
@@ -80,6 +80,10 @@ const $ = id => document.getElementById(id);
 let M = null;   // WASM module
 let ctx = 0;    // jpip context handle (pointer)
 let canvasW = 0, canvasH = 0;
+
+function wasmWrite(data, ptr) {
+  new Uint8Array(M.HEAPU8.buffer).set(data, ptr);
+}
 let rgbPtr = 0; // WASM heap pointer for RGBA output
 let running = false;
 let serverUrl = '';
@@ -189,7 +193,7 @@ async function connect() {
     // jpip_create_context parses the JPP-stream response internally,
     // extracts the main-header data-bin, and builds the CodestreamIndex.
     const binPtr = M._malloc(buf.length);
-    M.HEAPU8.set(buf, binPtr);
+    wasmWrite(buf, binPtr);
     ctx = M._jpip_create_context(binPtr, buf.length);
     M._free(binPtr);
   } catch (e) {
@@ -269,7 +273,7 @@ async function connect() {
       for (const ab of [r1, r2, r3]) {
         const arr = new Uint8Array(ab);
         const ptr = M._malloc(arr.length);
-        M.HEAPU8.set(arr, ptr);
+        wasmWrite(arr, ptr);
         M._jpip_add_response(ctx, ptr, arr.length);
         M._free(ptr);
       }

--- a/subprojects/jpip_viewer.html
+++ b/subprojects/jpip_viewer.html
@@ -65,6 +65,10 @@ let rgbPtr = 0;
 let serverUrl = '';
 let busy = false;
 
+function wasmWrite(data, ptr) {
+  new Uint8Array(M.HEAPU8.buffer).set(data, ptr);
+}
+
 // Viewport state
 let vpW = 0, vpH = 0;
 let panX = 0, panY = 0;   // top-left in canvas coordinates
@@ -147,14 +151,14 @@ async function fetchAndDecode() {
 
     M._jpip_begin_frame(ctx);
     const ptr = M._malloc(buf.length);
-    M.HEAPU8.set(buf, ptr);
+    wasmWrite(buf, ptr);
     M._jpip_add_response(ctx, ptr, buf.length);
     M._free(ptr);
     const rc = M._jpip_end_frame(ctx, rgbPtr, vpW, vpH);
     const tDecode = performance.now();
 
     if (rc === 0) {
-      const rgba = new Uint8Array(M.HEAPU8.buffer, rgbPtr, vpW * vpH * 4);
+      const rgba = new Uint8Array(M.wasmMemory ? M.wasmMemory.buffer : M.HEAPU8.buffer, rgbPtr, vpW * vpH * 4);
       drawFrame(rgba, vpW, vpH);
     }
 
@@ -190,7 +194,7 @@ async function connect() {
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
     const buf = new Uint8Array(await resp.arrayBuffer());
     const binPtr = M._malloc(buf.length);
-    M.HEAPU8.set(buf, binPtr);
+    wasmWrite(buf, binPtr);
     ctx = M._jpip_create_context(binPtr, buf.length);
     M._free(binPtr);
   } catch (e) {


### PR DESCRIPTION
With ALLOW_MEMORY_GROWTH, malloc can detach the HEAPU8 ArrayBuffer. The stale view silently writes to nothing → parse fails → 'Failed to build index'. Fix: fresh Uint8Array view after each malloc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)