### PR TITLE
feat(decode-timing): attach accumulator on all streaming invoke paths (step 1b)

### DIFF
--- a/source/apps/decoder/main_dec.cpp
+++ b/source/apps/decoder/main_dec.cpp
@@ -469,8 +469,11 @@ void print_help(char *cmd) {
   printf("-batch: Use batch (full-image buffer) decode path instead of the default streaming path.\n");
   printf("-ycbcr bt601|bt709: [EXPERIMENTAL] Convert YCbCr to RGB (PPM output only).\n");
   printf("--timing: Print per-stage decode timing to stderr.  Requires a build with\n");
-  printf("          -DOPENHTJ2K_DECODE_TIMING=ON and -batch (streaming-path timing\n");
-  printf("          is a follow-up).  Without the build flag, counters report zero.\n");
+  printf("          -DOPENHTJ2K_DECODE_TIMING=ON.  In -batch mode the full phase\n");
+  printf("          breakdown populates (parse / block_decode / idwt / color_transform /\n");
+  printf("          finalize).  In streaming mode only parse + pool_wait/work are\n");
+  printf("          reported — per-phase streaming timing is a follow-up.\n");
+  printf("          Without the build flag, counters report zero.\n");
 }
 
 int main(int argc, char *argv[]) {
@@ -628,8 +631,9 @@ int main(int argc, char *argv[]) {
   const bool want_timing = command_option_exists(argc, argv, "--timing");
   if (want_timing && !use_batch) {
     fprintf(stderr,
-            "WARNING: --timing only populates in batch mode; streaming-path timing\n"
-            "         is a follow-up.  Add -batch to see per-stage counters.\n");
+            "NOTE: streaming-mode --timing reports parse + pool_wait/work only;\n"
+            "      per-phase breakdown (block_decode / idwt / color / finalize) is\n"
+            "      still batch-only in this build.\n");
   }
   // Per-stage accumulator across all iterations.  The library sink fires once
   // per parse() and once per invoke(), so we sum them here for the aggregate
@@ -743,6 +747,7 @@ int main(int argc, char *argv[]) {
     try {
       decoder_owner = std::unique_ptr<open_htj2k::openhtj2k_decoder>(
           new open_htj2k::openhtj2k_decoder(infile_name, reduce_NL, num_threads));
+      if (want_timing) decoder_owner->set_timing_sink(timing_sink);
       decoder_owner->parse();
     } catch (std::exception &exc) {
       printf("ERROR: %s\n", exc.what());
@@ -930,5 +935,26 @@ int main(int argc, char *argv[]) {
          total_samples * static_cast<double>(num_iterations) / static_cast<double>(count));
   printf("throughput %lf [usec/sample]\n",
          static_cast<double>(count) / static_cast<double>(num_iterations) / total_samples);
+  if (want_timing) {
+    double denom = static_cast<double>(num_iterations);
+    if (denom < 1.0) denom = 1.0;
+    fprintf(stderr, "\n--- decode timing (averaged over %d iter, %" PRIu64 " reports) ---\n",
+            num_iterations, timing_num_reports);
+    for (unsigned i = 0; i < static_cast<unsigned>(open_htj2k::DecodeStage::kCount); ++i) {
+      const auto s = static_cast<open_htj2k::DecodeStage>(i);
+      fprintf(stderr, "  %-18s %10.3f ms  (%" PRIu64 " calls total)\n",
+              open_htj2k::decode_stage_name(s),
+              static_cast<double>(timing_total.stage_ns[i]) / 1e6 / denom,
+              timing_total.stage_count[i]);
+    }
+    fprintf(stderr, "  %-18s %10.3f ms\n  %-18s %10.3f ms  (%u workers)\n",
+            "pool_wait_ns (sum)", static_cast<double>(timing_total.pool_wait_ns) / 1e6 / denom,
+            "pool_work_ns (sum)", static_cast<double>(timing_total.pool_work_ns) / 1e6 / denom,
+            timing_pool_workers_last);
+#ifndef OPENHTJ2K_DECODE_TIMING
+    fprintf(stderr,
+            "  (all counters are zero — build with -DOPENHTJ2K_DECODE_TIMING=ON)\n");
+#endif
+  }
   return EXIT_SUCCESS;
 }

--- a/source/core/interface/decoder.cpp
+++ b/source/core/interface/decoder.cpp
@@ -290,7 +290,9 @@ void openhtj2k_decoder_impl::parse() {
         "openhtj2k_decoder_impl::parse().\n");
     throw std::exception();
   }
+#ifdef OPENHTJ2K_DECODE_TIMING
   timing_acc_.reset();
+#endif
   OPENHTJ2K_TIME_ATTACH(&timing_acc_);
   uint64_t pool_wait_base = 0, pool_work_base = 0;
   uint32_t pool_workers = 0;
@@ -306,7 +308,13 @@ void openhtj2k_decoder_impl::parse() {
   in.rewind_2bytes();
   is_parsed = true;
   OPENHTJ2K_TIME_REGION_END
+#ifdef OPENHTJ2K_DECODE_TIMING
   emit_timing_report(pool_wait_base, pool_work_base, pool_workers);
+#else
+  (void)pool_wait_base;
+  (void)pool_work_base;
+  (void)pool_workers;
+#endif
 }
 
 void openhtj2k_decoder_impl::emit_timing_report(uint64_t pool_wait_base, uint64_t pool_work_base,
@@ -407,7 +415,9 @@ void openhtj2k_decoder_impl::invoke(std::vector<int32_t *> &buf, std::vector<uin
         "openhtj2k_decoder_impl::invoke().\n");
     throw std::exception();
   }
+#ifdef OPENHTJ2K_DECODE_TIMING
   timing_acc_.reset();
+#endif
   OPENHTJ2K_TIME_ATTACH(&timing_acc_);
   uint64_t pool_wait_base = 0, pool_work_base = 0;
   uint32_t pool_workers = 0;
@@ -496,7 +506,13 @@ void openhtj2k_decoder_impl::invoke(std::vector<int32_t *> &buf, std::vector<uin
     OPENHTJ2K_TIME_REGION_END
     tileSet[i].destroy();  // Release tile-internal buffers immediately (output is in buf)
   }
+#ifdef OPENHTJ2K_DECODE_TIMING
   emit_timing_report(pool_wait_base, pool_work_base, pool_workers);
+#else
+  (void)pool_wait_base;
+  (void)pool_work_base;
+  (void)pool_workers;
+#endif
 }
 
 openhtj2k_decoder_impl::~openhtj2k_decoder_impl() {
@@ -554,7 +570,9 @@ void openhtj2k_decoder_impl::invoke_line_based(std::vector<int32_t *> &buf,
         "openhtj2k_decoder_impl::invoke_line_based().\n");
     throw std::exception();
   }
