### PR TITLE
feat(jpip): column-limited horizontal 1D IDWT (Phase 4B-H, option C)

### DIFF
--- a/source/core/coding/coding_units.cpp
+++ b/source/core/coding/coding_units.cpp
@@ -118,6 +118,15 @@ struct idwt_level_src_ctx {
   // PSE counts for in-place horizontal filter (precomputed at init).
   int32_t h_pse_left;   // left PSE samples for this level (function of u0%2, transformation)
   int32_t h_pse_right;  // right PSE samples for this level (function of u1%2, transformation)
+
+  // Horizontal IDWT output range (Phase 4B spatial-region decode).  Default
+  // = [u0, u1] → full-width horizontal lifting, byte-identical to pre-patch
+  // behaviour.  set_line_decode_col_range() can narrow this to the viewport
+  // range widened by per-level filter support, which routes the callback
+  // into a sub-range horizontal lifter that skips columns whose subband
+  // values are zero.
+  int32_t col_lo;
+  int32_t col_hi;
 };
 
 // Whole-sample symmetric extension: reflect idx into [0, len).
@@ -209,7 +218,8 @@ static void idwt_level_src_fn(void *ctx, int32_t abs_row, sprec_t *out) {
       if ((c->u0 % 2 != 0) && (c->transformation == 1)) out[0] /= 2.0f;
       return;
     }
-    idwt_1d_row_inplace(out, c->h_pse_left, c->h_pse_right, c->u0, c->u1, c->transformation);
+    idwt_1d_row_inplace_range(out, c->h_pse_left, c->h_pse_right, c->u0, c->u1, c->transformation,
+                              c->col_lo, c->col_hi);
     return;
   }
 
@@ -366,7 +376,8 @@ static void idwt_level_src_fn(void *ctx, int32_t abs_row, sprec_t *out) {
     if ((c->u0 % 2 != 0) && (c->transformation == 1)) out[0] /= 2.0f;
     return;
   }
