### PR TITLE
feat(demos): modernize JPIP viewer and foveated demo UI

### DIFF
--- a/subprojects/index.html
+++ b/subprojects/index.html
@@ -381,8 +381,8 @@
   <nav class="nav-tabs">
     <a href="index.html"    class="active">Still Image</a>
     <a href="rtp_demo.html">RTP Replay</a>
-    <a href="jpip_demo.html?server=https://jpip-demo.osamu620.dev">JPIP Foveation</a>
-    <a href="jpip_viewer.html?server=https://jpip-demo.osamu620.dev">JPIP Viewer</a>
+    <a href="jpip_demo.html?server=https://jpip-fovea.osamu620.dev">JPIP Foveation</a>
+    <a href="jpip_viewer.html?server=https://jpip-viewer.osamu620.dev">JPIP Viewer</a>
   </nav>
   <!-- Original simd_message element (hidden; JS reads/writes innerText; badge synced below) -->
   <pre id="simd_message" style="display:none"></pre>

--- a/subprojects/jpip_demo.html
+++ b/subprojects/jpip_demo.html
@@ -2,41 +2,266 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<title>OpenHTJ2K JPIP Foveation Demo</title>
+<title>OpenHTJ2K — JPIP Foveation Demo</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 <style>
-  body { margin: 0; background: #111; color: #eee; font-family: monospace; }
-  #controls { padding: 8px; }
-  #controls label { margin-right: 12px; }
-  #controls input { width: 360px; }
-  canvas { display: block; margin: 8px auto; cursor: crosshair; }
-  #stats { padding: 4px 8px; font-size: 13px; }
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  :root {
+    --bg:       #0f1117;
+    --surface:  #1a1d27;
+    --surface2: #20233a;
+    --border:   #2d3040;
+    --accent:   #4f8ef7;
+    --text:     #e8eaf0;
+    --text-sub: #9aa0b8;
+    --radius:   10px;
+  }
+  html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif;
+    min-height: 100vh;
+    padding: 32px 28px;
+    max-width: 1300px;
+    margin: 0 auto;
+  }
+
+  .site-header {
+    display: flex; align-items: center; gap: 14px; flex-wrap: wrap;
+    margin-bottom: 28px; padding-bottom: 20px;
+    border-bottom: 1px solid var(--border);
+  }
+  .site-header h1 { font-size: 20px; font-weight: 700; flex: 1; }
+  .nav-tabs {
+    display: flex; gap: 4px;
+    margin-bottom: 24px;
+    border-bottom: 1px solid var(--border);
+  }
+  .nav-tabs a {
+    padding: 10px 18px;
+    color: var(--text-sub); text-decoration: none;
+    font-size: 13px; font-weight: 600;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
+    transition: color 0.15s, border-color 0.15s;
+  }
+  .nav-tabs a:hover { color: var(--text); }
+  .nav-tabs a.active { color: var(--accent); border-bottom-color: var(--accent); }
+
+  .card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 18px;
+    margin-bottom: 18px;
+  }
+  .card-label {
+    font-size: 11px; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.6px;
+    color: var(--text-sub);
+    margin-bottom: 10px;
+  }
+
+  /* ── Controls row ────────────────────────────────────── */
+  .controls { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; }
+  .controls .ctrl { display: flex; flex-direction: column; gap: 4px; }
+  .controls .ctrl-label {
+    font-size: 11px; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.4px;
+    color: var(--text-sub);
+  }
+  .controls input[type=text], .controls input:not([type]) {
+    background: var(--bg); color: var(--text);
+    border: 1px solid var(--border); border-radius: 6px;
+    padding: 8px 10px; font-size: 13px; width: 320px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  .controls input:focus, .controls select:focus {
+    outline: 2px solid var(--accent); outline-offset: 1px;
+  }
+  .controls select {
+    background: var(--bg); color: var(--text);
+    border: 1px solid var(--border); border-radius: 6px;
+    padding: 8px 30px 8px 10px; font-size: 13px;
+    cursor: pointer; appearance: none; -webkit-appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='%239aa0b8' stroke-width='1.5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
+    background-repeat: no-repeat; background-position: right 10px center;
+  }
+  .btn {
+    background: var(--accent); color: #fff;
+    border: none; border-radius: 6px;
+    padding: 9px 18px; font-size: 13px; font-weight: 600;
+    cursor: pointer; font-family: inherit;
+    transition: filter 0.15s, transform 0.05s;
+  }
+  .btn:hover { filter: brightness(1.12); }
+  .btn:active { transform: translateY(1px); }
+
+  #info {
+    font-size: 12px; color: var(--text-sub);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    margin-left: 8px;
+  }
+
+  /* ── Canvas area ─────────────────────────────────────── */
+  .canvas-wrap {
+    background: #000;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 12px;
+    display: flex; justify-content: center;
+    position: relative;
+  }
+  canvas { display: block; cursor: crosshair; max-width: 100%; height: auto; }
+
+  /* ── Stats + Help ────────────────────────────────────── */
+  #stats {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 13px; color: var(--text);
+  }
+  #stats:empty::before {
+    content: 'Move the mouse over the image to start streaming.';
+    color: var(--text-sub); font-style: italic;
+  }
+  .help-grid {
+    display: grid; grid-template-columns: 1fr 1fr; gap: 24px;
+    font-size: 13px; line-height: 1.6; color: var(--text-sub);
+  }
+  .help-grid h3 {
+    font-size: 12px; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 0.6px;
+    color: var(--text); margin-bottom: 8px;
+  }
+  .help-grid b { color: var(--text); }
+  .help-grid a { color: var(--accent); text-decoration: none; }
+  .help-grid a:hover { text-decoration: underline; }
+  .help-grid ol { padding-left: 20px; }
+  .help-grid ol li { margin-bottom: 4px; }
+  @media (max-width: 720px) { .help-grid { grid-template-columns: 1fr; } }
+
+  /* ── Footer ──────────────────────────────────────────── */
+  .site-footer {
+    margin-top: 40px;
+    padding: 20px 0; border-top: 1px solid var(--border);
+    text-align: center; font-size: 13px; color: var(--text-sub);
+  }
+  .site-footer a {
+    color: var(--accent); text-decoration: none;
+    display: inline-flex; align-items: center; gap: 6px;
+  }
+  .site-footer a:hover { text-decoration: underline; }
 </style>
 </head>
 <body>
 
