### PR TITLE
fix(ht-decode): clamp layer_length in later-layer append path

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,51 @@
+# [0.15.2] - 2026-04-20
+
+## Security — companion hang on the v0.15.1 security fixture (Windows MSVC only)
+
+The same 231-byte fixture that exercised the v0.15.1 HT-block stack
+overflow also reached a second pathological code path: in
+`j2k_codeblock::create_compressed_buffer`
+(`source/core/coding/coding_units.cpp`), the sum of attacker-
+controlled `block->pass_length[i]` values (`layer_length`) was
+clamped to the bytes remaining in `tile_buf` only on the
+**first-layer** branch.  On any subsequent layer's append path, an
+un-clamped `layer_length` flowed into `buf_chain::copy_N_bytes`,
+whose `assert((pos + N) <= current_length)` precondition can be
+violated by a malformed stream.
+
+Platform asymmetry that hid this under v0.15.1:
+
+* **Linux / macOS release builds** compile with `-DNDEBUG`
+  (`CMakeLists.txt:141`), so `assert()` is a no-op.  The `memcpy`
+  in `copy_N_bytes` silently over-reads the `tile_buf` node;
+  HT-block decoding then rejects the resulting garbage with the
+  existing "cleanup pass suffix length … is invalid" and v0.15.1
+  "too many HT coding-pass segments" warnings and the process
+  exits cleanly in < 5 ms.
+* **Windows MSVC release builds** do not define `NDEBUG`
+  (`CMakeLists.txt:148` sets only `/Ox`), so `assert()` is live.
+  The assertion fires and the CRT invokes `abort()`, which on
+  GitHub Actions Windows runners surfaces as a Windows Error
+  Reporting dialog that waits for user input — producing the
+  "60 s CTest timeout with zero output" symptom on both
+  `windows-latest` (x86-64) and `windows-11-arm`.
+
+Fix: hoist the `layer_length > tile_buf->get_remaining_bytes()`
+clamp to the top of `create_compressed_buffer`, so it applies to
+both the first-layer zero-copy path and the subsequent-layer
+owned-buffer append path.  A `WARNING` printf matching the
+v0.15.1 wording pattern is emitted so the malformed-input
+rejection is observable in logs.  Platform-agnostic; no `#ifdef`
+involved.
+
+With the fix, the v0.15.1 regression fixture
+(`tests/data/security_ht_segments_overflow.j2k`) completes in
+~4 ms on Windows — the three downstream HT-block warnings fire,
+exit code is 0, and the previously-skipped
+`security_ht_segments_overflow` CTest case (un-skipped in
+`tests/security_regressions.cmake`) passes on Windows alongside
+Linux and macOS.  Full conformance suite remains green.
+
 # [0.15.1] - 2026-04-20
 
 ## Security

--- a/source/core/coding/coding_units.cpp
+++ b/source/core/coding/coding_units.cpp
@@ -864,6 +864,21 @@ void j2k_codeblock::create_compressed_buffer(buf_chain *tile_buf, int32_t buf_li
     layer_length += this->pass_length[static_cast<size_t>(i)];
   }
 
