### PR TITLE
feat(jpip): viewport-region perf — fsiz scaling, zero-row skip, col-range IDWT

### DIFF
--- a/VIEWER_PLAN.md
+++ b/VIEWER_PLAN.md
@@ -1,0 +1,192 @@
+# JPIP Large-Image Viewer Plan (revised)
+
+Interactive pan+zoom viewer for gigapixel images via JPIP.
+
+## Test image
+
+`heic2501a.j2c` — 42,208 x 9,870 (416 MP), 270 MB, 103,179 precincts.
+
+## V1 status (completed)
+
+The viewer works but has two problems at high zoom:
+
+1. **Blurry** — the decoded texture is limited to 4096 pixels
+   (maxDim cap) regardless of zoom.  At 50% zoom on a 42K image,
+   the viewport shows ~21K canvas pixels but the texture has only
+   4096 — a 5:1 downsampling that smears all detail.
+
+2. **Slow** — `jpip_end_frame` always runs the IDWT on the full
+   canvas at reduce_NL resolution.  At reduce=0, that's 42208×9870
+   → ~3000ms in WASM.  The server correctly sends only viewport
+   precincts (roff/rsiz), but the decoder ignores this and
+   processes every row.
+
+Both problems have the same root cause: **the decoder cannot output
+a spatial sub-region of the canvas.**  It always decodes the full
+canvas and downsamples to the output buffer.
+
+## The fix: viewport-region decode
+
+The viewer needs a WASM API that:
+
+1. Takes a viewport rectangle (ox, oy, w, h) in canvas coordinates
+2. Decodes ONLY the precincts that contribute to that rectangle
+3. Outputs a viewport-sized (w × h) RGBA buffer
+4. Runs the IDWT only on the rows within the rectangle
+
+### Why this is hard
+
+The line-based IDWT is sequential: row N depends on rows N-1 and
+N+1 via the lifting filter.  You cannot jump to row oy without
+processing rows 0 through oy-1.
+
+However, with the precinct filter (Phase 4A), rows outside the
+viewport region have absent precincts → zero subband data → the
+IDWT zero-skip optimization makes those rows nearly free (~10% of
+full cost).  The remaining cost is the structural overhead of
+iterating rows 0 to oy-1 even though they produce zeros.
+
+### Approach: early-start + early-exit
+
+```
+Row 0          ← zero-skip (absent precincts, ~free)
+...            ← zero-skip
+Row oy         ← START writing to output buffer
+...            ← full IDWT (viewport data)
+Row oy+h       ← STOP (early exit, skip all remaining rows)
+...
+Row H          ← never reached
+```
+
+**Early exit** (rows after oy+h): skip entirely.  `idwt_2d_state_free`
+is safe with partial pulls — verified in the Phase 4B analysis.  Saves
+~(H - oy - h) / H of the total cost.
+
+**Zero-skip** (rows before oy): Phase 4A's `adv_step` already skips
+lifting when both neighbor rows are zero.  Cost is ~10% per row
+(counter increments + zero checks, no SIMD arithmetic).
+
+**Combined savings** for a centered viewport on 42K image:
+
+| Region | Rows | Cost per row | Total |
+|---|---|---|---|
+| Before viewport (zero-skip) | ~4000 | ~10% | 400 |
+| Viewport | ~1000 | 100% | 1000 |
+| After viewport (early exit) | ~5000 | 0% | 0 |
+| **Total** | 10000 | | **1400** (vs 10000 full) |
+
+**Speedup: ~7x** (from ~3000ms to ~420ms in WASM for reduce=0).
+
+With reduce=1 (half resolution): canvas is 21104×4935.  The same
+approach gives ~210ms → acceptable for interactive browsing.
+
+### Implementation plan
+
+#### V2-1 · `jpip_end_frame_region` WASM API
+
+New function in `jpip_wrapper.cpp`:
+
+```c
+int jpip_end_frame_region(void *handle, uint8_t *rgb_out,
+                          int out_w, int out_h,
+                          int region_x, int region_y,
+                          int region_w, int region_h);
+```
+
+- Sets `reduce_NL` from `ctx->reduce_NL` (as now)
+- Sets precinct filter: only precincts overlapping
+  `[region_x, region_y, region_w, region_h]` at the reduced level
+- Calls `invoke_line_based_stream` with a row callback that:
+  - Skips output for rows < region_y
+  - Writes rows [region_y, region_y+region_h) to rgb_out
+  - After row region_y+region_h: no more writes (but rows still
+    iterate until early-exit is added)
+- Output buffer is `out_w × out_h` pixels (viewport-sized)
+
+This gives the **correct output** (no blur) without changing the
+decoder core.  The decode is still slow (iterates all rows) but
+the output quality is perfect.
+
+#### V2-2 · Early-exit row limit (re-implement Phase 4B)
+
+Add `row_limit` parameter to `decode_line_based_stream`:
+
+```cpp
+void decode_line_based_stream(
+    j2k_main_header &hdr, uint8_t reduce_NL,
+    const std::function<...> &cb,
+    uint32_t row_limit = UINT32_MAX);
+```
+
+When `row_limit < H`, the strip loop and Phase 1 pulls stop at
+`row_limit`.  The IDWT state is freed via `finalize_line_decode`
+which handles partial pulls safely.
+
+`jpip_end_frame_region` sets `row_limit = region_y + region_h`.
+
+**This is the same change we reverted earlier**, but now it's used
+inside `jpip_end_frame_region` — the output buffer contains the
+correct viewport data (no black regions) because the row callback
+only writes rows within the viewport.
+
+#### V2-3 · Wire into viewer JavaScript
+
+Update `jpip_viewer.html` to call `jpip_end_frame_region` instead
+of `jpip_end_frame`:
+
+```javascript
+const rc = M._jpip_end_frame_region(ctx, rgbPtr, vpW, vpH,
+    Math.round(panX), Math.round(panY),
+    Math.round(vpW / zoom), Math.round(vpH / zoom));
+```
+
+Remove the maxDim cap — the output is always viewport-sized.
+Remove the reduce-level-dependent fetch mode — always fetch the
+viewport region via roff/rsiz.
+
+#### V2-4 · Precinct-to-region filter
+
+The precinct filter for the viewport region: given (region_x,
+region_y, region_w, region_h) in canvas coordinates, determine
+which precincts at the active resolution level overlap.
+
+This is already solved by `resolve_view_window` — it maps a
+ViewWindow (fsiz/roff/rsiz) to a set of precinct keys.  The
+`jpip_end_frame_region` can build a ViewWindow from the region
+parameters and call `resolve_view_window` on the client-side
+CodestreamIndex.
+
+Alternatively, just use the server's response: the server already
+sends only viewport precincts via roff/rsiz.  The client doesn't
+need its own filter — absent precincts naturally produce zeros,
+and the IDWT zero-skip handles them.
+
+### Expected result
+
+| Zoom | Reduce | Decode (before) | Decode (after) | Quality |
+|---|---|---|---|---|
+| 5% | 4 | 50ms | 50ms (unchanged) | Good |
+| 10% | 3 | 100ms | 80ms | Good |
+| 25% | 2 | 200ms | 60ms | Sharp |
+| 50% | 0 | 3000ms | 420ms | **Sharp** (was blurry) |
+| 100% | 0 | 3000ms | 250ms | **Pixel-perfect** |
+
+### Risk
+
+The IDWT zero-skip for rows before the viewport depends on ALL
+precincts outside the viewport being absent.  If the server sends
+extra precincts (e.g., overlapping the viewport boundary), some
+pre-viewport rows may have data, reducing the zero-skip benefit.
+This is a minor performance issue, not a correctness issue.
+
+## V3 · Smooth transitions and caching (future)
+
+- Cache decoded tiles by (reduce, region) key
+- On pan: display cached tile immediately, refetch in background
+- On zoom: show cached low-res scaled up while high-res loads
+- Progressive: coarse response first, refine with follow-up
+
+## V4 · Native viewer (future)
+
+- GLFW-based pan+zoom with the same region-decode API
+- Native decode is ~5-10x faster than WASM → sub-50ms at any zoom