-<div id="controls">
-  <label>JPIP Server: <input id="server" value="http://localhost:8080" /></label>
-  <button id="connectBtn">Connect</button>
-  <span id="info"></span>
-  <br>
-  <label>Reduce: <select id="reduce">
-    <option value="0">0 (full res)</option>
-    <option value="1" selected>1 (half res)</option>
-    <option value="2">2 (quarter res)</option>
-  </select></label>
-  <label>Para ratio: <select id="para_ratio">
-    <option value="0.5" selected>0.5</option>
-    <option value="0.25">0.25</option>
-    <option value="0.125">0.125</option>
-  </select></label>
-  <label>Peri ratio: <select id="peri_ratio">
-    <option value="0.25">0.25</option>
-    <option value="0.125" selected>0.125</option>
-    <option value="0.0625">0.0625</option>
-  </select></label>
+<header class="site-header">
+  <svg width="38" height="38" viewBox="0 0 38 38" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" style="flex-shrink:0">
+    <rect width="38" height="38" rx="8" fill="#4f8ef7"/>
+    <rect x="6"  y="6"  width="11" height="11" rx="2" fill="white" opacity="1.0"/>
+    <rect x="21" y="6"  width="11" height="11" rx="2" fill="white" opacity="0.65"/>
+    <rect x="6"  y="21" width="11" height="11" rx="2" fill="white" opacity="0.4"/>
+    <rect x="21" y="21" width="11" height="11" rx="2" fill="white" opacity="0.2"/>
+  </svg>
+  <h1>HTJ2K / J2K-1 — JPIP Foveation Demo</h1>
+</header>
+
+<nav class="nav-tabs">
+  <a href="index.html">Still Image</a>
+  <a href="rtp_demo.html">RTP Replay</a>
+  <a href="jpip_demo.html" class="active">JPIP Foveation</a>
+  <a href="jpip_viewer.html">JPIP Viewer</a>
+</nav>
+
+<div class="card">
+  <div class="card-label">Connection &amp; foveation parameters</div>
+  <div class="controls">
+    <div class="ctrl">
+      <span class="ctrl-label">JPIP server</span>
+      <input id="server" type="text" value="https://jpip-fovea.osamu620.dev" />
+    </div>
+    <div class="ctrl">
+      <span class="ctrl-label">&nbsp;</span>
+      <button id="connectBtn" class="btn">Connect</button>
+    </div>
+    <div class="ctrl">
+      <span class="ctrl-label">Reduce (discard DWT levels)</span>
+      <select id="reduce">
+        <option value="0">0 — full resolution</option>
+        <option value="1" selected>1 — half resolution</option>
+        <option value="2">2 — quarter resolution</option>
+      </select>
+    </div>
+    <div class="ctrl">
+      <span class="ctrl-label">Parafovea ratio</span>
+      <select id="para_ratio">
+        <option value="0.5" selected>0.5</option>
+        <option value="0.25">0.25</option>
+        <option value="0.125">0.125</option>
+      </select>
+    </div>
+    <div class="ctrl">
+      <span class="ctrl-label">Periphery ratio</span>
+      <select id="peri_ratio">
+        <option value="0.25">0.25</option>
+        <option value="0.125" selected>0.125</option>
+        <option value="0.0625">0.0625</option>
+      </select>
+    </div>
+    <span id="info"></span>
+  </div>
 </div>
