### PR TITLE
perf(jpip): foveation + viewer optimizations (6 rounds)

### DIFF
--- a/source/apps/jpip_server/main.cpp
+++ b/source/apps/jpip_server/main.cpp
@@ -24,7 +24,6 @@
 #include <cstdlib>
 #include <cstring>
 #include <string>
-#include <unordered_set>
 #include <vector>
 
 #include "codestream_walker.hpp"
@@ -75,9 +74,6 @@ std::vector<uint8_t> build_jpp_stream(const ServerState &st, const ViewWindow &v
                                       size_t *n_keys_out = nullptr) {
   auto keys = resolve_view_window(*st.idx, vw);
   if (n_keys_out) *n_keys_out = keys.size();
-  std::unordered_set<uint64_t> keep;
-  keep.reserve(keys.size());
-  for (const auto &k : keys) keep.insert(st.idx->I(k.t, k.c, k.r, k.p_rc));
 
   std::vector<uint8_t> stream;
   MessageHeaderContext ctx;
@@ -90,20 +86,20 @@ std::vector<uint8_t> build_jpp_stream(const ServerState &st, const ViewWindow &v
   }
   if (!client_cache.has(kMsgClassMetadata, 0))
     emit_metadata_bin_zero(ctx, stream);
-  for (uint32_t t = 0; t < st.idx->num_tiles(); ++t) {
-    for (uint16_t c = 0; c < st.idx->num_components(); ++c) {
-      const auto &info = st.idx->tile_component(static_cast<uint16_t>(t), c);
-      for (uint8_t r = 0; r <= info.NL; ++r) {
-        const uint32_t n = info.npw[r] * info.nph[r];
-        for (uint32_t p = 0; p < n; ++p) {
-          const uint64_t I = st.idx->I(static_cast<uint16_t>(t), c, r, p);
-          if (keep.count(I) && !client_cache.has(kMsgClassPrecinct, I)) {
-            emit_precinct_databin(st.codestream.data(), st.codestream.size(),
-                                  static_cast<uint16_t>(t), c, r, p,
-                                  *st.idx, *st.locator, ctx, stream);
-          }
-        }
-      }
+
+  // Emit exactly the precincts resolve_view_window selected.  The old code
+  // walked the full T×C×R×P grid and tested every precinct ID against a
+  // hash set built from `keys`, which is O(total_precincts) per request.
+  // On heic2501a (103K precincts, ~500-precinct typical fovea), the walk
+  // dominated — especially under the foveation demo's 3× amplification.
+  // JPP-stream messages are order-agnostic (each carries class + id; the
+  // client reassembler sorts them), so emitting in `keys` order is fine.
+  for (const auto &k : keys) {
+    const uint64_t I = st.idx->I(k.t, k.c, k.r, k.p_rc);
+    if (!client_cache.has(kMsgClassPrecinct, I)) {
+      emit_precinct_databin(st.codestream.data(), st.codestream.size(),
+                            k.t, k.c, k.r, k.p_rc,
+                            *st.idx, *st.locator, ctx, stream);
     }
   }
   emit_eor(EorReason::WindowDone, ctx, stream);

--- a/source/apps/jpip_server/main.cpp
+++ b/source/apps/jpip_server/main.cpp
@@ -67,10 +67,14 @@ struct ServerState {
 };
 
 // Build the JPP-stream for a given ViewWindow, skipping data-bins
-// the client already has (per the cache model from §C.9).
+// the client already has (per the cache model from §C.9).  When
+// `n_keys_out` is non-null the caller gets the precinct count back
+// without having to re-run resolve_view_window.
 std::vector<uint8_t> build_jpp_stream(const ServerState &st, const ViewWindow &vw,
-                                      const CacheModel &client_cache = {}) {
+                                      const CacheModel &client_cache = {},
+                                      size_t *n_keys_out = nullptr) {
   auto keys = resolve_view_window(*st.idx, vw);
+  if (n_keys_out) *n_keys_out = keys.size();
   std::unordered_set<uint64_t> keep;
   keep.reserve(keys.size());
   for (const auto &k : keys) keep.insert(st.idx->I(k.t, k.c, k.r, k.p_rc));
@@ -167,16 +171,16 @@ void handle_connection(TcpStream &conn, const ServerState &st) {
 
   CacheModel client_cache;
   if (!req.model.empty()) client_cache = CacheModel::parse(req.model);
-  auto jpp = build_jpp_stream(st, req.view_window, client_cache);
+  size_t n_keys = 0;
+  auto jpp = build_jpp_stream(st, req.view_window, client_cache, &n_keys);
 
   const auto t1 = Clock::now();
   const double ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
 
-  auto keys = resolve_view_window(*st.idx, req.view_window);
   std::printf("  → %zu precincts (%.1f%%), %zu bytes JPP-stream, %.1f ms\n",
-              keys.size(),
+              n_keys,
               st.idx->total_precincts()
-                  ? (100.0 * static_cast<double>(keys.size()) / static_cast<double>(st.idx->total_precincts()))
+                  ? (100.0 * static_cast<double>(n_keys) / static_cast<double>(st.idx->total_precincts()))
                   : 0.0,
               jpp.size(), ms);
   std::fflush(stdout);
@@ -207,15 +211,15 @@ std::vector<uint8_t> handle_h3_request(const ServerState &st,
   const auto t0 = Clock::now();
   CacheModel h3_cache;
   if (!jpip_req.model.empty()) h3_cache = CacheModel::parse(jpip_req.model);
-  auto jpp = build_jpp_stream(st, jpip_req.view_window, h3_cache);
+  size_t n_keys = 0;
+  auto jpp = build_jpp_stream(st, jpip_req.view_window, h3_cache, &n_keys);
   const auto t1 = Clock::now();
   const double ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
 
-  auto keys = resolve_view_window(*st.idx, jpip_req.view_window);
   std::printf("  [H3] → %zu precincts (%.1f%%), %zu bytes, %.1f ms\n",
-              keys.size(),
+              n_keys,
               st.idx->total_precincts()
-                  ? (100.0 * static_cast<double>(keys.size()) / static_cast<double>(st.idx->total_precincts()))
+                  ? (100.0 * static_cast<double>(n_keys) / static_cast<double>(st.idx->total_precincts()))
                   : 0.0,
               jpp.size(), ms);
   std::fflush(stdout);

--- a/source/core/jpip/codestream_assembler.cpp
+++ b/source/core/jpip/codestream_assembler.cpp
@@ -3,6 +3,8 @@
 
 #include "codestream_assembler.hpp"
 
+#include <algorithm>
+
 #include "jpp_message.hpp"
 
 namespace open_htj2k {
@@ -162,6 +164,32 @@ std::vector<uint8_t> patch_cod_to_lrcp(const std::vector<uint8_t> &main_hdr) {
   return {};  // COD not found
 }
 
+// Inverse of CodestreamIndex::I().  Recovers (t, c, r, p_rc) from a
+// precinct in-class identifier.  Returns false when the identifier does
+// not land inside a valid (r, p_rc) slot for the (t, c) pair — e.g. a
+// corrupt or spoofed server response.  tc_cache is an optional pointer
+// used to skip the tile_component(t, c) lookup when successive IDs share
+// the same (t, c); callers that don't care can pass nullptr.
+bool decompose_precinct_I(const CodestreamIndex &idx, uint64_t I, PrecinctKey *out) {
+  const uint32_t nT = idx.num_tiles();
+  const uint16_t nC = idx.num_components();
+  if (nT == 0 || nC == 0) return false;
+  out->t  = static_cast<uint16_t>(I % nT);
+  uint64_t tmp = I / nT;
+  out->c  = static_cast<uint16_t>(tmp % nC);
+  const uint32_t s = static_cast<uint32_t>(tmp / nC);
+  const auto &tc = idx.tile_component(out->t, out->c);
+  for (uint8_t r = 0; r <= tc.NL; ++r) {
+    const uint32_t n = tc.npw[r] * tc.nph[r];
+    if (s >= tc.s_offset[r] && s < tc.s_offset[r] + n) {
+      out->r    = r;
+      out->p_rc = s - tc.s_offset[r];
+      return true;
+    }
+  }
+  return false;
+}
+
 }  // namespace
 
 ReassembleStatus reassemble_codestream_client(const DataBinSet &set,
@@ -177,34 +205,68 @@ ReassembleStatus reassemble_codestream_client(const DataBinSet &set,
 
   const uint16_t num_layers = idx.num_layers();
   const uint32_t nT = idx.num_tiles();
+  const uint16_t nC = idx.num_components();
+  const uint8_t  max_NL = idx.max_NL();
+
+  // Bucket every delivered precinct bin by (t, c, r), storing (p_rc, bin*)
+  // pairs sorted by p_rc.  The LRCP emit pass below then iterates ragged
+  // buckets rather than the full T·L·R·C·P grid — on a 103K-precinct
+  // asset with only a few hundred bins delivered, the old set.contains()
+  // probe cost dominated every dirty frame.
+  //
+  // Layout: per_tile[t][c * (max_NL + 1) + r] is the sorted bin list.
+  // max_NL + 1 is the row stride; tile-components with tc.NL < max_NL
+  // simply leave the high-r rows empty (the LRCP walk skips them via the
+  // `r > tc.NL` guard, matching the old loop's behaviour).
+  using DeliveredList = std::vector<std::pair<uint32_t, const std::vector<uint8_t>*>>;
+  const std::size_t stride = static_cast<std::size_t>(nC) * (max_NL + 1);
+  std::vector<std::vector<DeliveredList>> per_tile(nT);
+  for (auto &v : per_tile) v.resize(stride);
+
+  for (const auto &kv : set.keys()) {
+    if (kv.first != kMsgClassPrecinct) continue;
+    PrecinctKey pk;
+    if (!decompose_precinct_I(idx, kv.second, &pk)) continue;
+    auto &slot = per_tile[pk.t][static_cast<std::size_t>(pk.c) * (max_NL + 1) + pk.r];
+    slot.emplace_back(pk.p_rc, &set.get(kMsgClassPrecinct, kv.second));
+  }
+  for (auto &tile_buckets : per_tile) {
+    for (auto &slot : tile_buckets) {
+      std::sort(slot.begin(), slot.end(),
+                [](const auto &a, const auto &b) { return a.first < b.first; });
+    }
+  }
 
   for (uint32_t t = 0; t < nT; ++t) {
     std::vector<uint8_t> body;
 
-    // LRCP order: Layer → Resolution → Component → Precinct.
-    const uint8_t max_NL = idx.max_NL();
+    // LRCP order: Layer → Resolution → Component → Precinct.  Multi-layer
+    // is a deferred feature — the body block is just repeated num_layers
+    // times here, matching the pre-refactor behaviour where both branches
+    // of the `num_layers == 1` check emitted the same bytes.
+    const auto &tile_buckets = per_tile[t];
     for (uint16_t l = 0; l < num_layers; ++l) {
       for (uint8_t r = 0; r <= max_NL; ++r) {
-        for (uint16_t c = 0; c < idx.num_components(); ++c) {
+        for (uint16_t c = 0; c < nC; ++c) {
           const auto &tc = idx.tile_component(static_cast<uint16_t>(t), c);
           if (r > tc.NL) continue;
           const uint32_t np = tc.npw[r] * tc.nph[r];
-          for (uint32_t p = 0; p < np; ++p) {
-            const uint64_t I = idx.I(static_cast<uint16_t>(t), c, r, p);
-            if (set.contains(kMsgClassPrecinct, I)) {
-              const auto &bin = set.get(kMsgClassPrecinct, I);
-              if (num_layers == 1) {
-                // Single layer: bin = one packet, emit whole thing.
-                body.insert(body.end(), bin.begin(), bin.end());
-              } else {
-                // Multi-layer: would need per-layer byte offsets within
-                // the bin.  v1 does not support this — deferred.
-                body.insert(body.end(), bin.begin(), bin.end());
-              }
-            } else {
-              body.push_back(0x00);  // empty packet header
-            }
+          const auto &delivered =
+              tile_buckets[static_cast<std::size_t>(c) * (max_NL + 1) + r];
+          if (delivered.empty()) {
+            // Whole (r, c) group absent — one 0x00 per precinct.
+            body.insert(body.end(), np, 0x00);
+            continue;
           }
+          uint32_t cursor = 0;
+          for (const auto &entry : delivered) {
+            const uint32_t p_rc = entry.first;
+            const std::vector<uint8_t> &bin = *entry.second;
+            if (p_rc > cursor) body.insert(body.end(), p_rc - cursor, 0x00);
+            body.insert(body.end(), bin.begin(), bin.end());
+            cursor = p_rc + 1;
+          }
+          if (cursor < np) body.insert(body.end(), np - cursor, 0x00);
         }
       }
     }

--- a/subprojects/CMakeLists.txt
+++ b/subprojects/CMakeLists.txt
@@ -14,7 +14,7 @@ set(WASM_FLAGS_COMMON "\
     -s EXPORTED_FUNCTIONS=[_free,_malloc] \
     -s MALLOC=dlmalloc \
     -s FILESYSTEM=0 \
-    -s EXPORTED_RUNTIME_METHODS=[ccall,cwrap,writeArrayToMemory,getValue,HEAP32,HEAPU8] \
+    -s EXPORTED_RUNTIME_METHODS=[ccall,cwrap,writeArrayToMemory,getValue,HEAP32,HEAPU8,UTF8ToString] \
     -s NO_EXIT_RUNTIME=1 \
     -s ALLOW_MEMORY_GROWTH=1 \
     -s MAXIMUM_MEMORY=2GB \
@@ -176,7 +176,7 @@ target_link_libraries(libopen_htj2k_mt_simd PRIVATE open_htj2k_mt_simd_lib)
 # ── JPIP browser demo ────────────────────────────────────────────────────────
 # Exposes the JPIP client-side pipeline (parse → reassemble → decode) via
 # a thin C API that the JS side calls per frame.
-set(JPIP_EXPORTED_FUNCTIONS "[_malloc,_free,_jpip_create_context,_jpip_get_canvas_width,_jpip_get_canvas_height,_jpip_get_num_components,_jpip_get_total_precincts,_jpip_set_reduce,_jpip_begin_frame,_jpip_reset_cache,_jpip_get_response_buffer,_jpip_add_response,_jpip_end_frame,_jpip_end_frame_region,_jpip_destroy_context]")
+set(JPIP_EXPORTED_FUNCTIONS "[_malloc,_free,_jpip_create_context,_jpip_get_canvas_width,_jpip_get_canvas_height,_jpip_get_num_components,_jpip_get_total_precincts,_jpip_set_reduce,_jpip_get_cache_model,_jpip_begin_frame,_jpip_reset_cache,_jpip_get_response_buffer,_jpip_add_response,_jpip_end_frame,_jpip_end_frame_region,_jpip_destroy_context]")
 set(JPIP_INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR}/../source/core/jpip
     ${CMAKE_CURRENT_SOURCE_DIR}/../source/core/interface

--- a/subprojects/CMakeLists.txt
+++ b/subprojects/CMakeLists.txt
@@ -176,7 +176,7 @@ target_link_libraries(libopen_htj2k_mt_simd PRIVATE open_htj2k_mt_simd_lib)
 # ── JPIP browser demo ────────────────────────────────────────────────────────
 # Exposes the JPIP client-side pipeline (parse → reassemble → decode) via
 # a thin C API that the JS side calls per frame.
-set(JPIP_EXPORTED_FUNCTIONS "[_malloc,_free,_jpip_create_context,_jpip_get_canvas_width,_jpip_get_canvas_height,_jpip_get_num_components,_jpip_get_total_precincts,_jpip_set_reduce,_jpip_begin_frame,_jpip_reset_cache,_jpip_add_response,_jpip_end_frame,_jpip_end_frame_region,_jpip_destroy_context]")
+set(JPIP_EXPORTED_FUNCTIONS "[_malloc,_free,_jpip_create_context,_jpip_get_canvas_width,_jpip_get_canvas_height,_jpip_get_num_components,_jpip_get_total_precincts,_jpip_set_reduce,_jpip_begin_frame,_jpip_reset_cache,_jpip_get_response_buffer,_jpip_add_response,_jpip_end_frame,_jpip_end_frame_region,_jpip_destroy_context]")
 set(JPIP_INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR}/../source/core/jpip
     ${CMAKE_CURRENT_SOURCE_DIR}/../source/core/interface

--- a/subprojects/jpip_demo.html
+++ b/subprojects/jpip_demo.html
@@ -501,12 +501,15 @@ async function connect() {
       // The JPIP large-image viewer wants the opposite (accumulate for pan
       // reuse) and calls jpip_begin_frame (a no-op) instead.
       M._jpip_reset_cache(ctx);
+      // Reuse the WASM context's persistent response buffer so the three
+      // fovea/para/peri responses don't each trigger a _malloc/_free cycle
+      // on every gaze move.  The pointer is only valid until the next
+      // jpip_get_response_buffer() call, so we re-request it per response.
       for (const ab of [r1, r2, r3]) {
         const arr = new Uint8Array(ab);
-        const ptr = M._malloc(arr.length);
+        const ptr = M._jpip_get_response_buffer(ctx, arr.length);
         wasmWrite(arr, ptr);
         M._jpip_add_response(ctx, ptr, arr.length);
-        M._free(ptr);
       }
       const rc = M._jpip_end_frame(ctx, rgbPtr, c.width, c.height);
       const tDecode = performance.now();

--- a/subprojects/jpip_demo.html
+++ b/subprojects/jpip_demo.html
@@ -399,6 +399,18 @@ function buildQuery(fx, fy, ox, oy, sx, sy) {
   if (ox || oy) q += `&roff=${ox},${oy}`;
   if (sx || sy) q += `&rsiz=${sx},${sy}`;
   q += '&type=jpp-stream';
+  // Append the client cache-model (§C.9) so the server skips headers /
+  // tile-headers / metadata bins the WASM side already holds.  Precincts
+  // are intentionally NOT tracked — the demo's per-frame reset drops
+  // them so the periphery decays when the gaze moves (commit a6749fd).
+  if (ctx && M) {
+    const modelPtr = M._jpip_get_cache_model(ctx);
+    const model = modelPtr ? M.UTF8ToString(modelPtr) : '';
+    // Don't percent-encode — the server splits on ',' and on '=' /
+    // '&' without URL-decoding (see jpip_request.cpp), and commas are
+    // legal unencoded inside a query value.
+    if (model) q += `&model=${model}`;
+  }
   return q;
 }
 

--- a/subprojects/jpip_viewer.html
+++ b/subprojects/jpip_viewer.html
@@ -374,8 +374,11 @@ async function fetchView() {
   const viewW = vpW / zoom;
   const viewH = vpH / zoom;
 
-  // Build fetch key to detect if a refetch is needed
-  const key = `${red}:${Math.round(panX)}:${Math.round(panY)}:${Math.round(zoom*1000)}`;
+  // Build fetch key to detect if a refetch is needed.  `red` (from
+  // computeReduce()) already collapses zoom jitter within the same
+  // reduce level; including raw zoom here would trip on sub-pixel
+  // trackpad drift and re-fetch the same visible region.
+  const key = `${red}:${Math.round(panX)}:${Math.round(panY)}`;
   if (key === lastFetchKey && texW > 0) { return; }
   if (busy) return;
   busy = true;

--- a/subprojects/jpip_viewer.html
+++ b/subprojects/jpip_viewer.html
@@ -415,10 +415,12 @@ async function fetchView() {
     const tFetch = performance.now();
 
     M._jpip_begin_frame(ctx);
-    const ptr = M._malloc(buf.length);
+    // Reuse the WASM context's persistent response buffer (grow-only) so we
+    // don't pay a malloc/free round-trip on every pan.  The returned pointer
+    // is only valid until the next jpip_get_response_buffer() call.
+    const ptr = M._jpip_get_response_buffer(ctx, buf.length);
     wasmWrite(buf, ptr);
     M._jpip_add_response(ctx, ptr, buf.length);
-    M._free(ptr);
 
     // Grow-only: reuse the RGB buffer across frames.  Reallocating 14+ MB
     // on every pan event churns the WASM heap (which has ALLOW_MEMORY_GROWTH

--- a/subprojects/jpip_viewer.html
+++ b/subprojects/jpip_viewer.html
@@ -405,6 +405,14 @@ async function fetchView() {
   let q = `fsiz=${fW},${fH}`;
   if (rx > 0 || ry > 0) q += `&roff=${rx},${ry}`;
   q += `&rsiz=${rw},${rh}&type=jpp-stream`;
+  // Advertise the header / tile-header / metadata bins WASM already holds
+  // so the server can skip them on every pan — not percent-encoded; the
+  // server splits on literal ',' and '=' inside the query value.
+  if (ctx && M) {
+    const modelPtr = M._jpip_get_cache_model(ctx);
+    const model = modelPtr ? M.UTF8ToString(modelPtr) : '';
+    if (model) q += `&model=${model}`;
+  }
   const outW = vpW, outH = vpH;
 
   try {

--- a/subprojects/src/jpip_wrapper.cpp
+++ b/subprojects/src/jpip_wrapper.cpp
@@ -7,11 +7,14 @@
 
 #include <emscripten.h>
 
+#include <string>
+
 #include "decoder.hpp"
 #include "precinct_index.hpp"
 #include "jpp_parser.hpp"
 #include "codestream_assembler.hpp"
 #include "jpp_message.hpp"
+#include "cache_model.hpp"
 
 // ────────────────────────────────────────────────────────────────────────────
 // JPIP WASM API — thin C-linkage entry points for the browser demo.
@@ -69,6 +72,15 @@ struct JpipContext {
   // the per-frame _malloc / wasmWrite / _free triplet (3× per foveation
   // frame) and the repeated WASM heap churn that came with it.
   std::vector<uint8_t> response_buf;
+  // Cache model the client has authoritatively received — headers, tile
+  // headers, metadata-bin-0.  Precincts are intentionally not tracked:
+  // the foveation demo drops precinct state per frame so the periphery
+  // decays when the gaze moves.  Exposed to JS via jpip_get_cache_model()
+  // so the outgoing query can carry `&model=` and the server skips
+  // redundant header bytes.  Rebuilt lazily into `cache_model_str` when
+  // the JS caller asks for it.
+  open_htj2k::jpip::CacheModel client_cache;
+  std::string cache_model_str;
 };
 
 // Flush the single-tile reuse cache when a parameter that isn't part of the
@@ -102,8 +114,17 @@ void *jpip_create_context(const uint8_t *jpp_stream, size_t len) {
   ctx->canvas_h = idx->geometry().canvas_size.y;
   ctx->idx      = std::move(idx);
   ctx->dec.enable_single_tile_reuse(true);
-  // Seed the cache with the main-header data-bin that built the index.
+  // Seed the cache with the main-header data-bin that built the index,
+  // and mark every non-precinct bin present in the client CacheModel so
+  // the very first follow-up request carries an accurate &model= header.
   ctx->set.merge_from(tmp);
+  for (const auto &kv : tmp.keys()) {
+    if (kv.first == open_htj2k::jpip::kMsgClassPrecinct
+        || kv.first == open_htj2k::jpip::kMsgClassExtPrecinct) continue;
+    if (tmp.is_complete(kv.first, kv.second))
+      ctx->client_cache.mark(kv.first, kv.second);
+  }
+  ctx->cache_model_str.clear();
   ctx->dirty = true;
   return ctx;
 }
@@ -138,6 +159,22 @@ void jpip_set_reduce(void *handle, int n) {
   static_cast<JpipContext *>(handle)->reduce_NL = static_cast<uint8_t>(n);
 }
 
+// Returns a C string the JS caller can hand straight to UTF8ToString().
+// The string is the client's current cache-model request-field body
+// (§C.9) — e.g. "Hm,Ht0,M0" — which JS appends as `&model=<string>`
+// to every JPIP query.  The returned pointer is owned by the context
+// and is invalidated by the next call to this function or any call
+// that marks new bins (jpip_add_response, jpip_create_context).
+EMSCRIPTEN_KEEPALIVE
+const char *jpip_get_cache_model(void *handle) {
+  if (!handle) return "";
+  auto *ctx = static_cast<JpipContext *>(handle);
+  if (ctx->cache_model_str.empty() && ctx->client_cache.size() > 0) {
+    ctx->cache_model_str = ctx->client_cache.format();
+  }
+  return ctx->cache_model_str.c_str();
+}
+
 // Kept as a no-op: the viewer calls it before every jpip_add_response() but
 // clearing the DataBinSet here would throw away everything JPIP has cached
 // for earlier viewports, forcing the server to resend main-header and
@@ -148,16 +185,31 @@ void jpip_begin_frame(void *handle) {
   (void)handle;
 }
 
-// Explicit cache reset — intended for disconnect / reconnect flows.
+// Drop accumulated precincts but keep headers / tile-headers / metadata
+// bins.  The foveation demo calls this every frame so the periphery
+// decays when the gaze moves (commit a6749fd); preserving the header
+// bins means the reassembler still has them and the &model= header we
+// advertise stays consistent with what WASM actually holds.  The
+// client_cache isn't touched for the same reason — the server will keep
+// skipping the headers it already sent.
 EMSCRIPTEN_KEEPALIVE
 void jpip_reset_cache(void *handle) {
   if (!handle) return;
   auto *ctx = static_cast<JpipContext *>(handle);
-  ctx->set = {};
+  open_htj2k::jpip::DataBinSet kept;
+  for (const auto &kv : ctx->set.keys()) {
+    if (kv.first == open_htj2k::jpip::kMsgClassPrecinct
+        || kv.first == open_htj2k::jpip::kMsgClassExtPrecinct) continue;
+    const auto &bin = ctx->set.get(kv.first, kv.second);
+    kept.append(kv.first, kv.second, 0, bin.data(), bin.size(),
+                ctx->set.is_complete(kv.first, kv.second));
+  }
+  ctx->set = std::move(kept);
   ctx->sparse_cs.clear();
   ctx->dec_initialized = false;
   ctx->last_reduce_NL = 0xFF;
-  ctx->dirty = false;
+  // We dropped precincts, so the next end_frame() has to reassemble.
+  ctx->dirty = true;
 }
 
 // Return a pointer to the context's grow-only response staging buffer,
@@ -183,6 +235,21 @@ int jpip_add_response(void *handle, const uint8_t *jpp_stream, size_t len) {
   open_htj2k::jpip::DataBinSet tmp;
   if (!open_htj2k::jpip::parse_jpp_stream(jpp_stream, len, &tmp)) return -2;
   ctx->set.merge_from(tmp);
+  // Track completed non-precinct bins (headers, tile-headers, metadata) in
+  // the client cache model so the next &model= advertisement lets the
+  // server skip them.  Precincts are intentionally omitted — the foveation
+  // demo's per-frame reset drops them anyway.
+  bool cache_changed = false;
+  for (const auto &kv : tmp.keys()) {
+    if (kv.first == open_htj2k::jpip::kMsgClassPrecinct
+        || kv.first == open_htj2k::jpip::kMsgClassExtPrecinct) continue;
+    if (!tmp.is_complete(kv.first, kv.second)) continue;
+    if (!ctx->client_cache.has(kv.first, kv.second)) {
+      ctx->client_cache.mark(kv.first, kv.second);
+      cache_changed = true;
+    }
+  }
+  if (cache_changed) ctx->cache_model_str.clear();
   ctx->dirty = true;
   return 0;
 }

--- a/subprojects/src/jpip_wrapper.cpp
+++ b/subprojects/src/jpip_wrapper.cpp
@@ -205,31 +205,50 @@ int jpip_end_frame(void *handle, uint8_t *rgb_out, int out_w, int out_h) {
   const uint32_t ow = static_cast<uint32_t>(out_w);
   const uint32_t oh = static_cast<uint32_t>(out_h);
 
+  // Column index LUT — xc[xw] = xw · cw / ow.  Built on the first row
+  // callback (cw only becomes known once the decoder populates `widths`).
+  // Hoisting this out of the pixel loop eliminates an O(ow · oh) worth of
+  // per-pixel 64-bit divides that WASM can't strength-reduce.
+  std::vector<uint32_t> xc_lut;
+  uint32_t last_ch = 0;
+
   try {
     dec.invoke_line_based_stream_reuse(
         [&](uint32_t y, int32_t *const *rows, uint16_t nc) {
           if (nc < 3 || widths.empty() || heights.empty()) return;
           const uint32_t cw = widths[0];
           const uint32_t ch = heights[0];
+          if (xc_lut.size() != ow || last_ch != ch) {
+            xc_lut.resize(ow);
+            for (uint32_t xw = 0; xw < ow; ++xw) {
+              xc_lut[xw] = static_cast<uint32_t>(
+                  static_cast<uint64_t>(xw) * cw / (ow > 0 ? ow : 1));
+            }
+            last_ch = ch;
+          }
           const int32_t shift = (depths.empty() ? 0 : static_cast<int32_t>(depths[0]) - 8);
+          const int32_t shift_pos = shift > 0 ? shift : 0;  // no-op when bit-depth <= 8
           const uint32_t ty0 =
               static_cast<uint32_t>(static_cast<uint64_t>(y) * oh / (ch > 0 ? ch : 1));
           const uint32_t ty1 =
               static_cast<uint32_t>(static_cast<uint64_t>(y + 1) * oh / (ch > 0 ? ch : 1));
           if (ty0 >= oh) return;
           uint8_t *dst = rgb_out + static_cast<size_t>(ty0) * ow * 4;
+          const int32_t *__restrict__ r0 = rows[0];
+          const int32_t *__restrict__ r1 = rows[1];
+          const int32_t *__restrict__ r2 = rows[2];
+          const uint32_t *__restrict__ lut = xc_lut.data();
           for (uint32_t xw = 0; xw < ow; ++xw) {
-            const uint32_t xc =
-                static_cast<uint32_t>(static_cast<uint64_t>(xw) * cw / (ow > 0 ? ow : 1));
-            auto to_u8 = [shift](int32_t v) -> uint8_t {
-              if (shift > 0) v >>= shift;
-              if (v < 0) return 0;
-              if (v > 255) return 255;
-              return static_cast<uint8_t>(v);
-            };
-            dst[4 * xw + 0] = to_u8(rows[0][xc]);
-            dst[4 * xw + 1] = to_u8(rows[1][xc]);
-            dst[4 * xw + 2] = to_u8(rows[2][xc]);
+            const uint32_t xc = lut[xw];
+            int32_t v0 = r0[xc] >> shift_pos;
+            int32_t v1 = r1[xc] >> shift_pos;
+            int32_t v2 = r2[xc] >> shift_pos;
+            if (v0 < 0) v0 = 0; else if (v0 > 255) v0 = 255;
+            if (v1 < 0) v1 = 0; else if (v1 > 255) v1 = 255;
+            if (v2 < 0) v2 = 0; else if (v2 > 255) v2 = 255;
+            dst[4 * xw + 0] = static_cast<uint8_t>(v0);
+            dst[4 * xw + 1] = static_cast<uint8_t>(v1);
+            dst[4 * xw + 2] = static_cast<uint8_t>(v2);
             dst[4 * xw + 3] = 255;
           }
           for (uint32_t ty = ty0 + 1; ty < ty1 && ty < oh; ++ty) {
@@ -285,23 +304,44 @@ int jpip_end_frame_region(void *handle, uint8_t *rgb_out, int out_w, int out_h,
   const uint32_t ow = static_cast<uint32_t>(out_w);
   const uint32_t oh = static_cast<uint32_t>(out_h);
   const uint32_t red = ctx->reduce_NL;
-  const uint32_t ry0 = static_cast<uint32_t>(region_y) >> red;
-  const uint32_t ry1 = (static_cast<uint32_t>(region_y + region_h) + ((1u << red) - 1)) >> red;
-  const uint32_t rx0 = static_cast<uint32_t>(region_x) >> red;
-  const uint32_t rx1 = (static_cast<uint32_t>(region_x + region_w) + ((1u << red) - 1)) >> red;
+
+  // Canvas extent at the active reduce level — used to clamp the region
+  // bounds so the row callback's column LUT is guaranteed in-range and
+  // can drop its per-pixel `xc >= cw` guard.
+  const uint32_t cw_at_red = (ctx->canvas_w + ((1u << red) - 1)) >> red;
+  const uint32_t ch_at_red = (ctx->canvas_h + ((1u << red) - 1)) >> red;
+
+  const uint32_t ry0_u = static_cast<uint32_t>(region_y) >> red;
+  uint32_t ry1 = (static_cast<uint32_t>(region_y + region_h) + ((1u << red) - 1)) >> red;
+  const uint32_t rx0_u = static_cast<uint32_t>(region_x) >> red;
+  uint32_t rx1 = (static_cast<uint32_t>(region_x + region_w) + ((1u << red) - 1)) >> red;
+  if (ry1 > ch_at_red) ry1 = ch_at_red;
+  if (rx1 > cw_at_red) rx1 = cw_at_red;
+  const uint32_t ry0 = ry0_u;
+  const uint32_t rx0 = rx0_u;
+  if (rx1 <= rx0 || ry1 <= ry0) return -1;
+  const uint32_t rw = rx1 - rx0;
+  const uint32_t rh = ry1 - ry0;
 
   // The row callback below writes every output pixel when it fires for
   // every y in [ry0, ry1) — which it does on the success path.  The
-  // memset is only a safety net for partial-region panning where the
-  // xw<ow loop can early-break on edge columns (xc >= cw).  For the
-  // common full-canvas case (viewer at fit-zoom, initial load) the
-  // entire buffer is overwritten, so skip the O(ow·oh·4) wipe.
+  // memset is only a safety net for partial-region panning where not
+  // every output row is written.  For the common full-canvas case
+  // (viewer at fit-zoom, initial load) the entire buffer is overwritten,
+  // so skip the O(ow·oh·4) wipe.
   const bool full_coverage =
       (region_x == 0 && region_y == 0
        && static_cast<uint32_t>(region_x + region_w) >= ctx->canvas_w
        && static_cast<uint32_t>(region_y + region_h) >= ctx->canvas_h);
   if (!full_coverage)
     std::memset(rgb_out, 0, static_cast<size_t>(ow) * oh * 4);
+
+  // Precompute the column LUT upfront — xc depends only on (rx0, rw, ow),
+  // all of which are known before the decoder starts emitting rows.
+  std::vector<uint32_t> xc_lut(ow);
+  for (uint32_t xw = 0; xw < ow; ++xw) {
+    xc_lut[xw] = rx0 + static_cast<uint32_t>(static_cast<uint64_t>(xw) * rw / ow);
+  }
 
   dec.set_row_limit(ry1);
   dec.set_col_range(rx0, rx1);
@@ -310,28 +350,29 @@ int jpip_end_frame_region(void *handle, uint8_t *rgb_out, int out_w, int out_h,
         [&](uint32_t y, int32_t *const *rows, uint16_t nc) {
           if (nc < 3 || widths.empty() || heights.empty()) return;
           if (y < ry0 || y >= ry1) return;
-          const uint32_t cw = widths[0];
           const int32_t shift = (depths.empty() ? 0 : static_cast<int32_t>(depths[0]) - 8);
-          const uint32_t rh = ry1 - ry0;
-          const uint32_t rw = rx1 - rx0;
-          const uint32_t ty = static_cast<uint32_t>(static_cast<uint64_t>(y - ry0) * oh / (rh > 0 ? rh : 1));
+          const int32_t shift_pos = shift > 0 ? shift : 0;  // no-op when bit-depth <= 8
+          const uint32_t ty = static_cast<uint32_t>(static_cast<uint64_t>(y - ry0) * oh / rh);
           if (ty >= oh) return;
           uint8_t *dst = rgb_out + static_cast<size_t>(ty) * ow * 4;
+          const int32_t *__restrict__ r0 = rows[0];
+          const int32_t *__restrict__ r1 = rows[1];
+          const int32_t *__restrict__ r2 = rows[2];
+          const uint32_t *__restrict__ lut = xc_lut.data();
           for (uint32_t xw = 0; xw < ow; ++xw) {
-            const uint32_t xc = rx0 + static_cast<uint32_t>(static_cast<uint64_t>(xw) * rw / (ow > 0 ? ow : 1));
-            if (xc >= cw) break;
-            auto to_u8 = [shift](int32_t v) -> uint8_t {
-              if (shift > 0) v >>= shift;
-              if (v < 0) return 0;
-              if (v > 255) return 255;
-              return static_cast<uint8_t>(v);
-            };
-            dst[4 * xw + 0] = to_u8(rows[0][xc]);
-            dst[4 * xw + 1] = to_u8(rows[1][xc]);
-            dst[4 * xw + 2] = to_u8(rows[2][xc]);
+            const uint32_t xc = lut[xw];
+            int32_t v0 = r0[xc] >> shift_pos;
+            int32_t v1 = r1[xc] >> shift_pos;
+            int32_t v2 = r2[xc] >> shift_pos;
+            if (v0 < 0) v0 = 0; else if (v0 > 255) v0 = 255;
+            if (v1 < 0) v1 = 0; else if (v1 > 255) v1 = 255;
+            if (v2 < 0) v2 = 0; else if (v2 > 255) v2 = 255;
+            dst[4 * xw + 0] = static_cast<uint8_t>(v0);
+            dst[4 * xw + 1] = static_cast<uint8_t>(v1);
+            dst[4 * xw + 2] = static_cast<uint8_t>(v2);
             dst[4 * xw + 3] = 255;
           }
-          const uint32_t ty1_out = static_cast<uint32_t>(static_cast<uint64_t>(y - ry0 + 1) * oh / (rh > 0 ? rh : 1));
+          const uint32_t ty1_out = static_cast<uint32_t>(static_cast<uint64_t>(y - ry0 + 1) * oh / rh);
           for (uint32_t ty2 = ty + 1; ty2 < ty1_out && ty2 < oh; ++ty2)
             std::memcpy(rgb_out + static_cast<size_t>(ty2) * ow * 4, dst, ow * 4);
         },

--- a/subprojects/src/jpip_wrapper.cpp
+++ b/subprojects/src/jpip_wrapper.cpp
@@ -64,6 +64,11 @@ struct JpipContext {
   // decode.  Lets jpip_end_frame*() skip reassembly when nothing changed
   // and the viewer's lastFetchKey guard was bypassed by an upstream resize.
   bool dirty = false;
+  // Grow-only staging buffer for JPIP server responses.  Exposed to JS via
+  // jpip_get_response_buffer() so the viewer and foveation demo can skip
+  // the per-frame _malloc / wasmWrite / _free triplet (3× per foveation
+  // frame) and the repeated WASM heap churn that came with it.
+  std::vector<uint8_t> response_buf;
 };
 
 // Flush the single-tile reuse cache when a parameter that isn't part of the
@@ -153,6 +158,22 @@ void jpip_reset_cache(void *handle) {
   ctx->dec_initialized = false;
   ctx->last_reduce_NL = 0xFF;
   ctx->dirty = false;
+}
+
+// Return a pointer to the context's grow-only response staging buffer,
+// resized to at least `min_size` bytes.  JS is expected to write the
+// next JPIP response body into [ptr, ptr + min_size) and then call
+// jpip_add_response(handle, ptr, actual_len) — no _malloc / _free
+// round-trip per frame.  The returned pointer is stable across calls
+// until a growth forces reallocation; callers MUST call this function
+// (and take its return value) before every write, never cache the
+// pointer across calls.
+EMSCRIPTEN_KEEPALIVE
+uint8_t *jpip_get_response_buffer(void *handle, size_t min_size) {
+  if (!handle) return nullptr;
+  auto *ctx = static_cast<JpipContext *>(handle);
+  if (ctx->response_buf.size() < min_size) ctx->response_buf.resize(min_size);
+  return ctx->response_buf.data();
 }
 
 EMSCRIPTEN_KEEPALIVE

--- a/subprojects/src/jpip_wrapper.cpp
+++ b/subprojects/src/jpip_wrapper.cpp
@@ -290,7 +290,18 @@ int jpip_end_frame_region(void *handle, uint8_t *rgb_out, int out_w, int out_h,
   const uint32_t rx0 = static_cast<uint32_t>(region_x) >> red;
   const uint32_t rx1 = (static_cast<uint32_t>(region_x + region_w) + ((1u << red) - 1)) >> red;
 
-  std::memset(rgb_out, 0, static_cast<size_t>(ow) * oh * 4);
+  // The row callback below writes every output pixel when it fires for
+  // every y in [ry0, ry1) — which it does on the success path.  The
+  // memset is only a safety net for partial-region panning where the
+  // xw<ow loop can early-break on edge columns (xc >= cw).  For the
+  // common full-canvas case (viewer at fit-zoom, initial load) the
+  // entire buffer is overwritten, so skip the O(ow·oh·4) wipe.
+  const bool full_coverage =
+      (region_x == 0 && region_y == 0
+       && static_cast<uint32_t>(region_x + region_w) >= ctx->canvas_w
+       && static_cast<uint32_t>(region_y + region_h) >= ctx->canvas_h);
+  if (!full_coverage)
+    std::memset(rgb_out, 0, static_cast<size_t>(ow) * oh * 4);
 
   dec.set_row_limit(ry1);
   dec.set_col_range(rx0, rx1);


### PR DESCRIPTION
## Summary

Six stacked perf rounds for the JPIP foveation demo and gigapixel viewer.  Each commit is independently reviewable.

| Round | Win |
|---|---|
| 1 — trivial | Server: drop the double `resolve_view_window` call that log lines were paying for.  Viewer: drop zoom jitter from `lastFetchKey`.  WASM: skip the per-frame output memset when the region covers the canvas. |
| 2 — server keys-driven emit | Server emits precincts straight from `resolve_view_window`'s keys instead of hash-probing the full T×C×R×P grid.  Removes the 3× foveation amplification. |
| 3 — client reassembler | `reassemble_codestream_client` buckets delivered precincts by tile once, then walks only touched (r,c) groups with 0x00 run-fill for gaps.  Biggest viewer win on high-precinct assets. |
| 4 — WASM row callback | Hoist the per-pixel `xc` out to a LUT, branchless u8 clamps, `__restrict__` pointers.  Clamps `rx1`/`ry1` to canvas at reduce level so the per-pixel `xc >= cw` guard can go. |
| 5 — heap reuse | `jpip_get_response_buffer` exposes a stable grow-only pointer; foveation demo's 3 `_malloc`/`_free` per gaze move disappear. |
| 6 — cache model | WASM tracks `Hm`/`Ht*`/`M0` via core `CacheModel`; both demos append `&model=` so the server stops re-sending headers every frame.  `jpip_reset_cache` softens to keep headers. |

Explicitly deferred: init-gating (#8 from the original punch list) — risk-reward is unclear without a profiler inside the reuse-cache hit path.

## Test plan

- [x] 613/613 native ctest cases pass after each round
- [x] WASM build (st + mt+SIMD) clean after every WASM-touching round
- [x] `jpip_benchmark` round-trip on the 3,630-precinct `land_shallow_topo_1920_fov.j2c` asset still produces matching bandwidth + speedup numbers
- [ ] CI (GitHub Actions): build + test matrix + WASM demo deploy
- [ ] Manual smoke on the browser demos once deployed — per-pan `fetch` bytes should drop by the header payload after the first frame; periphery must still decay in the foveation demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)