### PR TITLE
experiment: no brace wrap (DO NOT MERGE)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,19 @@ if (NOT EMSCRIPTEN)
   endif()
 endif()
 
+# ── Decode-path per-stage timing instrumentation ────────────────────────────
+# Attaches lightweight wall-clock counters around parse / block-decode / IDWT /
+# color-transform / finalize, and per-worker idle/work counters in the thread
+# pool.  Default OFF — macros compile out to (void)0 so instrumented and stock
+# builds are binary-identical in the hot path.  Enable with
+#   -DOPENHTJ2K_DECODE_TIMING=ON
+# to drive a DecodeTimingReport through openhtj2k_decoder::set_timing_sink().
+option(OPENHTJ2K_DECODE_TIMING "Enable per-stage decode timing counters (default OFF)" OFF)
+if(OPENHTJ2K_DECODE_TIMING)
+  target_compile_definitions(open_htj2k PUBLIC "OPENHTJ2K_DECODE_TIMING")
+  message(STATUS "OPENHTJ2K_DECODE_TIMING is set")
+endif()
+
 # ── QUIC / HTTP/3 support (Phase 5) ─────────────────────────────────────────
 # Requires MsQuic (QUIC transport) and nghttp3 (HTTP/3 framing).
 # On macOS: brew install libmsquic libnghttp3

--- a/source/apps/decoder/main_dec.cpp
+++ b/source/apps/decoder/main_dec.cpp
@@ -32,6 +32,7 @@
 // (c) 2019 - 2021 Osamu Watanabe, Takushoku University, Vrije Universiteit Brussels
 
 #include <chrono>
+#include <cinttypes>
 #include <cstdint>
 #include <cstdio>
 #include <memory>