--- a/source/core/coding/coding_units.cpp
+++ b/source/core/coding/coding_units.cpp
@@ -129,6 +129,28 @@ static inline int32_t pse_row_idx(int32_t idx, int32_t len) {
   return (idx < len) ? idx : period - idx;
 }
 
+// Early-exit check for LP+HP both-zero.  Scans 16 uint32 words at a time and
+// returns false the moment any non-zero bit pattern (including -0.0f) is seen.
+// For dense data the first block fails the test, so cost is O(64 B) per row.
+// For JPIP sparse frames the scan runs to completion and the caller skips the
+// full interleave + horizontal-IDWT path for this row.
+static inline bool lp_hp_both_zero(const sprec_t *lp, int32_t lp_w,
+                                   const sprec_t *hp, int32_t hp_w) {
+  auto scan = [](const sprec_t *row, int32_t w) -> bool {
+    const uint32_t *p = reinterpret_cast<const uint32_t *>(row);
+    int32_t i = 0;
+    for (; i + 16 <= w; i += 16) {
+      uint32_t acc = 0;
+      for (int32_t j = 0; j < 16; ++j) acc |= p[i + j];
+      if (acc) return false;
+    }
+    uint32_t acc = 0;
+    for (; i < w; ++i) acc |= p[i];
+    return acc == 0;
+  };
+  return scan(lp, lp_w) && scan(hp, hp_w);
+}
+
 // Callback invoked by idwt_2d_state::fetch_one() for each source row.
 static void idwt_level_src_fn(void *ctx, int32_t abs_row, sprec_t *out) {
   auto *c = static_cast<idwt_level_src_ctx *>(ctx);
@@ -164,6 +186,13 @@ static void idwt_level_src_fn(void *ctx, int32_t abs_row, sprec_t *out) {
       lp_ptr = c->ll0_buf->row_ptr(c->ll_y0 + clamped);
     }
     const sprec_t *hp_ptr = c->hl_buf->row_ptr(c->hl_y0 + sub_idx);
+    const int32_t width = c->u1 - c->u0;
+    if (width <= 0) return;
+    // Fast path: both subbands all-zero → horizontal IDWT output is all-zero.
+    if (lp_hp_both_zero(lp_ptr, c->lp_width, hp_ptr, c->hp_width)) {
+      memset(out, 0, sizeof(sprec_t) * static_cast<size_t>(width));
+      return;
+    }
     // Fall through to shared interleave + horizontal IDWT code below.
     // Interleave: LP at u0%2, HP at 1-u0%2.
     const int32_t u_off  = c->u0 & 1;
@@ -176,8 +205,6 @@ static void idwt_level_src_fn(void *ctx, int32_t abs_row, sprec_t *out) {
       for (int32_t j = 0; j < c->lp_width; ++j)  out[2 * j + 1] = lp_ptr[j];
     }
     (void)min_w;  // suppress unused-variable warning (used in BIDIR path below)
-    const int32_t width = c->u1 - c->u0;
-    if (width <= 0) return;
     if (width == 1) {
       if ((c->u0 % 2 != 0) && (c->transformation == 1)) out[0] /= 2.0f;
       return;
@@ -216,6 +243,18 @@ static void idwt_level_src_fn(void *ctx, int32_t abs_row, sprec_t *out) {
   } else {
     lp_ptr = c->lh_buf->row_ptr(c->lh_y0 + sub_idx);     // no copy
     hp_ptr = c->hh_buf->row_ptr(c->hh_y0 + sub_idx);     // no copy
+  }
+
+  // Fast path: both subbands all-zero → horizontal IDWT output is all-zero.
+  // For dense codestreams the early-exit scan returns false after ~1 cache
+  // line; for sparse JPIP frames this eliminates the per-row interleave +
+  // 1D-IDWT cost for absent precincts.
+  {
+    const int32_t width_z = c->u1 - c->u0;
+    if (width_z > 0 && lp_hp_both_zero(lp_ptr, c->lp_width, hp_ptr, c->hp_width)) {
+      memset(out, 0, sizeof(sprec_t) * static_cast<size_t>(width_z));
+      return;
+    }
   }
 
   // Interleave: LP always at u0%2 column-offset, HP at 1-u0%2.
@@ -2312,6 +2351,29 @@ void j2k_tile_component::init_line_decode(bool ring_mode) {
         }
       }
     }