-<canvas id="canvas"></canvas>
-<div id="stats"></div>
+
+<div class="canvas-wrap">
+  <canvas id="canvas"></canvas>
+</div>
+
+<div class="card"><div id="stats"></div></div>
+
+<div class="card">
+  <div class="help-grid">
+    <div>
+      <h3>What is this?</h3>
+      A JPIP (ISO/IEC 15444-9) foveated-decode demo.  Three concentric view-window requests
+      are sent per mouse move: a small sharp <b>fovea</b> around the cursor, a medium-resolution
+      <b>parafovea</b>, and a coarse full-image <b>periphery</b>.  The server streams only the
+      precincts each region needs; the client reassembles them and decodes the composite
+      JPEG 2000 / HTJ2K codestream in WebAssembly.  Bandwidth per frame is a small fraction
+      of a full-image decode.
+    </div>
+    <div>
+      <h3>How to operate</h3>
+      <ol>
+        <li>Click <b>Connect</b> (the server URL is already filled in).</li>
+        <li>Move the mouse over the image — the sharp fovea follows the cursor.</li>
+        <li>Adjust <b>Reduce</b>, <b>Parafovea ratio</b>, <b>Periphery ratio</b> to trade
+            detail for bandwidth.</li>
+        <li>The stats line below the image reports fetched bytes, decode time and FPS.</li>
+      </ol>
+      <p style="margin-top:10px">Related: <a href="jpip_viewer.html">pan-and-zoom viewer</a> for
+      gigapixel images.</p>
+    </div>
+  </div>
+</div>
+
+<footer class="site-footer">
+  <a href="https://github.com/osamu620/OpenHTJ2K" target="_blank" rel="noopener">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577
+        0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7
+        3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236
+        1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93
+        0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322
+        3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552
+        3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91
+        1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22
+        0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092
+        24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
+    </svg>
+    osamu620/OpenHTJ2K
+  </a>
+</footer>
+
 <script>
   (function() {
     var p = new URLSearchParams(location.search);
@@ -161,7 +386,7 @@ async function init() {
   $('info').textContent = 'Loading WASM…';
   try {
     M = await createModule();
-    $('info').textContent = `WASM ready (${useMt ? 'MT+SIMD' : 'SIMD'}). Enter server URL and click Connect.`;
+    $('info').textContent = `WASM ready (${useMt ? 'MT+SIMD' : 'SIMD'}).`;
   } catch (e) {
     $('info').textContent = 'WASM load failed: ' + e.message;
     console.error('WASM load error:', e);

--- a/subprojects/jpip_viewer.html
+++ b/subprojects/jpip_viewer.html
@@ -2,26 +2,204 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<title>OpenHTJ2K JPIP Viewer — Large Image Browser</title>
+<title>OpenHTJ2K — JPIP Gigapixel Viewer</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 <style>
-  body { margin: 0; background: #111; color: #eee; font-family: monospace; overflow: hidden; }
-  #controls { padding: 8px; }
-  #controls label { margin-right: 12px; }
-  #controls input { width: 360px; }
-  canvas { display: block; cursor: grab; }
-  canvas.dragging { cursor: grabbing; }
-  #stats { padding: 4px 8px; font-size: 13px; position: fixed; bottom: 0; left: 0; right: 0;
-           background: rgba(0,0,0,0.7); }
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  :root {
+    --bg:        #0f1117;
+    --surface:   #1a1d27;
+    --surface2:  #20233a;
+    --border:    #2d3040;
+    --accent:    #4f8ef7;
+    --text:      #e8eaf0;
+    --text-sub:  #9aa0b8;
+  }
+  html, body {
+    height: 100%;
+    background: var(--bg);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif;
+    overflow: hidden;
+  }
+
+  /* ── Top bar ─────────────────────────────────────────── */
+  #topbar {
+    position: fixed; top: 0; left: 0; right: 0; height: 56px;
+    display: flex; align-items: center; gap: 14px;
+    padding: 0 16px;
+    background: rgba(15, 17, 23, 0.85);
+    backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--border);
+    z-index: 20;
+  }
+  #topbar .brand { display: flex; align-items: center; gap: 10px; }
+  #topbar .brand h1 { font-size: 13px; font-weight: 700; white-space: nowrap; }
+  #topbar .brand .sub {
+    font-size: 11px; color: var(--text-sub); font-weight: 500;
+    padding: 2px 8px; border: 1px solid var(--border); border-radius: 20px;
+  }
+  #topbar a.home {
+    color: var(--text-sub); text-decoration: none; font-size: 12px; font-weight: 600;
+    padding: 6px 10px; border-radius: 6px; transition: background 0.15s, color 0.15s;
+  }
+  #topbar a.home:hover { background: var(--surface); color: var(--text); }
+
+  #topbar label.field {
+    display: flex; align-items: center; gap: 6px;
+    font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-sub);
+    font-weight: 600;
+  }
+  #topbar input#server {
+    width: 320px; min-width: 180px;
+    background: var(--bg); color: var(--text);
+    border: 1px solid var(--border); border-radius: 6px;
+    padding: 7px 10px; font-size: 12px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  #topbar input#server:focus { outline: 2px solid var(--accent); outline-offset: 1px; }
+  #topbar .btn {
+    background: var(--accent); color: #fff;
+    border: none; border-radius: 6px; padding: 7px 16px;
+    font-size: 12px; font-weight: 600; cursor: pointer;
+    font-family: inherit; transition: filter 0.15s, transform 0.05s;
+  }
+  #topbar .btn:hover { filter: brightness(1.12); }
+  #topbar .btn:active { transform: translateY(1px); }
+  #topbar .btn.ghost {
+    background: transparent; color: var(--text-sub);
+    border: 1px solid var(--border);
+  }
+  #topbar .btn.ghost:hover { color: var(--text); border-color: var(--text-sub); }
+
+  #info {
+    flex: 1; min-width: 0;
+    font-size: 12px; color: var(--text-sub);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+
+  /* ── Canvas ──────────────────────────────────────────── */
+  #canvas {
+    position: fixed; top: 56px; left: 0;
+    /* width/height set in JS from vpW/vpH */
+    display: block; cursor: grab;
+    background: #000;
+  }
+  #canvas.dragging { cursor: grabbing; }
+
+  /* ── Stats bar (bottom) ──────────────────────────────── */
+  #stats {
+    position: fixed; bottom: 0; left: 0; right: 0;
+    padding: 8px 14px; font-size: 12px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    background: rgba(15, 17, 23, 0.85);
+    backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px);
+    border-top: 1px solid var(--border);
+    color: var(--text-sub);
+    z-index: 10;
+  }
+  #stats:empty::before {
+    content: 'Ready — enter the JPIP server URL above and click Connect.';
+    color: var(--text-sub); font-style: italic;
+  }
+
+  /* ── Help panel (floating) ───────────────────────────── */
+  #help {
+    position: fixed; top: 74px; right: 16px; max-width: 340px;
+    background: rgba(26, 29, 39, 0.95);
+    backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 14px 16px;
+    font-size: 12px; line-height: 1.55; color: var(--text-sub);
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+    z-index: 15;
+  }
+  #help h3 { font-size: 12px; color: var(--text); margin-bottom: 8px; }
+  #help .section-h {
+    font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.7px;
+    color: var(--text-sub); margin: 10px 0 4px; opacity: 0.8;
+  }
+  #help b { color: var(--text); }
+  #help a { color: var(--accent); text-decoration: none; }
+  #help a:hover { text-decoration: underline; }
+  #help kbd {
+    background: var(--surface2);
+    border: 1px solid var(--border); border-bottom-width: 2px;
+    border-radius: 4px;
+    padding: 0 6px; margin: 0 1px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 11px; color: var(--text);
+    display: inline-block; min-width: 18px; text-align: center;
+  }
+  #help .close {
+    float: right; cursor: pointer; color: var(--text-sub);
+    margin: -4px -4px 0 8px; padding: 4px 6px;
+    border-radius: 4px; font-size: 14px; line-height: 1;
+  }
+  #help .close:hover { background: var(--surface); color: var(--text); }
+  #help .row { margin: 2px 0; }
+
+  /* Small-screen collapse of the top bar */
+  @media (max-width: 780px) {
+    #topbar { height: auto; padding: 10px 12px; flex-wrap: wrap; gap: 8px; }
+    #canvas { top: 98px; }
+    #help { top: 116px; right: 12px; max-width: calc(100% - 24px); }
+    #topbar input#server { width: 100%; }
+  }
 </style>
 </head>
 <body>
