### PR TITLE
fix(jpip-demo): reset cache per frame so periphery decays when gaze moves

### DIFF
--- a/subprojects/CMakeLists.txt
+++ b/subprojects/CMakeLists.txt
@@ -176,7 +176,7 @@ target_link_libraries(libopen_htj2k_mt_simd PRIVATE open_htj2k_mt_simd_lib)
 # ── JPIP browser demo ────────────────────────────────────────────────────────
 # Exposes the JPIP client-side pipeline (parse → reassemble → decode) via
 # a thin C API that the JS side calls per frame.
-set(JPIP_EXPORTED_FUNCTIONS "[_malloc,_free,_jpip_create_context,_jpip_get_canvas_width,_jpip_get_canvas_height,_jpip_get_num_components,_jpip_get_total_precincts,_jpip_set_reduce,_jpip_begin_frame,_jpip_add_response,_jpip_end_frame,_jpip_end_frame_region,_jpip_destroy_context]")
+set(JPIP_EXPORTED_FUNCTIONS "[_malloc,_free,_jpip_create_context,_jpip_get_canvas_width,_jpip_get_canvas_height,_jpip_get_num_components,_jpip_get_total_precincts,_jpip_set_reduce,_jpip_begin_frame,_jpip_reset_cache,_jpip_add_response,_jpip_end_frame,_jpip_end_frame_region,_jpip_destroy_context]")
 set(JPIP_INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR}/../source/core/jpip
     ${CMAKE_CURRENT_SOURCE_DIR}/../source/core/interface

--- a/subprojects/jpip_demo.html
+++ b/subprojects/jpip_demo.html
@@ -494,7 +494,13 @@ async function connect() {
       ]);
       const tFetch = performance.now();
 
-      M._jpip_begin_frame(ctx);
+      // Foveation demo semantics: each frame is a fresh 3-cone RoI snapshot
+      // (fovea / parafovea / periphery at the current gaze point).  We want
+      // the previous gaze's high-res precincts to disappear when the mouse
+      // moves, so explicitly drop the accumulated DataBinSet + decoder state.
+      // The JPIP large-image viewer wants the opposite (accumulate for pan
+      // reuse) and calls jpip_begin_frame (a no-op) instead.
+      M._jpip_reset_cache(ctx);
       for (const ab of [r1, r2, r3]) {
         const arr = new Uint8Array(ab);
         const ptr = M._malloc(arr.length);


### PR DESCRIPTION
## Summary
Regression from #285 (c30f0dd).  That PR made `jpip_begin_frame` a no-op so the large-image JPIP viewer could accumulate cached precincts across pans — but the foveated demo relied on the old per-frame-clear semantics.  Without a clear, previously-fovea regions retained their high-res precincts forever: once an area had been inside the gaze it never decayed back to periphery resolution, defeating the whole point of the demo.

## The two demos have opposite cache needs
- **`jpip_viewer`**: accumulate (reuse precincts across pans → fast).
- **`jpip_demo` (foveated)**: don't accumulate (each frame is a fresh 3-cone RoI snapshot).

## Fix
- Export `_jpip_reset_cache` from the WASM JPIP module (CMakeLists.txt).
- Foveated demo calls `M._jpip_reset_cache(ctx)` per frame instead of `jpip_begin_frame` — explicit reset of `DataBinSet` + persistent decoder state.
- Viewer is unchanged (still calls the no-op `jpip_begin_frame`).

## Test plan
- [ ] Open `/jpip_demo`, move the mouse across the image, then stop. The area where the mouse currently sits should be sharp; previously-gazed areas should drop back to periphery quality.
- [ ] Verify `/jpip_viewer` still benefits from the persistent cache (second+ pan to a new viewport should render fast).

🤖 Generated with [Claude Code](https://claude.com/claude-code)