-  idwt_1d_row_inplace(out, c->h_pse_left, c->h_pse_right, c->u0, c->u1, c->transformation);
+  idwt_1d_row_inplace_range(out, c->h_pse_left, c->h_pse_right, c->u0, c->u1, c->transformation,
+                            c->col_lo, c->col_hi);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -2324,6 +2335,8 @@ void j2k_tile_component::init_line_decode(bool ring_mode) {
     c.hh_y0          = (sb_HH != nullptr) ? static_cast<int32_t>(sb_HH->get_pos0().y) : 0;
     c.h_pse_left     = (u1 - u0 > 1) ? kHPseLeft[u0 % 2][eff]  : 0;
     c.h_pse_right    = (u1 - u0 > 1) ? kHPseRight[u1 % 2][eff] : 0;
+    c.col_lo         = u0;
+    c.col_hi         = u1;
 
     // lp_tmp only needed when has_child (child state writes output into it as fallback).
     // hp_tmp eliminated: HP data is read directly from subband row buffers.
@@ -2358,8 +2371,9 @@ void j2k_tile_component::set_line_decode_col_range(uint32_t col_lo, uint32_t col
   if (line_dec == nullptr) return;
   j2k_tcomp_line_dec *ld = line_dec.get();
   if (ld->NL_active <= 0) return;
-  idwt_2d_state *states = ld->states.get();
-  const int32_t NL_act  = ld->NL_active;
+  idwt_2d_state       *states = ld->states.get();
+  idwt_level_src_ctx  *ctxs   = ld->ctxs.get();
+  const int32_t NL_act        = ld->NL_active;
   // Seed with caller's finest-level range.  Coarser levels are derived by
   // halving and widening by the 9/7 filter support (4 samples each side,
   // conservative over-estimate that also covers 5/3 where support is 2).
@@ -2367,6 +2381,15 @@ void j2k_tile_component::set_line_decode_col_range(uint32_t col_lo, uint32_t col
   int32_t b = static_cast<int32_t>(col_hi);
   for (int32_t i = NL_act - 1; i >= 0; --i) {
     idwt_2d_state_set_col_range(&states[i], a, b);
+    // Mirror the same range onto the level's source ctx so the horizontal
+    // IDWT producer narrows its processing window to match.  Clamp to the
+    // level's [u0, u1].
+    int32_t ca = a, cb = b;
+    if (ca < ctxs[i].u0) ca = ctxs[i].u0;
+    if (cb > ctxs[i].u1) cb = ctxs[i].u1;
+    if (ca > cb) ca = cb;
+    ctxs[i].col_lo = ca;
+    ctxs[i].col_hi = cb;
     // Next coarser level's output feeds this level's horizontal IDWT, which
     // reads up to 4 samples beyond each output column.  In subband coords
     // (half-width) that maps to ±2 samples; we round up to 4 for safety.

--- a/source/core/transform/dwt.hpp
+++ b/source/core/transform/dwt.hpp
@@ -435,6 +435,20 @@ void idwt_2d_state_free(idwt_2d_state *s);
 // any pull_row().  See idwt_2d_state::col_lo / col_hi comments.
 void idwt_2d_state_set_col_range(idwt_2d_state *s, int32_t col_lo, int32_t col_hi);
 
+// Sub-range horizontal 1D IDWT.  col_lo / col_hi are target-valid-output
+// columns in ROW coords [0, u1-u0].  When the caller passes the full range
+// (col_lo <= 0 && col_hi >= u1 - u0) this function is a thin wrapper around
+// idwt_1d_row_inplace() and produces byte-identical output — that is the
+// default JPIP-unaware path.  When a narrower range is requested, a scalar
+// sub-range lifter runs over [col_lo - pse, col_hi + pse] (clamped to
+// [0, u1 - u0]) and skips the columns outside that window.  The caller
+// guarantees the samples outside the processing range are zero on entry and
+// must remain zero on exit; for JPIP this is true because interleave zeros
+// all samples outside the precinct-populated region.
+void idwt_1d_row_inplace_range(sprec_t *row, int32_t left, int32_t right,
+                               int32_t u0, int32_t u1, uint8_t transformation,
+                               int32_t col_lo, int32_t col_hi);
+
 // Rewind streaming cursors (next_out / next_fetch / ring_origin / d_level /
 // top_dlevel / bot_dlevel) to the post-init state without freeing any
 // buffers.  Used by the single-tile reuse path; a subsequent pull_row

--- a/source/core/transform/idwt.cpp
+++ b/source/core/transform/idwt.cpp
@@ -808,6 +808,131 @@ void idwt_1d_row_inplace(sprec_t *row, const int32_t left, const int32_t right,
     idwt_1d_filtr_irrev53_fn(row - left, left, u0, u1);
 }
 
+// Sub-range 9/7 IDWT: runs only the 4-pass lifting on buffer positions
+// [buf_lo, buf_hi] (inclusive) of X.  The kernel's parity / offset logic is
+// inherited from u_i0 unchanged so the LP/HP identity of each column matches
+// the full-width kernel.  Caller guarantees samples at positions outside
+// [buf_lo, buf_hi] are zero on entry and remain zero on exit (so Pass 1
+// boundary reads of X[n - 1] / X[n + 1] give zero when n is at the lower
+// or upper edge, which matches the full-width result under a zero-padded
+// input — the JPIP-sparse invariant).  buf_lo / buf_hi are in the same
+// buffer-offset frame as the existing kernel's internal `n`.
+static void idwt_1d_filtr_irrev97_fixed_range(sprec_t *X, const int32_t left,
+                                              const int32_t u_i0, const int32_t u_i1,
+                                              const int32_t buf_lo, const int32_t buf_hi) {
+  const int32_t start  = u_i0 / 2;
+  const int32_t stop   = u_i1 / 2;
+  const int32_t offset = left - u_i0 % 2;
+
+  auto clip = [&](int32_t n_init, int32_t n_last_incl,
+                  int32_t &ns, int32_t &ne) {
+    // Return the first / last n in [buf_lo, buf_hi] that is reachable from
+    // n_init by step +2 and lies within [n_init, n_last_incl].
+    ns = (buf_lo > n_init) ? buf_lo : n_init;
+    if (((ns - n_init) & 1) != 0) ns += 1;
+    ne = (buf_hi < n_last_incl) ? buf_hi : n_last_incl;
+    if (((ne - n_init) & 1) != 0) ne -= 1;
+  };
+
+  int32_t ns, ne;
+  // Pass 1 (fD): writes X[n].  Original loop n = -2+offset .. -2+offset+2*(stop-start+1+1) step 2.
+  clip(-2 + offset, -2 + offset + 2 * (stop - start + 2), ns, ne);
+  for (int32_t n = ns; n <= ne; n += 2) {
+    X[n] = X[n] - fD * (X[n - 1] + X[n + 1]);
+  }
+  // Pass 2 (fC): writes X[n + 1].  Original n = -2+offset .. -2+offset+2*(stop-start+1) step 2.
+  clip(-2 + offset, -2 + offset + 2 * (stop - start + 1), ns, ne);
+  for (int32_t n = ns; n <= ne; n += 2) {
+    X[n + 1] = X[n + 1] - fC * (X[n] + X[n + 2]);
+  }
+  // Pass 3 (fB): writes X[n].  Original n = offset .. offset+2*(stop-start) step 2.
+  clip(offset, offset + 2 * (stop - start), ns, ne);
+  for (int32_t n = ns; n <= ne; n += 2) {
+    X[n] = X[n] - fB * (X[n - 1] + X[n + 1]);
+  }
+  // Pass 4 (fA): writes X[n + 1].  Original n = offset .. offset+2*(stop-start-1) step 2.
+  clip(offset, offset + 2 * (stop - start - 1), ns, ne);
+  for (int32_t n = ns; n <= ne; n += 2) {
+    X[n + 1] = X[n + 1] - fA * (X[n] + X[n + 2]);
+  }
+}
+
+// Sub-range 5/3 IDWT.  Same contract as idwt_1d_filtr_irrev97_fixed_range.
+static void idwt_1d_filtr_rev53_fixed_range(sprec_t *X, const int32_t left,
+                                            const int32_t u_i0, const int32_t u_i1,
+                                            const int32_t buf_lo, const int32_t buf_hi) {
+  const int32_t start  = u_i0 / 2;
+  const int32_t stop   = u_i1 / 2;
+  const int32_t offset = left - u_i0 % 2;
+
+  auto clip = [&](int32_t n_init, int32_t n_last_incl,
+                  int32_t &ns, int32_t &ne) {
+    ns = (buf_lo > n_init) ? buf_lo : n_init;
+    if (((ns - n_init) & 1) != 0) ns += 1;
+    ne = (buf_hi < n_last_incl) ? buf_hi : n_last_incl;
+    if (((ne - n_init) & 1) != 0) ne -= 1;
+  };
+
+  int32_t ns, ne;
+  // Pass 1: writes X[n].  Original n = offset .. offset + 2*(stop-start) step 2.
+  clip(offset, offset + 2 * (stop - start), ns, ne);
+  for (int32_t n = ns; n <= ne; n += 2) {
+    X[n] -= floorf((X[n - 1] + X[n + 1] + 2) * 0.25f);
+  }
+  // Pass 2: writes X[n + 1].  Original n = offset .. offset + 2*(stop-start-1) step 2.
+  clip(offset, offset + 2 * (stop - start - 1), ns, ne);
+  for (int32_t n = ns; n <= ne; n += 2) {
+    X[n + 1] += floorf((X[n] + X[n + 2]) * 0.5f);
+  }
+}
+
+void idwt_1d_row_inplace_range(sprec_t *row, const int32_t left, const int32_t right,
+                               const int32_t u0, const int32_t u1, const uint8_t transformation,
+                               const int32_t col_lo, const int32_t col_hi) {
+  const int32_t width = u1 - u0;
+  // Default / caller asked for full row → go through the existing fast path.
+  // Produces byte-identical output; zero regression risk for non-JPIP decode.
+  if (col_lo <= u0 && col_hi >= u1) {
+    idwt_1d_row_inplace(row, left, right, u0, u1, transformation);
+    return;
+  }
+  // PSE fill is still required at the row edges because the 1D lifter may
+  // read those positions during boundary work even when the target output
+  // window is entirely interior.  Keep the existing inplace PSE setup.
+  if (width >= 9) {
+    dwt_pse_fill_inplace_simd(row, width);
+  } else {
+    for (int32_t i = 1; i <= left; ++i)
+      row[-i] = row[PSEo(u0 - i, u0, u1)];
+    for (int32_t i = 1; i <= right; ++i)
+      row[width + i - 1] = row[PSEo(u1 - u0 + i - 1 + u0, u0, u1)];
+  }
+  // Translate target row cols [col_lo, col_hi] → buffer positions.
+  // X = row - left, so row col k lives at X[k - u0 + left].
+  // Widen by the filter support so the 4-pass (or 2-pass) lifter has valid
+  // neighbors at the target edges.
+  const int32_t widen = (transformation == 1) ? 2 : 4;
+  int32_t row_lo = col_lo - u0 - widen;
+  int32_t row_hi = col_hi - u0 - 1 + widen;  // inclusive row-col upper bound
+  if (row_lo < 0) row_lo = 0;
+  if (row_hi > width - 1) row_hi = width - 1;
+  const int32_t buf_lo = row_lo + left;
+  const int32_t buf_hi = row_hi + left;
+
+  sprec_t *X = row - left;
+  if (transformation == 1) {
+    idwt_1d_filtr_rev53_fixed_range(X, left, u0, u1, buf_lo, buf_hi);
+  } else if (transformation == 0) {
+    idwt_1d_filtr_irrev97_fixed_range(X, left, u0, u1, buf_lo, buf_hi);
+  } else {
+    // ATK irrev53 — rare; fall back to full-width path (no sub-range variant yet).
+    if (transformation < 2)
+      idwt_1d_filtr_fixed[transformation](X, left, u0, u1);
+    else
+      idwt_1d_filtr_irrev53_fn(X, left, u0, u1);
+  }
+}
+
 // =============================================================================
 // Streaming 2D IDWT — idwt_2d_state
 // =============================================================================


### PR DESCRIPTION
## Summary

Finishes the spatial-region decode path opened by #280. At `reduce=0` the viewer bottleneck was horizontal 1D IDWT running full canvas width (~42 K cols) on every fetched row, independent of the viewport. This PR restricts that work to the viewport column window + filter support, with a zero-cost path for normal decode.

**Stacked on #280** — target that branch so the diff shows only option-C changes.

## What

- Added `idwt_1d_row_inplace_range(row, left, right, u0, u1, transformation, col_lo, col_hi)`. When the caller asks for the full row (default behaviour), it dispatches to the existing `idwt_1d_row_inplace` — **same SIMD kernel, same binary output, zero intentional regression**. Only when a restricted range is requested does a scalar sub-range lifter take over.
- Scalar per-pass clipped-loop kernels: `idwt_1d_filtr_irrev97_fixed_range` (9/7, 4 passes) and `idwt_1d_filtr_rev53_fixed_range` (5/3, 2 passes). Each pass computes its in-range `n` span from the original kernel's parity-aware step-2 iteration. ATK irrev53 falls back to full-width (no sub-range variant).
- `idwt_level_src_ctx` gains `col_lo` / `col_hi` defaulting to `[u0, u1]`. `j2k_tile_component::set_line_decode_col_range` now mirrors the per-level range onto the level's src ctx so both horizontal (in ctx) and vertical (in state) lifting clip to the same window.
- `idwt_level_src_fn` invokes the new `_range` helper for both `DWT_HORZ` and `DWT_BIDIR` levels.

## Test plan

- [x] 613/613 conformance tests pass (`ctest -j 8` under `build/`)
- [x] Dense 416 MP benchmark (5 runs, median): baseline **1622 ms**, patched **1587 ms** (within noise, no regression)
- [x] Standalone correctness check: decode heic2501a twice, once with default col_range and once with a viewport-sized range; confirm byte-identical output within the window on 42208×9870×3 gigapixel source and multiple conformance files
- [x] WASM viewer at reduce=0 on a 2419×1389 viewport: decode **963 ms → 714 ms** (~1.35× speedup; per-row cost 0.216 → 0.124 ms)

## Notes

The sub-range lifter is scalar; at narrow viewport ratios the 8× SIMD advantage of the existing full-width kernel mostly offsets the proportional work reduction. A SIMD sub-range variant would push the win further but is a separate follow-up — this PR is already within the no-regression guardrails and the viewer is materially faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)