-<div id="controls">
-  <label>JPIP Server: <input id="server" value="http://localhost:8080" /></label>
-  <button id="connectBtn">Connect</button>
+
+<div id="topbar">
+  <a href="index.html" class="home" title="Back to demo index">← Demos</a>
+  <div class="brand">
+    <svg width="24" height="24" viewBox="0 0 38 38" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <rect width="38" height="38" rx="8" fill="#4f8ef7"/>
+      <rect x="6"  y="6"  width="11" height="11" rx="2" fill="white" opacity="1.0"/>
+      <rect x="21" y="6"  width="11" height="11" rx="2" fill="white" opacity="0.65"/>
+      <rect x="6"  y="21" width="11" height="11" rx="2" fill="white" opacity="0.4"/>
+      <rect x="21" y="21" width="11" height="11" rx="2" fill="white" opacity="0.2"/>
+    </svg>
+    <h1>JPIP Gigapixel Viewer</h1>
+    <span class="sub">OpenHTJ2K</span>
+  </div>
+  <label class="field">
+    Server
+    <input id="server" type="text" value="https://jpip-viewer.osamu620.dev" />
+  </label>
+  <button id="connectBtn" class="btn">Connect</button>
   <span id="info"></span>
+  <button class="btn ghost" id="helpBtn" title="Show help">?</button>
 </div>