+#ifdef OPENHTJ2K_DECODE_TIMING
   timing_acc_.reset();
+#endif
   OPENHTJ2K_TIME_ATTACH(&timing_acc_);
   uint64_t pool_wait_base = 0, pool_work_base = 0;
   uint32_t pool_workers = 0;
@@ -635,7 +653,13 @@ void openhtj2k_decoder_impl::invoke_line_based(std::vector<int32_t *> &buf,
     tileSet[i].decode_line_based(main_header, reduce_NL, buf);
     tileSet[i].destroy();  // Release tile-internal buffers immediately (output is in buf)
   }
+#ifdef OPENHTJ2K_DECODE_TIMING
   emit_timing_report(pool_wait_base, pool_work_base, pool_workers);
+#else
+  (void)pool_wait_base;
+  (void)pool_work_base;
+  (void)pool_workers;
+#endif
 }
 
 void openhtj2k_decoder::invoke_line_based(std::vector<int32_t *> &buf, std::vector<uint32_t> &width,
@@ -653,7 +677,9 @@ void openhtj2k_decoder_impl::invoke_line_based_stream(
         "openhtj2k_decoder_impl::invoke_line_based_stream().\n");
     throw std::exception();
   }
+#ifdef OPENHTJ2K_DECODE_TIMING
   timing_acc_.reset();