+  }
+}
+
+void j2k_tile_component::set_line_decode_col_range(uint32_t col_lo, uint32_t col_hi) {
+  if (line_dec == nullptr) return;
+  j2k_tcomp_line_dec *ld = line_dec.get();
+  if (ld->NL_active <= 0) return;
+  idwt_2d_state *states = ld->states.get();
+  const int32_t NL_act  = ld->NL_active;
+  // Seed with caller's finest-level range.  Coarser levels are derived by
+  // halving and widening by the 9/7 filter support (4 samples each side,
+  // conservative over-estimate that also covers 5/3 where support is 2).
+  int32_t a = static_cast<int32_t>(col_lo);
+  int32_t b = static_cast<int32_t>(col_hi);
+  for (int32_t i = NL_act - 1; i >= 0; --i) {
+    idwt_2d_state_set_col_range(&states[i], a, b);
+    // Next coarser level's output feeds this level's horizontal IDWT, which
+    // reads up to 4 samples beyond each output column.  In subband coords
+    // (half-width) that maps to ±2 samples; we round up to 4 for safety.
+    const int32_t halved_lo = (a >> 1) - 4;
+    const int32_t halved_hi = ((b + 1) >> 1) + 4;
+    a = halved_lo;
+    b = halved_hi;
   }
 }
 