+
 <canvas id="canvas"></canvas>
-<div id="stats">Arrows: pan (Shift=fast) | +/-: zoom | Home: reset | Trackpad: scroll=pan, pinch/Ctrl+scroll=zoom</div>
+
+<div id="help">
+  <span class="close" id="helpClose" title="Close">✕</span>
+  <h3>JPIP Gigapixel Viewer</h3>
+  Only the precincts that fall inside the current viewport are fetched and decoded,
+  so pan-and-zoom on a 400+ MP image stays interactive.
+
+  <div class="section-h">Pan</div>
+  <div class="row">Drag the image with the mouse.</div>
+  <div class="row"><kbd>←</kbd> <kbd>→</kbd> <kbd>↑</kbd> <kbd>↓</kbd>  (<kbd>Shift</kbd> = large step)</div>
+  <div class="row">Trackpad: two-finger scroll.</div>
+
+  <div class="section-h">Zoom</div>
+  <div class="row"><kbd>+</kbd> / <kbd>−</kbd> in / out,&nbsp;<kbd>Home</kbd> reset.</div>
+  <div class="row">Trackpad: pinch.&nbsp;Mouse: <kbd>Ctrl</kbd>+wheel.</div>
+
+  <div class="section-h">Stats bar</div>
+  <div class="row">canvas size · zoom · reduce_NL · viewport region · pan · fetch/decode ms</div>
+
+  <div class="section-h">Related</div>
+  <div class="row"><a href="jpip_demo.html">→ Foveated streaming demo</a></div>
+</div>
+
+<div id="stats"></div>
+
 <script>
   (function() {
     var p = new URLSearchParams(location.search);
@@ -46,6 +224,16 @@
     );
   }
 </script>