@@ -456,6 +457,9 @@ void print_help(char *cmd) {
   printf("-num_threads n: Number of threads (0 = auto).\n");
   printf("-batch: Use batch (full-image buffer) decode path instead of the default streaming path.\n");
   printf("-ycbcr bt601|bt709: [EXPERIMENTAL] Convert YCbCr to RGB (PPM output only).\n");
+  printf("--timing: Print per-stage decode timing to stderr.  Requires a build with\n");
+  printf("          -DOPENHTJ2K_DECODE_TIMING=ON and -batch (streaming-path timing\n");
+  printf("          is a follow-up).  Without the build flag, counters report zero.\n");
 }
 
 int main(int argc, char *argv[]) {
@@ -544,7 +548,7 @@ int main(int argc, char *argv[]) {
   // Reject any unrecognised flags.
   {
     static const char *const known[] = {
-        "-h", "-i", "-o", "-reduce", "-iter", "-num_threads", "-batch", "-ycbcr", nullptr};
+        "-h", "-i", "-o", "-reduce", "-iter", "-num_threads", "-batch", "-ycbcr", "--timing", nullptr};
     for (int i = 1; i < argc; ++i) {
       if (argv[i][0] != '-') continue;
       bool recognised = false;
@@ -610,6 +614,29 @@ int main(int argc, char *argv[]) {
   }
 
   const bool use_batch = command_option_exists(argc, argv, "-batch");
+  const bool want_timing = command_option_exists(argc, argv, "--timing");
+  if (want_timing && !use_batch) {
+    fprintf(stderr,
+            "WARNING: --timing only populates in batch mode; streaming-path timing\n"
+            "         is a follow-up.  Add -batch to see per-stage counters.\n");
+  }
+  // Per-stage accumulator across all iterations.  The library sink fires once
+  // per parse() and once per invoke(), so we sum them here for the aggregate
+  // report at exit.  pool_wait/work counters come in already-diffed across
+  // each call, so summing is meaningful.
+  open_htj2k::DecodeTimingReport timing_total{};
+  uint32_t timing_pool_workers_last = 0;
+  uint64_t timing_num_reports       = 0;
+  auto timing_sink = [&](const open_htj2k::DecodeTimingReport &r) {
+    for (unsigned i = 0; i < static_cast<unsigned>(open_htj2k::DecodeStage::kCount); ++i) {
+      timing_total.stage_ns[i] += r.stage_ns[i];
+      timing_total.stage_count[i] += r.stage_count[i];
+    }
+    timing_total.pool_wait_ns += r.pool_wait_ns;
+    timing_total.pool_work_ns += r.pool_work_ns;
+    timing_pool_workers_last = r.pool_workers;
+    ++timing_num_reports;
+  };
 
   std::vector<uint32_t> img_width;
   std::vector<uint32_t> img_height;
@@ -630,6 +657,7 @@ int main(int argc, char *argv[]) {
       img_signed.clear();
       try {
         open_htj2k::openhtj2k_decoder decoder(infile_name, reduce_NL, num_threads);
+        if (want_timing) decoder.set_timing_sink(timing_sink);
         decoder.parse();
         decoder.invoke(buf, img_width, img_height, img_depth, img_signed);
       } catch (std::exception &exc) {
@@ -660,6 +688,27 @@ int main(int argc, char *argv[]) {
            total_samples * static_cast<double>(num_iterations) / static_cast<double>(count));
     printf("throughput %lf [usec/sample]\n",
            static_cast<double>(count) / static_cast<double>(num_iterations) / total_samples);
+    if (want_timing) {
+      double denom = static_cast<double>(num_iterations);
+      if (denom < 1.0) denom = 1.0;
+      fprintf(stderr, "\n--- decode timing (averaged over %d iter, %" PRIu64 " reports) ---\n",
+              num_iterations, timing_num_reports);
+      for (unsigned i = 0; i < static_cast<unsigned>(open_htj2k::DecodeStage::kCount); ++i) {
+        const auto s = static_cast<open_htj2k::DecodeStage>(i);
+        fprintf(stderr, "  %-18s %10.3f ms  (%" PRIu64 " calls total)\n",
+                open_htj2k::decode_stage_name(s),
+                static_cast<double>(timing_total.stage_ns[i]) / 1e6 / denom,
+                timing_total.stage_count[i]);
+      }
+      fprintf(stderr, "  %-18s %10.3f ms\n  %-18s %10.3f ms  (%u workers)\n",
+              "pool_wait_ns (sum)", static_cast<double>(timing_total.pool_wait_ns) / 1e6 / denom,
+              "pool_work_ns (sum)", static_cast<double>(timing_total.pool_work_ns) / 1e6 / denom,
+              timing_pool_workers_last);
+#ifndef OPENHTJ2K_DECODE_TIMING
+      fprintf(stderr,
+              "  (all counters are zero — build with -DOPENHTJ2K_DECODE_TIMING=ON)\n");
+#endif
+    }
     return EXIT_SUCCESS;
   }
 

--- a/source/core/coding/coding_units.cpp
+++ b/source/core/coding/coding_units.cpp
@@ -4085,8 +4085,7 @@ void j2k_tile::decode() {
   auto pool = ThreadPool::get();
   // std::vector<std::future<int>> results;
 #endif
-  {
-    OPENHTJ2K_TIME_SCOPE(BlockDecode);
+  OPENHTJ2K_TIME_SCOPE(BlockDecode);
   for (uint16_t c = 0; c < num_components; c++) {
     const uint8_t ROIshift = this->tcomp[c].get_ROIshift();
     const uint8_t NL       = this->tcomp[c].get_dwt_levels();
@@ -4228,7 +4227,6 @@ void j2k_tile::decode() {
     aligned_mem_free(buf_for_states);
     aligned_mem_free(buf_for_samples);
   }
-  }  // end BlockDecode scope
 
   OPENHTJ2K_TIME_SCOPE(IDWT);
   for (uint16_t c = 0; c < num_components; c++) {

--- a/source/core/coding/coding_units.cpp
+++ b/source/core/coding/coding_units.cpp
@@ -36,6 +36,7 @@
 #endif
 #include "coding_units.hpp"
 #include "block_decoding.hpp"
+#include "decode_timing.hpp"
 #include "dwt.hpp"
 #include "color.hpp"
 #include "finalize_narrow.hpp"
@@ -4084,6 +4085,8 @@ void j2k_tile::decode() {
   auto pool = ThreadPool::get();
   // std::vector<std::future<int>> results;
 #endif
+  {
+    OPENHTJ2K_TIME_SCOPE(BlockDecode);
   for (uint16_t c = 0; c < num_components; c++) {
     const uint8_t ROIshift = this->tcomp[c].get_ROIshift();
     const uint8_t NL       = this->tcomp[c].get_dwt_levels();
@@ -4225,7 +4228,9 @@ void j2k_tile::decode() {
     aligned_mem_free(buf_for_states);
     aligned_mem_free(buf_for_samples);
   }
+  }  // end BlockDecode scope
 
+  OPENHTJ2K_TIME_SCOPE(IDWT);
   for (uint16_t c = 0; c < num_components; c++) {
     // const uint8_t ROIshift       = this->tcomp[c].get_ROIshift();
     const uint8_t NL             = this->tcomp[c].get_dwt_levels();

--- a/source/core/common/ThreadPool.hpp
+++ b/source/core/common/ThreadPool.hpp
@@ -41,6 +41,10 @@
   #include <type_traits>
   #include <unordered_map>
 
+  #ifdef OPENHTJ2K_DECODE_TIMING
+    #include <chrono>
+  #endif
+
 // Thread-local flag: true when the current thread is running inside the pool worker loop.
 // Set once in worker() — avoids the hash-map lookup in decode_strip_core's in_worker check.
 inline thread_local bool g_in_worker_thread = false;
@@ -129,8 +133,16 @@ class ThreadPool {
       : stop(false), ring_head_(0), ring_tail_(0), thread_count_(thread_count) {
     ring_ = std::unique_ptr<InlineTask[]>(new InlineTask[RING_CAP]);
     threads = std::make_unique<std::thread[]>(thread_count_);
+  #ifdef OPENHTJ2K_DECODE_TIMING
+    wait_ns_ = std::unique_ptr<std::atomic<uint64_t>[]>(new std::atomic<uint64_t>[thread_count_]);
+    work_ns_ = std::unique_ptr<std::atomic<uint64_t>[]>(new std::atomic<uint64_t>[thread_count_]);
     for (size_t i = 0; i < thread_count_; ++i) {
-      threads[i] = std::thread(&ThreadPool::worker, this);
+      wait_ns_[i].store(0, std::memory_order_relaxed);
+      work_ns_[i].store(0, std::memory_order_relaxed);
+    }
+  #endif
+    for (size_t i = 0; i < thread_count_; ++i) {
+      threads[i] = std::thread(&ThreadPool::worker, this, i);
     }
   }
 
@@ -163,6 +175,22 @@ class ThreadPool {
   // Returns true when called from inside a pool worker thread.
   // Uses a thread-local flag set in worker() — no hash map lookup.
   static bool is_worker_thread() { return g_in_worker_thread; }
+
+  #ifdef OPENHTJ2K_DECODE_TIMING
+  // Sum of wall-clock ns each worker thread has spent blocked on the
+  // task-queue condvar (wait_ns) and executing tasks (work_ns), summed
+  // across all workers in this pool.  Lifetime counters — the caller
+  // is expected to snapshot at a known point and diff later.
+  void get_timing_counters(uint64_t &wait_ns, uint64_t &work_ns) const {
+    uint64_t w = 0, k = 0;
+    for (size_t i = 0; i < thread_count_; ++i) {
+      w += wait_ns_[i].load(std::memory_order_relaxed);
+      k += work_ns_[i].load(std::memory_order_relaxed);
+    }
+    wait_ns = w;
+    work_ns = k;
+  }
+  #endif
 
   #if ((defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L)
   /**
@@ -329,16 +357,28 @@ class ThreadPool {
    *  Continuously pops tasks out of the queue and executes them, as long as the atomic variable running is
    * set to true.
    */
-  void worker() {
+  void worker(size_t worker_idx) {
     g_in_worker_thread = true;
     InlineTask batch[BATCH];
+    (void)worker_idx;  // unused unless OPENHTJ2K_DECODE_TIMING
 
     for (;;) {
       size_t n = 0;
 
       {
         std::unique_lock<std::mutex> lock(tasks_mutex);
+  #ifdef OPENHTJ2K_DECODE_TIMING
+        const auto t_wait_begin = std::chrono::steady_clock::now();
+  #endif
         condition.wait(lock, [&] { return !ring_empty_() || stop; });
+  #ifdef OPENHTJ2K_DECODE_TIMING
+        const auto t_wait_end = std::chrono::steady_clock::now();
+        wait_ns_[worker_idx].fetch_add(
+            static_cast<uint64_t>(
+                std::chrono::duration_cast<std::chrono::nanoseconds>(t_wait_end - t_wait_begin)
+                    .count()),
+            std::memory_order_relaxed);
+  #endif
 
         if (stop && ring_empty_()) {
           return;
@@ -351,9 +391,20 @@ class ThreadPool {
         }
       }
 
+  #ifdef OPENHTJ2K_DECODE_TIMING
+      const auto t_work_begin = std::chrono::steady_clock::now();
+  #endif
       for (size_t i = 0; i < n; ++i) {
         batch[i]();
       }
+  #ifdef OPENHTJ2K_DECODE_TIMING
+      const auto t_work_end = std::chrono::steady_clock::now();
+      work_ns_[worker_idx].fetch_add(
+          static_cast<uint64_t>(
+              std::chrono::duration_cast<std::chrono::nanoseconds>(t_work_end - t_work_begin)
+                  .count()),
+          std::memory_order_relaxed);
+  #endif
     }
   }
 
@@ -401,6 +452,14 @@ class ThreadPool {
    * @brief A condition variable used to notify worker threads of state changes.
    */
   std::condition_variable condition;
+
+  #ifdef OPENHTJ2K_DECODE_TIMING
+  // Per-worker lifetime counters of time spent blocked on the condvar vs
+  // executing tasks.  One atomic per worker avoids cross-worker cache-line
+  // contention on the hot path.  Only allocated when timing is enabled.
+  std::unique_ptr<std::atomic<uint64_t>[]> wait_ns_;
+  std::unique_ptr<std::atomic<uint64_t>[]> work_ns_;
+  #endif
 
   /**
    * @brief An atomic singleton for the instance (lock-free read via get()).

--- a/source/core/common/decode_timing.hpp
+++ b/source/core/common/decode_timing.hpp
@@ -1,0 +1,133 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Internal timing infrastructure for decode-path instrumentation.
+//
+// When compiled with -DOPENHTJ2K_DECODE_TIMING=ON, an accumulator is
+// attached to each decoder_impl for the duration of a public call.
+// Scope macros sprinkled through the decode pipeline accumulate wall
+// clock into that accumulator via a thread-local pointer.  At the end
+// of the public call, the impl emits a DecodeTimingReport to the
+// registered sink.
+//
+// When the macro is undefined, every scope expands to (void)0 and all
+// instrumentation vanishes.  No atomic ops, no chrono calls, no
+// per-stage branching — zero measurable overhead in normal Release
+// builds.
+
+#pragma once
+
+#include "decode_timing_report.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+
+namespace open_htj2k {
+namespace internal {
+
+class DecodeTimingAccumulator {
+ public:
+  DecodeTimingAccumulator() { reset(); }
+
+  void add(DecodeStage s, uint64_t ns) {
+    const auto i = static_cast<unsigned>(s);
+    stage_ns_[i].fetch_add(ns, std::memory_order_relaxed);
+    stage_count_[i].fetch_add(1, std::memory_order_relaxed);
+  }
+
+  void reset() {
+    for (unsigned i = 0; i < static_cast<unsigned>(DecodeStage::kCount); ++i) {
+      stage_ns_[i].store(0, std::memory_order_relaxed);
+      stage_count_[i].store(0, std::memory_order_relaxed);
+    }
+  }
+
+  DecodeTimingReport snapshot() const {
+    DecodeTimingReport r;
+    for (unsigned i = 0; i < static_cast<unsigned>(DecodeStage::kCount); ++i) {
+      r.stage_ns[i]    = stage_ns_[i].load(std::memory_order_relaxed);
+      r.stage_count[i] = stage_count_[i].load(std::memory_order_relaxed);
+    }
+    return r;
+  }
+
+ private:
+  std::atomic<uint64_t> stage_ns_[static_cast<unsigned>(DecodeStage::kCount)];
+  std::atomic<uint64_t> stage_count_[static_cast<unsigned>(DecodeStage::kCount)];
+};
+
+// Thread-local pointer set by the decoder_impl for the duration of a
+// public call.  Phase scopes read this; workers don't — worker-thread
+// accounting lives in the ThreadPool counters instead.
+inline thread_local DecodeTimingAccumulator *g_decode_accumulator = nullptr;
+
+// RAII scope: samples steady_clock on construction and destruction;
+// adds the elapsed ns to the current thread-local accumulator if one
+// is attached.  Safe to construct when no accumulator is attached —
+// becomes a pair of steady_clock reads with no storage effect.
+class DecodeTimingScope {
+ public:
+  DecodeTimingScope(DecodeStage s) noexcept : stage_(s) {
+    if (g_decode_accumulator) {
+      t0_ = std::chrono::steady_clock::now();
+    }
+  }
+  ~DecodeTimingScope() {
+    if (g_decode_accumulator) {
+      const auto t1 = std::chrono::steady_clock::now();
+      const auto ns =
+          std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0_).count();
+      g_decode_accumulator->add(stage_, static_cast<uint64_t>(ns));
+    }
+  }
+  DecodeTimingScope(const DecodeTimingScope &)            = delete;
+  DecodeTimingScope &operator=(const DecodeTimingScope &) = delete;
+
+ private:
+  DecodeStage stage_;
+  std::chrono::steady_clock::time_point t0_;
+};
+
+// RAII attach/detach for the thread-local accumulator.  Use at the
+// top of parse() / invoke*() in decoder_impl.
+class DecodeTimingAttach {
+ public:
+  explicit DecodeTimingAttach(DecodeTimingAccumulator *a) noexcept : prev_(g_decode_accumulator) {
+    g_decode_accumulator = a;
+  }
+  ~DecodeTimingAttach() { g_decode_accumulator = prev_; }
+  DecodeTimingAttach(const DecodeTimingAttach &)            = delete;
+  DecodeTimingAttach &operator=(const DecodeTimingAttach &) = delete;
+
+ private:
+  DecodeTimingAccumulator *prev_;
+};
+
+}  // namespace internal
+}  // namespace open_htj2k
+
+// ─── Scope macros ───────────────────────────────────────────────────────────
+// OPENHTJ2K_TIME_SCOPE(Parse)         — expands to an RAII scope covering
+//                                        the remainder of the enclosing block
+// OPENHTJ2K_TIME_ATTACH(acc_ptr)      — attach an accumulator for the remainder
+//                                        of the enclosing block (decoder_impl use)
+//
+// Concatenation of __LINE__ ensures multiple scopes within the same function
+// get distinct variable names.
+
+#ifdef OPENHTJ2K_DECODE_TIMING
+  #define OPENHTJ2K_TIMING_CONCAT_(a, b) a##b
+  #define OPENHTJ2K_TIMING_CONCAT(a, b)  OPENHTJ2K_TIMING_CONCAT_(a, b)
+  #define OPENHTJ2K_TIME_SCOPE(stage)                                            \
+    ::open_htj2k::internal::DecodeTimingScope OPENHTJ2K_TIMING_CONCAT(           \
+        _ohtj2k_tscope_, __LINE__)(::open_htj2k::DecodeStage::stage)
+  #define OPENHTJ2K_TIME_ATTACH(acc_ptr)                                         \
+    ::open_htj2k::internal::DecodeTimingAttach OPENHTJ2K_TIMING_CONCAT(          \
+        _ohtj2k_tattach_, __LINE__)(acc_ptr)
+#else
+  #define OPENHTJ2K_TIME_SCOPE(stage)    ((void)0)
+  #define OPENHTJ2K_TIME_ATTACH(acc_ptr) ((void)0)
+#endif

--- a/source/core/common/decode_timing_report.hpp
+++ b/source/core/common/decode_timing_report.hpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Public report struct produced by the decoder's per-stage timing
+// instrumentation.  Populated only in builds compiled with
+// -DOPENHTJ2K_DECODE_TIMING=ON; otherwise the callback is never invoked
+// and all counters stay zero.
+
+#pragma once
+
+#include <cstdint>
+
+namespace open_htj2k {
+
+enum class DecodeStage : unsigned {
+  Parse          = 0,
+  BlockDecode    = 1,
+  IDWT           = 2,
+  ColorTransform = 3,
+  Finalize       = 4,
+  kCount         = 5,
+};
+
+inline const char *decode_stage_name(DecodeStage s) {
+  switch (s) {
+    case DecodeStage::Parse:          return "parse";
+    case DecodeStage::BlockDecode:    return "block_decode";
+    case DecodeStage::IDWT:           return "idwt";
+    case DecodeStage::ColorTransform: return "color_transform";
+    case DecodeStage::Finalize:       return "finalize";
+    default:                          return "?";
+  }
+}
+
+// Wall-clock nanoseconds summed across invocations of each stage over the
+// lifetime of a single public decode call (parse() or invoke*()).  The
+// report is emitted exactly once per call via the registered sink.
+//
+// pool_wait_ns / pool_work_ns are aggregated across all worker threads in
+// the shared pool, not just the ones touched by this decode call — they
+// are process-lifetime counters and only meaningful when diffed between
+// the start and end of a given decode, or when the caller controls pool
+// usage (e.g. a single decode at a time with no background work).
+struct DecodeTimingReport {
+  uint64_t stage_ns[static_cast<unsigned>(DecodeStage::kCount)]    = {0, 0, 0, 0, 0};
+  uint64_t stage_count[static_cast<unsigned>(DecodeStage::kCount)] = {0, 0, 0, 0, 0};
+
+  // Pool-wide worker-thread accounting.  Sums wall-clock ns each worker
+  // spent blocked on the task-queue condvar vs executing tasks.  When
+  // timing is disabled at compile time these stay zero.
+  uint64_t pool_wait_ns = 0;
+  uint64_t pool_work_ns = 0;
+  uint32_t pool_workers = 0;
+};
+
+}  // namespace open_htj2k

--- a/source/core/interface/decoder.cpp
+++ b/source/core/interface/decoder.cpp
@@ -50,6 +50,7 @@
   #include <sys/stat.h>
 #endif
 #include "coding_units.hpp"
+#include "decode_timing.hpp"
 #include "ThreadPool.hpp"
 #ifdef _OPENMP
   #include <omp.h>
@@ -90,6 +91,18 @@ class openhtj2k_decoder_impl {
   // each tile's tile_buf.  Empty std::function means "do not observe".
   std::function<void(uint16_t, uint16_t, uint8_t, uint32_t, uint16_t, uint64_t, uint64_t)>
       packet_observer_;
+
+  // Per-stage decode timing.  Accumulator is present in every build so the
+  // sink lifecycle is consistent; the scope macros are no-ops when the
+  // OPENHTJ2K_DECODE_TIMING macro is undefined, so no counters are written.
+  internal::DecodeTimingAccumulator timing_acc_;
+  std::function<void(const DecodeTimingReport &)> timing_sink_;
+
+  // Snapshot + emit the current accumulator state through the registered
+  // sink, then reset counters for the next public call.  Includes pool
+  // worker idle/work counters (diffed across the call).  No-op when no
+  // sink is installed.
+  void emit_timing_report(uint64_t pool_wait_base, uint64_t pool_work_base, uint32_t pool_workers);
 
  public:
   openhtj2k_decoder_impl();
@@ -133,6 +146,9 @@ class openhtj2k_decoder_impl {
   void set_precinct_filter(std::function<bool(uint16_t, uint16_t, uint8_t, uint32_t)> f);
   void set_packet_observer(
       std::function<void(uint16_t, uint16_t, uint8_t, uint32_t, uint16_t, uint64_t, uint64_t)> f);
+  void set_timing_sink(std::function<void(const DecodeTimingReport &)> f) {
+    timing_sink_ = std::move(f);
+  }
 
   // Binds precinct_filter_'s (t, c, r, p_rc) signature into a (c, r, p_rc)
   // closure for the given tile and installs it on the tile (or clears it
@@ -274,10 +290,44 @@ void openhtj2k_decoder_impl::parse() {
         "openhtj2k_decoder_impl::parse().\n");
     throw std::exception();
   }
-  // Read main header
-  main_header.read(in);
-  in.rewind_2bytes();
-  is_parsed = true;
+  timing_acc_.reset();
+  OPENHTJ2K_TIME_ATTACH(&timing_acc_);
+  uint64_t pool_wait_base = 0, pool_work_base = 0;
+  uint32_t pool_workers = 0;
+#if defined(OPENHTJ2K_THREAD) && defined(OPENHTJ2K_DECODE_TIMING)
+  if (auto *pool = ThreadPool::get()) {
+    pool_workers = static_cast<uint32_t>(pool->num_threads());
+    pool->get_timing_counters(pool_wait_base, pool_work_base);
+  }
+#endif
+  {
+    OPENHTJ2K_TIME_SCOPE(Parse);
+    // Read main header
+    main_header.read(in);
+    in.rewind_2bytes();
+    is_parsed = true;
+  }
+  emit_timing_report(pool_wait_base, pool_work_base, pool_workers);
+}
+
+void openhtj2k_decoder_impl::emit_timing_report(uint64_t pool_wait_base, uint64_t pool_work_base,
+                                                uint32_t pool_workers) {
+  if (!timing_sink_) return;
+  DecodeTimingReport r = timing_acc_.snapshot();
+#if defined(OPENHTJ2K_THREAD) && defined(OPENHTJ2K_DECODE_TIMING)
+  if (auto *pool = ThreadPool::get()) {
+    uint64_t w = 0, k = 0;
+    pool->get_timing_counters(w, k);
+    r.pool_wait_ns = (w >= pool_wait_base) ? (w - pool_wait_base) : 0;
+    r.pool_work_ns = (k >= pool_work_base) ? (k - pool_work_base) : 0;
+    r.pool_workers = pool_workers;
+  }
+#else
+  (void)pool_wait_base;
+  (void)pool_work_base;
+  (void)pool_workers;
+#endif
+  timing_sink_(r);
 }
 
 uint16_t openhtj2k_decoder_impl::get_num_component() const { return main_header.SIZ->get_num_components(); }
@@ -358,6 +408,16 @@ void openhtj2k_decoder_impl::invoke(std::vector<int32_t *> &buf, std::vector<uin
         "openhtj2k_decoder_impl::invoke().\n");
     throw std::exception();
   }
+  timing_acc_.reset();
+  OPENHTJ2K_TIME_ATTACH(&timing_acc_);
+  uint64_t pool_wait_base = 0, pool_work_base = 0;
+  uint32_t pool_workers = 0;
+#if defined(OPENHTJ2K_THREAD) && defined(OPENHTJ2K_DECODE_TIMING)
+  if (auto *pool = ThreadPool::get()) {
+    pool_workers = static_cast<uint32_t>(pool->num_threads());
+    pool->get_timing_counters(pool_wait_base, pool_work_base);
+  }
+#endif
   if (reduce_NL > this->get_max_safe_reduce_NL()) {
     throw std::runtime_error(
         "Attempting to access a non-existent resolution level: -reduce exceeds the\n"
@@ -429,10 +489,17 @@ void openhtj2k_decoder_impl::invoke(std::vector<int32_t *> &buf, std::vector<uin
       throw std::runtime_error("Abort Decoding!");
     };
     tileSet[i].decode();
-    tileSet[i].ycbcr_to_rgb();
-    tileSet[i].finalize(main_header, reduce_NL, buf);  // Copy reconstructed image to output buffer
+    {
+      OPENHTJ2K_TIME_SCOPE(ColorTransform);
+      tileSet[i].ycbcr_to_rgb();
+    }
+    {
+      OPENHTJ2K_TIME_SCOPE(Finalize);
+      tileSet[i].finalize(main_header, reduce_NL, buf);  // Copy reconstructed image to output buffer
+    }
     tileSet[i].destroy();  // Release tile-internal buffers immediately (output is in buf)
   }
+  emit_timing_report(pool_wait_base, pool_work_base, pool_workers);
 }
 
 openhtj2k_decoder_impl::~openhtj2k_decoder_impl() {
@@ -785,6 +852,10 @@ void openhtj2k_decoder_impl::enable_single_tile_reuse(bool on) {
     cached_tileSet_.clear();
     cached_header_fingerprint_ = 0;
   }
+}
+
+void openhtj2k_decoder::set_timing_sink(std::function<void(const DecodeTimingReport &)> sink) {
+  this->impl->set_timing_sink(std::move(sink));
 }
 
 void openhtj2k_decoder::set_row_limit(uint32_t limit) {

--- a/source/core/interface/decoder.hpp
+++ b/source/core/interface/decoder.hpp
@@ -31,6 +31,7 @@
 #include <functional>
 #include <memory>
 #include <vector>
+#include "decode_timing_report.hpp"
 #include "planar_output_desc.hpp"
 #if defined(_MSC_VER) && !defined(OHTJ2K_STATIC)
   #define OPENHTJ2K_EXPORT __declspec(dllexport)
@@ -156,6 +157,16 @@ class openhtj2k_decoder {
                                                      std::vector<uint32_t> &, std::vector<uint8_t> &,
                                                      std::vector<bool> &);
   OPENHTJ2K_EXPORT void destroy();
+
+  // Per-stage decode timing sink.  When set, a DecodeTimingReport is
+  // emitted once at the end of each parse() and invoke*() call.  Only
+  // populated with non-zero counters in builds compiled with
+  // -DOPENHTJ2K_DECODE_TIMING=ON; the sink is invoked either way so
+  // that callers can rely on its lifecycle and detect at runtime
+  // whether the build is instrumented (all counters == 0 when not).
+  // Pass an empty std::function to clear.
+  OPENHTJ2K_EXPORT void set_timing_sink(std::function<void(const DecodeTimingReport &)> sink);
+
   OPENHTJ2K_EXPORT ~openhtj2k_decoder();
 };
 }  // namespace open_htj2k


### PR DESCRIPTION
CI-bisect experiment on top of PR 305. Testing whether the brace wrapping around j2k_tile::decode()'s block-decode loop is what perturbs Windows x64 MSVC codegen. If windows-latest goes from 42/42/41 back down to something in the tolerance, braces are the trigger. Delete this branch after CI reports.