@@ -4800,8 +4862,20 @@ void j2k_tile::decode_line_based(j2k_main_header &hdr, uint8_t reduce_NL_val,
 
 void j2k_tile::decode_line_based_stream(j2k_main_header &hdr, uint8_t reduce_NL_val,
                                         const std::function<void(uint32_t, int32_t *const *, uint16_t)> &cb,
-                                        uint32_t row_limit) {
+                                        uint32_t row_limit,
+                                        uint32_t col_lo_in, uint32_t col_hi_in) {
   const uint16_t NC = num_components;
+
+  // Apply per-level column range to each component's IDWT state chain.
+  // col_lo_in / col_hi_in are in the finest active-level output coord space
+  // (= subsampled-tcomp coords after reduce).  When the caller uses the
+  // defaults [0, UINT32_MAX) every level's col range resolves to the full
+  // [u0, u1] → idwt kernel loops unchanged from pre-patch behaviour.
+  if (col_lo_in != 0 || col_hi_in != UINT32_MAX) {
+    for (uint16_t c = 0; c < NC; ++c) {
+      tcomp[c].set_line_decode_col_range(col_lo_in, col_hi_in);
+    }
+  }
 
   struct CInfo {
     int32_t DC_OFFSET, MAXVAL, MINVAL;

--- a/source/core/coding/coding_units.hpp
+++ b/source/core/coding/coding_units.hpp
@@ -588,6 +588,12 @@ class j2k_tile_component : public j2k_tile_base {
   // false, both functions behave as before.  The destructor forces false
   // before calling finalize_line_decode to guarantee cleanup.
   void set_line_decode_persistent(bool on) { line_dec_persistent_ = on; }
+  // Apply a column range to this component's IDWT level chain.  col_lo / col_hi
+  // are in finest-active-level tile-component coords.  Each coarser level's
+  // range is derived by halving + widening for the 9/7 filter support.
+  // Must be called after init_line_decode() (states must exist).  Defaults
+  // (col_lo == 0, col_hi == UINT32_MAX) behave exactly like pre-patch code.
+  void set_line_decode_col_range(uint32_t col_lo, uint32_t col_hi);
 
   // ── Line-based encode API ─────────────────────────────────────────────────
   // init_line_encode():     allocates FDWT state chain; call after enc_init().
@@ -810,7 +816,8 @@ class j2k_tile : public j2k_tile_base {
   void decode_line_based_stream(
       j2k_main_header &main_header, uint8_t reduce_NL,
       const std::function<void(uint32_t y, int32_t *const *, uint16_t nc)> &cb,
-      uint32_t row_limit = UINT32_MAX);
+      uint32_t row_limit = UINT32_MAX,
+      uint32_t col_lo = 0, uint32_t col_hi = UINT32_MAX);
   // Direct-to-planar streaming decode.  Reads float from IDWT ring buffers and
   // writes uint8/uint16 directly to caller-provided plane buffers, bypassing
   // the strip scratch, out_rows int32 intermediate, and callback overhead.

--- a/source/core/interface/decoder.cpp
+++ b/source/core/interface/decoder.cpp
@@ -60,6 +60,8 @@ class openhtj2k_decoder_impl {
   j2c_src_memory in;
   uint8_t reduce_NL;
   uint32_t row_limit_ = UINT32_MAX;
+  uint32_t col_lo_    = 0;
+  uint32_t col_hi_    = UINT32_MAX;
   bool is_codestream_set;
   bool is_parsed;
   j2k_main_header main_header;
@@ -124,6 +126,10 @@ class openhtj2k_decoder_impl {
                                     std::vector<bool> &);
   void enable_single_tile_reuse(bool on);
   void set_row_limit(uint32_t limit) { row_limit_ = limit; }
+  void set_col_range(uint32_t col_lo, uint32_t col_hi) {
+    col_lo_ = col_lo;
+    col_hi_ = col_hi;
+  }
   void set_precinct_filter(std::function<bool(uint16_t, uint16_t, uint8_t, uint32_t)> f);
   void set_packet_observer(
       std::function<void(uint16_t, uint16_t, uint8_t, uint32_t, uint16_t, uint64_t, uint64_t)> f);
@@ -672,7 +678,7 @@ void openhtj2k_decoder_impl::invoke_line_based_stream(
       tileSet[tile_idx].decode_line_based_stream(main_header, reduce_NL,
           [&](uint32_t y_local, int32_t *const *rows, uint16_t nc) {
             cb(global_y + y_local, rows, nc);
-          }, row_limit_);
+          }, row_limit_, col_lo_, col_hi_);
       tileSet[tile_idx].destroy();
       global_y += band_h0;
     }
@@ -734,7 +740,8 @@ void openhtj2k_decoder_impl::invoke_line_based_stream(
         tileSet[tile_idx].destroy();
         throw std::runtime_error("Abort Decoding!");
       }
-      tileSet[tile_idx].decode_line_based_stream(main_header, reduce_NL, scatter, row_limit_);
+      tileSet[tile_idx].decode_line_based_stream(main_header, reduce_NL, scatter, row_limit_,
+                                                  col_lo_, col_hi_);
       tileSet[tile_idx].destroy();  // Release tile-internal buffers immediately
     }
 
@@ -784,6 +791,10 @@ void openhtj2k_decoder_impl::enable_single_tile_reuse(bool on) {
 
 void openhtj2k_decoder::set_row_limit(uint32_t limit) {
   this->impl->set_row_limit(limit);
+}
+
+void openhtj2k_decoder::set_col_range(uint32_t col_lo, uint32_t col_hi) {
+  this->impl->set_col_range(col_lo, col_hi);
 }
 
 void openhtj2k_decoder::set_precinct_filter(
@@ -1032,7 +1043,8 @@ void openhtj2k_decoder_impl::invoke_line_based_stream_reuse(
     throw std::runtime_error("Abort Decoding!");
   }
 
-  cached_tileSet_[0].decode_line_based_stream(main_header, reduce_NL, cb, row_limit_);
+  cached_tileSet_[0].decode_line_based_stream(main_header, reduce_NL, cb, row_limit_,
+                                               col_lo_, col_hi_);
 
   cached_header_fingerprint_ = fp;
 }

--- a/source/core/interface/decoder.hpp
+++ b/source/core/interface/decoder.hpp
@@ -117,6 +117,15 @@ class openhtj2k_decoder {
   // this many luma rows.  Default = UINT32_MAX (no limit).
   OPENHTJ2K_EXPORT void set_row_limit(uint32_t limit);
 
+  // Phase 4B spatial-region column range (horizontal viewport clipping).
+  // Restricts the vertical-IDWT lifting work to columns [col_lo, col_hi) in
+  // the finest-resolution output coordinates (after reduce_NL).  Coarser
+  // levels automatically receive a halved range widened by the filter
+  // support.  Default = [0, UINT32_MAX) → full-width lifting (same cost as
+  // before this API existed).  Columns outside the range produce
+  // indeterminate output; the caller must only read within [col_lo, col_hi).
+  OPENHTJ2K_EXPORT void set_col_range(uint32_t col_lo, uint32_t col_hi);
+
   // JPIP partial-decode hook.  When set, every subsequent invoke*() call
   // consults this filter per-packet: precincts for which the filter returns
   // false have their body bytes dropped (not attached to codeblocks) while

--- a/source/core/transform/dwt.hpp
+++ b/source/core/transform/dwt.hpp
@@ -403,6 +403,15 @@ struct idwt_2d_state {
   int32_t next_out;    // next output row (v0 ≤ next_out < v1)
   int32_t next_fetch;  // next real row to fetch from source (v0 ≤ next_fetch ≤ v1)
 
+  // ── column-range for vertical lifting (default = full [u0, u1]) ───────────
+  // When JPIP region decode restricts the horizontal span, vertical lifting
+  // is clipped to [col_lo, col_hi] — columns outside the range are left
+  // untouched in the ring buffer.  Only the caller's read range within
+  // [col_lo, col_hi] is guaranteed valid.  For default (full) decode the
+  // range equals [u0, u1] and kernels run unchanged.
+  int32_t col_lo;
+  int32_t col_hi;
+
   // ── source ────────────────────────────────────────────────────────────────
   idwt_row_src_fn get_src_row;
   void           *src_ctx;
@@ -420,6 +429,11 @@ void idwt_2d_state_init(idwt_2d_state *s,
 
 // Free buffers allocated by idwt_2d_state_init.
 void idwt_2d_state_free(idwt_2d_state *s);
+
+// Restrict vertical lifting to columns [col_lo, col_hi).  Passing the default
+// [u0, u1] restores full-width lifting.  Must be called after _init and before
+// any pull_row().  See idwt_2d_state::col_lo / col_hi comments.
+void idwt_2d_state_set_col_range(idwt_2d_state *s, int32_t col_lo, int32_t col_hi);
 
 // Rewind streaming cursors (next_out / next_fetch / ring_origin / d_level /
 // top_dlevel / bot_dlevel) to the post-init state without freeing any

--- a/source/core/transform/idwt.cpp
+++ b/source/core/transform/idwt.cpp
@@ -863,19 +863,25 @@ static inline void adv_step(idwt_2d_state *s, int32_t r, int8_t cur) {
   sprec_t *tgt  = rptr(s, r);
   sprec_t *prev = rptr(s, r - 1);
   sprec_t *next = rptr(s, r + 1);
-  const int32_t w = s->u1 - s->u0;
+  // Vertical lifting is per-column-independent — restricting to [col_lo, col_hi]
+  // is safe.  Columns outside this range retain whatever value the fetch_one
+  // path wrote (typically zero from absent-precinct fast path), so only the
+  // caller's read range [col_lo, col_hi] is guaranteed valid.  Default range
+  // equals [u0, u1] → same work as before.
+  const int32_t col0 = s->col_lo - s->u0;
+  const int32_t w    = s->col_hi - s->col_lo;
 
   if (s->transformation == 0) {  // irrev 9/7
     const float coeff = lp ? (cur == 0 ? fD : fB) : (cur == 0 ? fC : fA);
-    adv_irrev_ver_step_fn(w, prev, next, tgt, coeff);
+    adv_irrev_ver_step_fn(w, prev + col0, next + col0, tgt + col0, coeff);
   } else if (s->transformation >= 2) {  // ATK irrev (e.g. irrev53): no floor, 2-step filter
     const float coeff = lp ? 0.25f : -0.5f;
-    adv_irrev_ver_step_fn(w, prev, next, tgt, coeff);
+    adv_irrev_ver_step_fn(w, prev + col0, next + col0, tgt + col0, coeff);
   } else {  // rev 5/3
     if (lp) {
-      adv_rev_ver_lp_step_fn(w, prev, next, tgt);
+      adv_rev_ver_lp_step_fn(w, prev + col0, next + col0, tgt + col0);
     } else {
-      adv_rev_ver_hp_step_fn(w, prev, next, tgt);
+      adv_rev_ver_hp_step_fn(w, prev + col0, next + col0, tgt + col0);
     }
   }
   set_dl(s, r, cur + 1);
@@ -1044,10 +1050,20 @@ void idwt_2d_state_init(idwt_2d_state *s,
   for (int32_t i = 0; i < 4;                     ++i) { s->top_dlevel[i] = -1; s->top_pse_zero[i] = true; }
   for (int32_t i = 0; i < 4;                     ++i) { s->bot_dlevel[i] = -1; s->bot_pse_zero[i] = true; }
 
+  s->col_lo      = u0;
+  s->col_hi      = u1;
   s->next_out    = v0;
   s->next_fetch  = v0;
   s->get_src_row = src_fn;
   s->src_ctx     = src_ctx;
+}
+
+void idwt_2d_state_set_col_range(idwt_2d_state *s, int32_t col_lo, int32_t col_hi) {
+  if (col_lo < s->u0) col_lo = s->u0;
+  if (col_hi > s->u1) col_hi = s->u1;
+  if (col_lo > col_hi) col_lo = col_hi;  // degenerate → empty range
+  s->col_lo = col_lo;
+  s->col_hi = col_hi;
 }
 
 void idwt_2d_state_free(idwt_2d_state *s) {

--- a/subprojects/jpip_viewer.html
+++ b/subprojects/jpip_viewer.html
@@ -155,14 +155,25 @@ async function fetchView() {
 
   // Always fetch the viewport region — server sends only visible precincts.
   // jpip_end_frame_region extracts the viewport from the decoded canvas.
+  // fsiz tells the server which resolution frame we want: canvas / 2^reduce.
+  // Use ceil-divide so fsiz matches the server's fsiz_at(r) formula (which
+  // uses ceil_div_u); floor-divide trips Round::Down into picking the next
+  // coarser level when the height isn't a multiple of 2^reduce — that loses
+  // a full resolution level of detail and produces a blurry / broken frame.
   const regionX = Math.max(0, Math.round(panX));
   const regionY = Math.max(0, Math.round(panY));
   const regionW = Math.min(Math.round(viewW), canvasW - regionX);
   const regionH = Math.min(Math.round(viewH), canvasH - regionY);
-  const fW = canvasW, fH = canvasH;
+  const ceilShift = (v, s) => ((v + (1 << s) - 1) >> s);
+  const fW = Math.max(1, ceilShift(canvasW, red));
+  const fH = Math.max(1, ceilShift(canvasH, red));
+  const rx = regionX >> red;
+  const ry = regionY >> red;
+  const rw = Math.max(1, ceilShift(regionW, red));
+  const rh = Math.max(1, ceilShift(regionH, red));
   let q = `fsiz=${fW},${fH}`;
-  if (regionX > 0 || regionY > 0) q += `&roff=${regionX},${regionY}`;
-  q += `&rsiz=${regionW},${regionH}&type=jpp-stream`;
+  if (rx > 0 || ry > 0) q += `&roff=${rx},${ry}`;
+  q += `&rsiz=${rw},${rh}&type=jpp-stream`;
   const outW = vpW, outH = vpH;
 
   try {
@@ -195,6 +206,7 @@ async function fetchView() {
       }
       decReduce = red;
       lastFetchKey = key;
+      drawViewport();
     }
     $('stats').textContent =
       `${canvasW}×${canvasH} | zoom ${(zoom*100).toFixed(0)}% reduce=${red} region(${regionW}×${regionH}) | ` +

--- a/subprojects/src/jpip_wrapper.cpp
+++ b/subprojects/src/jpip_wrapper.cpp
@@ -203,6 +203,7 @@ int jpip_end_frame_region(void *handle, uint8_t *rgb_out, int out_w, int out_h,
   std::memset(rgb_out, 0, static_cast<size_t>(ow) * oh * 4);
 
   dec.set_row_limit(ry1);
+  dec.set_col_range(rx0, rx1);
   try {
     dec.invoke_line_based_stream(
         [&](uint32_t y, int32_t *const *rows, uint16_t nc) {


### PR DESCRIPTION
## Summary

Three independent wins for the JPIP gigapixel viewer and one viewer-side correctness fix.

- **Viewer `fsiz` / `roff` / `rsiz` scaling by `reduce_NL`** — the previous client sent `fsiz = canvasW, canvasH` regardless of zoom level, forcing the server to return every precinct at full resolution (264 MB for the 416 MP heic2501a test image). Ceil-divide is required so the request matches the server's `fsiz_at(r)` exactly; floor-divide trips `Round::Down` into picking one discard level coarser than intended, producing an LL-only / broken frame.
- **Skip row interleave + 1D horizontal IDWT when both LP and HP subband rows are all-zero** (`idwt_level_src_fn`). Early-exit 16-word scan bails after the first cache line on dense data, so normal decode is unaffected.
- **Column-limited vertical IDWT.** New `idwt_2d_state::col_lo / col_hi` (default `= u0 / u1` → unchanged behaviour), new `openhtj2k_decoder::set_col_range()`, propagated per level with a conservative ±4 sample widening for the 9/7 filter support. `jpip_end_frame_region` wires it to the viewport.
- **Viewer: call `drawViewport()` after the successful texImage2D upload.** Previously the GL quad was never drawn — the texture held the new frame but the canvas never refreshed until the next explicit interaction.

## Test plan

- [x] Build native + WASM
- [x] All 613 conformance tests pass (`ctest -j 8` under `build/`)
- [x] Dense 416 MP decode benchmark (5 runs, median): baseline **1622 ms**, patched **1573 ms** — within noise, no regression
- [x] WASM viewer at `reduce = 4` bandwidth drops from ~264 MB to ~4 MB
- [x] WASM viewer renders correctly at every zoom level after the ceil-divide fix
- [ ] Reviewer sanity check that the col-range widening (`±4` per coarser level) is conservative enough for real-world `Xsiz % 2^NL != 0` edge cases

## Notes

- `VIEWER_PLAN.md` is the design doc for this work; kept under the repo root as a planning artifact. Safe to delete later if not wanted in the tree.
- Horizontal-limited 1D IDWT (would further reduce reduce-0 viewport decode from ~1000 ms to ~300 ms) is explicitly out of scope — tracked as a separate follow-up because it touches the AVX2/NEON/WASM 1D kernels' boundary handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)