+<script>
+  // Help panel show/hide.
+  (function() {
+    var help = document.getElementById('help');
+    document.getElementById('helpClose').onclick = function() { help.style.display = 'none'; };
+    document.getElementById('helpBtn').onclick    = function() {
+      help.style.display = (help.style.display === 'none') ? '' : 'none';
+    };
+  })();
+</script>
 <script type="module">
 const hasSimd = await wasmFeatureDetect.simd();
 const hasMt = window.crossOriginIsolated && (typeof SharedArrayBuffer !== 'undefined');
@@ -61,6 +249,13 @@ let vpW = 0, vpH = 0, panX = 0, panY = 0, zoom = 1.0;
 let decReduce = -1, rgbPtr = 0;
 
 function wasmWrite(data, ptr) { new Uint8Array(M.HEAPU8.buffer).set(data, ptr); }
+
+// Compute the vertical space occupied by the fixed top bar at the current
+// viewport width.  Used to size the canvas below the bar.
+function topBarHeight() {
+  const tb = document.getElementById('topbar');
+  return tb ? tb.offsetHeight : 56;
+}
 
 // ── WebGL2 with aspect-ratio-correct quad ───────────────────────────────
 let gl = null, glTex = null, glProgram = null, texW = 0, texH = 0;
@@ -106,7 +301,7 @@ function initWebGL(canvas) {
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
   gl.bindVertexArray(gl.createVertexArray());
   gl.viewport(0, 0, canvas.width, canvas.height);
-  gl.clearColor(0.067, 0.067, 0.067, 1);
+  gl.clearColor(0.059, 0.066, 0.09, 1);
   return true;
 }
 
@@ -220,7 +415,7 @@ async function init() {
   $('info').textContent = 'Loading WASM…';
   try {
     M = await createModule();
-    $('info').textContent = `WASM ready (${useMt?'MT+SIMD':'SIMD'}). Enter server URL and click Connect.`;
+    $('info').textContent = `WASM ready (${useMt?'MT+SIMD':'SIMD'}).`;
   } catch (e) { $('info').textContent = 'WASM load failed: ' + e.message; }
   $('connectBtn').onclick = connect;
 }