+#endif
   OPENHTJ2K_TIME_ATTACH(&timing_acc_);
   uint64_t pool_wait_base = 0, pool_work_base = 0;
   uint32_t pool_workers = 0;
@@ -765,7 +791,13 @@ void openhtj2k_decoder_impl::invoke_line_based_stream(
       tileSet[tile_idx].destroy();
       global_y += band_h0;
     }
-    emit_timing_report(pool_wait_base, pool_work_base, pool_workers);
+  #ifdef OPENHTJ2K_DECODE_TIMING
+  emit_timing_report(pool_wait_base, pool_work_base, pool_workers);
+#else
+  (void)pool_wait_base;
+  (void)pool_work_base;
+  (void)pool_workers;
+#endif
     return;
   }
 
@@ -840,7 +872,13 @@ void openhtj2k_decoder_impl::invoke_line_based_stream(
     }
     global_y += band_h[0];
   }
+#ifdef OPENHTJ2K_DECODE_TIMING
   emit_timing_report(pool_wait_base, pool_work_base, pool_workers);
+#else
+  (void)pool_wait_base;
+  (void)pool_work_base;
+  (void)pool_workers;
+#endif
 }
 
 void openhtj2k_decoder::invoke_line_based_stream(
@@ -955,7 +993,9 @@ void openhtj2k_decoder_impl::invoke_line_based_stream_reuse(
     invoke_line_based_stream(std::move(cb), width, height, depth, is_signed);
     return;
   }
+#ifdef OPENHTJ2K_DECODE_TIMING
   timing_acc_.reset();
+#endif
   OPENHTJ2K_TIME_ATTACH(&timing_acc_);
   uint64_t pool_wait_base = 0, pool_work_base = 0;
   uint32_t pool_workers = 0;
@@ -1147,7 +1187,13 @@ void openhtj2k_decoder_impl::invoke_line_based_stream_reuse(
                                                col_lo_, col_hi_);
 
   cached_header_fingerprint_ = fp;
+#ifdef OPENHTJ2K_DECODE_TIMING
   emit_timing_report(pool_wait_base, pool_work_base, pool_workers);
+#else
+  (void)pool_wait_base;
+  (void)pool_work_base;
+  (void)pool_workers;
+#endif
 }
 
 // ── Direct-to-planar decode ───────────────────────────────────────────────
@@ -1218,7 +1264,9 @@ void openhtj2k_decoder_impl::invoke_line_based_direct(
     return;
   }
 
+#ifdef OPENHTJ2K_DECODE_TIMING
   timing_acc_.reset();
+#endif
   OPENHTJ2K_TIME_ATTACH(&timing_acc_);
   uint64_t pool_wait_base = 0, pool_work_base = 0;
   uint32_t pool_workers = 0;
@@ -1366,7 +1414,13 @@ void openhtj2k_decoder_impl::invoke_line_based_direct(
   cached_tileSet_[0].decode_line_based_stream_planar(main_header, reduce_NL, descs, nc);
 
   cached_header_fingerprint_ = fp;
+#ifdef OPENHTJ2K_DECODE_TIMING
   emit_timing_report(pool_wait_base, pool_work_base, pool_workers);
+#else
+  (void)pool_wait_base;
+  (void)pool_work_base;
+  (void)pool_workers;
+#endif
 }
 
 void openhtj2k_decoder_impl::invoke_line_based_predecoded(std::vector<int32_t *> &buf,
@@ -1380,7 +1434,9 @@ void openhtj2k_decoder_impl::invoke_line_based_predecoded(std::vector<int32_t *>
         "openhtj2k_decoder_impl::invoke_line_based_predecoded().\n");
     throw std::exception();
   }
