### PR TITLE
refactor(decoder): add pull_strip_into_buf overload with caller dst

### DIFF
--- a/source/core/coding/coding_units.cpp
+++ b/source/core/coding/coding_units.cpp
@@ -2451,9 +2451,14 @@ sprec_t *j2k_tile_component::pull_strip_into_buf(uint32_t count, uint32_t stride
     ld->strip_buf_floats = needed;
   }
 
-  if (count == 0) return ld->strip_buf;
+  return pull_strip_into_buf(count, stride_floats, ld->strip_buf);
+}
 
-  sprec_t *dst = ld->strip_buf;
+sprec_t *j2k_tile_component::pull_strip_into_buf(uint32_t count, uint32_t stride_floats,
+                                                 sprec_t *dst) {
+  if (line_dec == nullptr || dst == nullptr) return nullptr;
+  if (count == 0) return dst;
+
   for (uint32_t r = 0; r < count; ++r) {
     const sprec_t *src = pull_line_ref();
     if (src == nullptr) {
@@ -2467,7 +2472,7 @@ sprec_t *j2k_tile_component::pull_strip_into_buf(uint32_t count, uint32_t stride
     std::memcpy(dst + static_cast<size_t>(r) * stride_floats, src,
                 sizeof(sprec_t) * stride_floats);
   }
-  return ld->strip_buf;
+  return dst;
 }
 
 void j2k_tile_component::finalize_line_decode() {

--- a/source/core/coding/coding_units.hpp
+++ b/source/core/coding/coding_units.hpp
@@ -575,6 +575,13 @@ class j2k_tile_component : public j2k_tile_base {
   // copy is necessary because idwt_2d_state's ring is too shallow to keep a
   // whole outer strip pinned.
   sprec_t *pull_strip_into_buf(uint32_t count, uint32_t stride_floats);
+  // Overload that writes into a caller-owned destination instead of the
+  // per-component line_dec->strip_buf.  Used by the pipelined strip driver in
+  // decode_line_based_stream_planar to hold two strips in flight
+  // simultaneously (one being read by Phase 2, one being written by Phase 1's
+  // pool tasks).  Caller guarantees dst has capacity >= count * stride_floats
+  // sprec_t elements and 32-byte alignment.
+  sprec_t *pull_strip_into_buf(uint32_t count, uint32_t stride_floats, sprec_t *dst);
   void finalize_line_decode();
   // Mark all subband row bufs in line_dec as bypass (for pre-decoded diagnostic).
   void mark_line_dec_predecoded();


### PR DESCRIPTION
## Summary

- Adds an overload `pull_strip_into_buf(count, stride, sprec_t* dst)` that writes into a caller-owned destination instead of the per-component `line_dec->strip_buf`. The existing single-arg signature is preserved and now delegates to the new overload.
- No behavior change for any existing caller. Conformance suite byte-identical; 447/447 tests green on Windows MSVC Release, and the Spark 4K Y/Cb/Cr planes are byte-identical to the `origin/main` decode.
- This is preparatory refactoring for a planned double-buffered strip pipeline in `decode_line_based_stream_planar` that needs two strip-scratch slots in flight simultaneously.

## Background

VTune hotspot profiling of `open_htj2k_rtp_decode_profile` on a 4K 4:2:2 HT 1.7 bpp fixture (Spark, 150×3 frames) showed **33.7% of CPU time in `SleepConditionVariableSRW`** — thread-pool workers idle waiting for work. The plan to close that gap was to pipeline strip N+1's Phase 1 (per-component `pull_strip_into_buf`) against strip N's Phase 2 (finalize + plane write) in `decode_line_based_stream_planar`.

A prototype of the pipelined driver was written on this branch and then dropped. **Empirically it regressed wall-clock by ~80% at 4 threads (33.9 ms → 61.5 ms per frame)** on an Alder Lake-P XPS13, while improving 2-thread runs by ~20%. Root cause: removing the main thread from the `dec_strip_barrier_wait` / `try_run_one` drain loop during Phase 2 strips one "worker-equivalent" off the nested codeblock dispatch. On a 4-worker hybrid-core pool that help is load-bearing — without it, e-core workers become the long pole. A future attempt will need to keep main-thread draining active (e.g., by interleaving `try_run_one` calls into the finalize inner loop) or by splitting Phase 2 across workers rather than running it serially on main.

Shipping only the refactor piece so the overload is available for that next attempt, with no behavior change in the meantime.

## Test plan

- [x] `ctest -C Release` on Windows MSVC 17.14 — 447/447 passed sequentially.
- [x] Byte-equality: `cmp` of decoded PGX planes for `u10_part15_lossless.j2c` and a Spark 4K frame against `origin/main` — identical.
- [x] Full CI matrix (Ubuntu gcc/clang, Ubuntu-ARM, macOS Intel/Apple Silicon, Windows x86-64/ARM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)