@@ -251,8 +446,10 @@ async function connect() {
 
   const c = $('canvas');
   vpW = window.innerWidth;
-  vpH = window.innerHeight - 40;
+  vpH = window.innerHeight - topBarHeight();
   c.width = vpW; c.height = vpH;
+  c.style.width  = vpW + 'px';
+  c.style.height = vpH + 'px';
   initWebGL(c);
 
   zoom = vpW / canvasW;
@@ -302,6 +499,8 @@ async function connect() {
 
   // ── Keyboard ──
   window.addEventListener('keydown', e => {
+    // Don't hijack typing in inputs (the server URL field, etc.)
+    if (e.target && (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA')) return;
     const step = e.shiftKey ? 500 : 100;
     let needRedraw = false, needRefetch = false;
     switch (e.key) {

--- a/subprojects/rtp_demo.html
+++ b/subprojects/rtp_demo.html
@@ -346,8 +346,8 @@
   <nav class="nav-tabs">
     <a href="index.html">Still Image</a>
     <a href="rtp_demo.html" class="active">RTP Replay</a>
-    <a href="jpip_demo.html?server=https://jpip-demo.osamu620.dev">JPIP Foveation</a>
-    <a href="jpip_viewer.html?server=https://jpip-demo.osamu620.dev">JPIP Viewer</a>
+    <a href="jpip_demo.html?server=https://jpip-fovea.osamu620.dev">JPIP Foveation</a>
+    <a href="jpip_viewer.html?server=https://jpip-viewer.osamu620.dev">JPIP Viewer</a>
   </nav>
 
   <div class="privacy-notice">


### PR DESCRIPTION
## Summary

Rebuilds the look of the two JPIP demo pages on the same design system as `index.html` / `rtp_demo.html` so all four demo pages feel like one product. No JS behaviour changes beyond what's noted below — the existing decode / pan-zoom / foveation logic is reused verbatim.

### Shared styling

- System font stack (`-apple-system`, `Segoe UI`, `Roboto`, …).
- Dark design tokens matching `index.html`: `--bg`, `--surface`, `--surface2`, `--border`, `--accent`, `--text`, `--text-sub`.
- Consistent cards, labels, buttons, inputs, select menus, `<kbd>` keycap styling, and footer.

### `jpip_demo.html` (foveated)

- Header row with the product logo (multi-resolution grid) and title.
- Nav tabs matching `index.html` (Still Image · RTP Replay · JPIP Foveation · JPIP Viewer) so users can move between demos in one click.
- Controls gathered into a card with labelled fields: server URL, Connect button, Reduce, Parafovea ratio, Periphery ratio.
- Canvas wrapped in a dark card with rounded corners.
- Separate stats card + two-column help card ("What is this?" + "How to operate" with an ordered list of steps and a cross-link to the viewer).
- Default server value updated to `https://jpip-fovea.osamu620.dev`.

### `jpip_viewer.html` (gigapixel pan-zoom)

- Slim fixed top bar (56 px, wraps on narrow screens) with back link, logo, title, server URL field, Connect button, status, and a "?" ghost button that toggles the floating help panel.
- Canvas is positioned below the bar; its height is recomputed from the bar's actual `offsetHeight` instead of a hard-coded `40` so the responsive breakpoint stays correct.
- Glass-effect stats bar pinned to the bottom, with a helpful empty-state hint before first Connect.
- Floating help panel (top-right, dismissible) with `<kbd>`-styled keycap cheatsheet, split into **Pan / Zoom / Stats bar / Related** sections.
- Keyboard handler now ignores keys while typing in the server URL field so editing the URL doesn't pan the canvas.
- Default server value updated to `https://jpip-viewer.osamu620.dev`.

### `index.html` / `rtp_demo.html`

- Nav-tab `?server=…` query strings updated to the two new hostnames.

## Test plan

- [x] Both demo pages render in a local static server
- [x] Nav-tab links point at the new `jpip-fovea.osamu620.dev` / `jpip-viewer.osamu620.dev` hostnames
- [x] Closing tags balanced, `connectBtn` referenced in both HTML and JS
- [x] Reviewer visually checks against the live Cloudflare Pages deploy (CI auto-deploys on merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)