+#ifdef OPENHTJ2K_DECODE_TIMING
   timing_acc_.reset();
+#endif
   OPENHTJ2K_TIME_ATTACH(&timing_acc_);
   uint64_t pool_wait_base = 0, pool_work_base = 0;
   uint32_t pool_workers = 0;
@@ -1456,7 +1512,13 @@ void openhtj2k_decoder_impl::invoke_line_based_predecoded(std::vector<int32_t *>
     }
     tileSet[i].decode_line_based_predecoded(main_header, reduce_NL, buf);
   }
+#ifdef OPENHTJ2K_DECODE_TIMING
   emit_timing_report(pool_wait_base, pool_work_base, pool_workers);
+#else
+  (void)pool_wait_base;
+  (void)pool_work_base;
+  (void)pool_workers;
+#endif
 }
 
 void openhtj2k_decoder::invoke_line_based_predecoded(std::vector<int32_t *> &buf,

--- a/source/core/interface/decoder.cpp
+++ b/source/core/interface/decoder.cpp
@@ -554,6 +554,16 @@ void openhtj2k_decoder_impl::invoke_line_based(std::vector<int32_t *> &buf,
         "openhtj2k_decoder_impl::invoke_line_based().\n");
     throw std::exception();
   }
+  timing_acc_.reset();
+  OPENHTJ2K_TIME_ATTACH(&timing_acc_);
+  uint64_t pool_wait_base = 0, pool_work_base = 0;
+  uint32_t pool_workers = 0;
+#if defined(OPENHTJ2K_THREAD) && defined(OPENHTJ2K_DECODE_TIMING)
+  if (auto *pool = ThreadPool::get()) {
+    pool_workers = static_cast<uint32_t>(pool->num_threads());
+    pool->get_timing_counters(pool_wait_base, pool_work_base);
+  }
+#endif
   if (reduce_NL > this->get_max_safe_reduce_NL()) {
     throw std::runtime_error(
         "Attempting to access a non-existent resolution level: -reduce exceeds the\n"
@@ -625,6 +635,7 @@ void openhtj2k_decoder_impl::invoke_line_based(std::vector<int32_t *> &buf,
     tileSet[i].decode_line_based(main_header, reduce_NL, buf);
     tileSet[i].destroy();  // Release tile-internal buffers immediately (output is in buf)
   }
+  emit_timing_report(pool_wait_base, pool_work_base, pool_workers);
 }
 
 void openhtj2k_decoder::invoke_line_based(std::vector<int32_t *> &buf, std::vector<uint32_t> &width,
@@ -642,6 +653,16 @@ void openhtj2k_decoder_impl::invoke_line_based_stream(
         "openhtj2k_decoder_impl::invoke_line_based_stream().\n");
     throw std::exception();
   }
+  timing_acc_.reset();
+  OPENHTJ2K_TIME_ATTACH(&timing_acc_);
+  uint64_t pool_wait_base = 0, pool_work_base = 0;
+  uint32_t pool_workers = 0;
+#if defined(OPENHTJ2K_THREAD) && defined(OPENHTJ2K_DECODE_TIMING)
+  if (auto *pool = ThreadPool::get()) {
+    pool_workers = static_cast<uint32_t>(pool->num_threads());
+    pool->get_timing_counters(pool_wait_base, pool_work_base);
+  }
+#endif
   if (reduce_NL > this->get_max_safe_reduce_NL()) {
     throw std::runtime_error(
         "Attempting to access a non-existent resolution level: -reduce exceeds the\n"
@@ -744,6 +765,7 @@ void openhtj2k_decoder_impl::invoke_line_based_stream(
       tileSet[tile_idx].destroy();
       global_y += band_h0;
     }
+    emit_timing_report(pool_wait_base, pool_work_base, pool_workers);
     return;
   }
 
@@ -818,6 +840,7 @@ void openhtj2k_decoder_impl::invoke_line_based_stream(
     }
     global_y += band_h[0];
   }
+  emit_timing_report(pool_wait_base, pool_work_base, pool_workers);
 }
 
 void openhtj2k_decoder::invoke_line_based_stream(
@@ -928,9 +951,20 @@ void openhtj2k_decoder_impl::invoke_line_based_stream_reuse(
     throw std::exception();
   }
   if (!single_tile_reuse_enabled_) {
+    // Delegate; the inner call owns timing for this decode.
     invoke_line_based_stream(std::move(cb), width, height, depth, is_signed);
     return;
   }
+  timing_acc_.reset();
+  OPENHTJ2K_TIME_ATTACH(&timing_acc_);
+  uint64_t pool_wait_base = 0, pool_work_base = 0;
+  uint32_t pool_workers = 0;
+#if defined(OPENHTJ2K_THREAD) && defined(OPENHTJ2K_DECODE_TIMING)
+  if (auto *pool = ThreadPool::get()) {
+    pool_workers = static_cast<uint32_t>(pool->num_threads());
+    pool->get_timing_counters(pool_wait_base, pool_work_base);
+  }
+#endif
   if (reduce_NL > this->get_max_safe_reduce_NL()) {
     throw std::runtime_error(
         "Attempting to access a non-existent resolution level: -reduce exceeds the\n"
@@ -1113,6 +1147,7 @@ void openhtj2k_decoder_impl::invoke_line_based_stream_reuse(
                                                col_lo_, col_hi_);
 
   cached_header_fingerprint_ = fp;
+  emit_timing_report(pool_wait_base, pool_work_base, pool_workers);
 }
 
 // ── Direct-to-planar decode ───────────────────────────────────────────────
@@ -1174,13 +1209,25 @@ void openhtj2k_decoder_impl::invoke_line_based_direct(
   if (numTiles.x != 1 || numTiles.y != 1) {
     cached_tileSet_.clear();
     cached_header_fingerprint_ = 0;
-    // Multi-tile: fall back via recursive call with reuse disabled.
+    // Multi-tile: fall back via recursive call with reuse disabled.  Inner
+    // call owns timing for this decode.
     bool was_enabled = single_tile_reuse_enabled_;
     single_tile_reuse_enabled_ = false;
     invoke_line_based_direct(descs, nc, width, height, depth, is_signed);
     single_tile_reuse_enabled_ = was_enabled;
     return;
   }
+
+  timing_acc_.reset();
+  OPENHTJ2K_TIME_ATTACH(&timing_acc_);
+  uint64_t pool_wait_base = 0, pool_work_base = 0;
+  uint32_t pool_workers = 0;
+#if defined(OPENHTJ2K_THREAD) && defined(OPENHTJ2K_DECODE_TIMING)
+  if (auto *pool = ThreadPool::get()) {
+    pool_workers = static_cast<uint32_t>(pool->num_threads());
+    pool->get_timing_counters(pool_wait_base, pool_work_base);
+  }
+#endif
 
   // Fingerprint — identical to invoke_line_based_stream_reuse.
   auto fnv1a_u64 = [](uint64_t h, const void *data, size_t len) {
@@ -1319,6 +1366,7 @@ void openhtj2k_decoder_impl::invoke_line_based_direct(
   cached_tileSet_[0].decode_line_based_stream_planar(main_header, reduce_NL, descs, nc);
 
   cached_header_fingerprint_ = fp;
+  emit_timing_report(pool_wait_base, pool_work_base, pool_workers);
 }
 
 void openhtj2k_decoder_impl::invoke_line_based_predecoded(std::vector<int32_t *> &buf,
@@ -1332,6 +1380,16 @@ void openhtj2k_decoder_impl::invoke_line_based_predecoded(std::vector<int32_t *>
         "openhtj2k_decoder_impl::invoke_line_based_predecoded().\n");
     throw std::exception();
   }
+  timing_acc_.reset();
+  OPENHTJ2K_TIME_ATTACH(&timing_acc_);
+  uint64_t pool_wait_base = 0, pool_work_base = 0;
+  uint32_t pool_workers = 0;
+#if defined(OPENHTJ2K_THREAD) && defined(OPENHTJ2K_DECODE_TIMING)
+  if (auto *pool = ThreadPool::get()) {
+    pool_workers = static_cast<uint32_t>(pool->num_threads());
+    pool->get_timing_counters(pool_wait_base, pool_work_base);
+  }
+#endif
   if (reduce_NL > this->get_max_safe_reduce_NL()) {
     throw std::runtime_error(
         "Attempting to access a non-existent resolution level: -reduce exceeds the\n"
@@ -1398,6 +1456,7 @@ void openhtj2k_decoder_impl::invoke_line_based_predecoded(std::vector<int32_t *>
     }
     tileSet[i].decode_line_based_predecoded(main_header, reduce_NL, buf);
   }
+  emit_timing_report(pool_wait_base, pool_work_base, pool_workers);
 }
 
 void openhtj2k_decoder::invoke_line_based_predecoded(std::vector<int32_t *> &buf,


### PR DESCRIPTION
## Summary

Extends PR #305's per-stage timing infrastructure to the streaming
decode APIs so ``--timing`` works regardless of which decode path the
user calls. Step 1b of the DECODE_OPT_REPORT §7 sequence.

## What it covers

All five streaming entry points now reset the accumulator, snapshot
pool wait/work baselines, run the decode, and emit the report through
the registered sink:

- ``invoke_line_based``
- ``invoke_line_based_stream``
- ``invoke_line_based_stream_reuse``
- ``invoke_line_based_direct``
- ``invoke_line_based_predecoded``

``_reuse`` and ``_direct`` delegate to ``_stream`` for the non-reuse
case; the inner call owns timing in that scenario so we don't
double-emit.

## Scope limit (documented)

The per-phase RAII scopes (BlockDecode / IDWT / ColorTransform /
Finalize) live inside ``j2k_tile::decode() / ycbcr_to_rgb() /
finalize()`` — the batch path's callees. The streaming callees
(``decode_line_based*``) interleave these phases per-strip and would
need finer-grained instrumentation to split cleanly. For now,
streaming reports populate ``parse`` + ``pool_wait/work`` and leave
the four per-phase counters at zero. A follow-up can scope the
per-strip work if there's demand.

## Sample output

### Streaming (``--timing`` without ``-batch``)
```
--- decode timing (averaged over 1 iter, 2 reports) ---
  parse                   0.004 ms  (1 calls total)
  block_decode            0.000 ms  (0 calls total)
  idwt                    0.000 ms  (0 calls total)
  color_transform         0.000 ms  (0 calls total)
  finalize                0.000 ms  (0 calls total)
  pool_wait_ns (sum)      4.266 ms
  pool_work_ns (sum)      0.179 ms  (16 workers)
```

### Batch (``--timing -batch``)
Unchanged from PR #305 — full per-phase breakdown.

## CLI changes

- ``--timing`` no longer emits a WARNING for non-batch use; prints an
  informational NOTE explaining the streaming-mode scope.
- Timing sink is wired in the streaming decoder owner path as well.
- Timing table now prints at the end of both batch and streaming exit
  paths (previously only batch).

## Test plan

- [x] Default build (macro OFF): 618/618 conformance tests pass.
- [x] Timing build (macro ON): 603/603 conformance tests pass.
- [x] Smoke tests on ``kodim23_mono`` in both streaming and batch
      modes produce the expected per-phase counters.
- [ ] CI (9-platform matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)