+  // Clamp layer_length to bytes remaining in the tile-part codestream.
+  // The packet-header-decoded pass_length[] is attacker-controllable on
+  // malformed inputs; without this clamp, a later copy_N_bytes/borrow_N_bytes
+  // call can read past the end of the tile_buf node (UB on Linux release
+  // where asserts are compiled out, or a CRT abort on Windows MSVC release
+  // where asserts remain enabled).
+  {
+    const uint32_t avail = tile_buf->get_remaining_bytes();
+    if (layer_length > avail) {
+      printf("WARNING: codeblock layer length %u exceeds %u remaining bytes — malformed input.\n",
+             (unsigned)layer_length, (unsigned)avail);
+      layer_length = avail;
+    }
+  }
+
   if (this->compressed_data == nullptr) {
     // First contributing layer for this codeblock.
     if (layer_length == 0) {
@@ -873,14 +888,6 @@ void j2k_codeblock::create_compressed_buffer(buf_chain *tile_buf, int32_t buf_li
       this->current_address = this->compressed_data;
     } else {
       // Zero-copy: borrow a direct pointer into the codestream buffer.
-      // Clamp layer_length to available data for truncated codestreams.
-      const uint32_t avail = tile_buf->get_remaining_bytes();
-      if (layer_length > avail) {
-        layer_length = avail;
-      }
-      if (layer_length == 0) {
-        return;
-      }
       // The codestream buffer outlives all codeblocks, and all decoders
       // (HT fwd/rev/MEL, and MQ) treat compressed_data as read-only.
       // compressed_is_pooled = true suppresses free() in the destructor.

--- a/tests/security_regressions.cmake
+++ b/tests/security_regressions.cmake
@@ -30,23 +30,11 @@ set(_SEC_CRASH_RE
 # code, so we can't rely on WILL_FAIL.  Instead, require that the
 # specific guard printf from the patched code path fires (proof the
 # bounds check is in effect) and reject any crash-marker text.
-#
-# WIN32 skip: on the MSVC Windows CI runners (both x86_64 and ARM64)
-# the decoder hangs on this fixture before ever reaching the HT
-# codeblock code the fix patches — no output is produced inside a
-# 60 s timeout, despite Linux + macOS + WASM completing in <5 ms.
-# That's a separate pre-existing pathological-input hang in the
-# decoder, not caused by the guard we're regression-testing.  Left
-# out here so the security patch isn't held; tracked for a follow-up
-# release.  Coverage on Linux + macOS (both SIMD and scalar) is
-# sufficient to prove the guard fires.
-if(NOT WIN32)
-  add_test(NAME security_ht_segments_overflow
-           COMMAND open_htj2k_dec
-                   -i ${SECURITY_DATA_DIR}/security_ht_segments_overflow.j2k
-                   -o security_ht_segments_overflow.pgx)
-  set_tests_properties(security_ht_segments_overflow PROPERTIES
-      PASS_REGULAR_EXPRESSION "too many HT coding-pass segments"
-      FAIL_REGULAR_EXPRESSION "${_SEC_CRASH_RE}"
-      TIMEOUT 60)
-endif()
+add_test(NAME security_ht_segments_overflow
+         COMMAND open_htj2k_dec
+                 -i ${SECURITY_DATA_DIR}/security_ht_segments_overflow.j2k
+                 -o security_ht_segments_overflow.pgx)
+set_tests_properties(security_ht_segments_overflow PROPERTIES
+    PASS_REGULAR_EXPRESSION "too many HT coding-pass segments"
+    FAIL_REGULAR_EXPRESSION "${_SEC_CRASH_RE}"
+    TIMEOUT 60)


### PR DESCRIPTION
## Summary

- Fixes the **Windows-only 60 s CTest hang** on the v0.15.1 security fixture (`tests/data/security_ht_segments_overflow.j2k`). Root cause: `j2k_codeblock::create_compressed_buffer` clamped `layer_length` (sum of attacker-controlled `pass_length[i]` values) to the tile-buf's remaining bytes only on the first-layer branch. On any subsequent layer's append path, the un-clamped value reached `buf_chain::copy_N_bytes`, whose `assert((pos + N) <= current_length)` precondition the malformed stream violates.
- Platform asymmetry that hid this under #199: Linux/macOS Release defines `-DNDEBUG` so `assert()` is compiled out and the decoder silently over-reads then rejects the garbage at the HT-block layer (<5 ms, exit 0). Windows MSVC Release does **not** define `NDEBUG` (only `/Ox`), so `assert()` is live → CRT `abort()` → on GitHub Actions this surfaces as a Windows Error Reporting dialog, producing the reported "60 s timeout with zero output" on both `windows-latest` and `windows-11-arm`.
- Fix hoists the existing `layer_length > tile_buf->get_remaining_bytes()` clamp to the top of `create_compressed_buffer` so both paths share it, with a v0.15.1-style `WARNING: codeblock layer length N exceeds M remaining bytes — malformed input.` print. Platform-agnostic; no `#ifdef`. Un-skips the `security_ht_segments_overflow` CTest case on Windows.

## Test plan

- [x] Full CI green on `ubuntu-latest`, `ubuntu-24.04-arm`, `macos-latest`, `macos-15-intel`, `windows-latest`, `windows-11-arm` — especially `security_ht_segments_overflow` passing on the two Windows jobs that previously timed out.
- [x] Local Windows repro verified: fixture now completes in ~4 ms / exit 0 with all four expected warnings firing (the new guard + the three downstream HT-block warnings matching Linux).
- [x] Local `ctest -C Release` (447 tests, sequential) all pass on Windows (MSVC 17.14); no regression on any valid codestream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)