### PR TITLE
fix(ht-decode): odd-height blocks race via i_samples overflow under MT

### DIFF
--- a/source/core/coding/ht_block_decoding.cpp
+++ b/source/core/coding/ht_block_decoding.cpp
@@ -1174,7 +1174,23 @@ bool htj2k_decode(j2k_codeblock *block, const uint8_t ROIshift) {
 
     // HT block decoding
     bool dequant_done = false;
-    if (num_ht_passes == 1 && ROIshift == 0) {
+    // The fused-dequant scalar/NEON/AVX2/WASM kernels process samples in
+    // 2-row quad pairs and write both rows of every pair unconditionally to
+    // `block->i_samples`.  When `block->size.y` is odd the last pair's
+    // second-row write lands `band_stride` bytes past the block's final
+    // row — into the NEXT block's i_samples region when codeblocks tile
+    // vertically inside the subband (e.g. 1×1 blocks stacked in a narrow
+    // subband from a horizontally-subsampled component).  Under single-
+    // threaded decode the overflow is harmlessly overwritten by the next
+    // block's legitimate row-0 write, but under multi-threaded dispatch
+    // the blocks finish out-of-order and the stale overflow clobbers
+    // adjacent blocks' output.  Fall back to the non-fused path (which
+    // writes into the block-local sample_buf scratch, not i_samples) when
+    // height is odd; the separate dequant pass below handles bounds
+    // correctly.
+    const bool fuseable = (num_ht_passes == 1) && (ROIshift == 0)
+                          && ((block->size.y & 1u) == 0u);
+    if (fuseable) {
       ht_cleanup_decode<true, true>(block, static_cast<uint8_t>(30 - S_blk), Lcup, Pcup, Scup);
       dequant_done = true;
     } else if (num_ht_passes == 1) {


### PR DESCRIPTION
## Summary

The fused-dequant HT cleanup-pass kernels (scalar + NEON + AVX2 + WASM)
process samples in **2-row quad pairs** and unconditionally write both
rows of every pair to ``block->i_samples``. When ``block->size.y`` is
odd, the last pair's second-row write lands ``band_stride`` bytes past
the block's final row — **into the next block's ``i_samples`` region**
when codeblocks tile vertically inside the same subband.

## Where it manifests

Part 1 HT codestreams with heavy horizontal chroma subsampling create
very narrow tile-components that produce narrow subbands with
1×1 codeblocks stacked vertically. Concretely:
``conformance_data/ds1_ht_07_b11.j2k`` — 12×12 canvas, ``XRsiz=4`` on
component 0, yielding a 2-wide tile-component and 1-wide subbands.

## Why it only surfaces under multithreaded scalar decode

- **Single-thread / batch**: codeblocks decode in dispatch order. Block
  N's stale row-1 overflow is harmlessly overwritten by block N+1's
  legitimate row-0 write before anyone reads it. Output ends up
  correct.
- **NEON / AVX2 multithreaded**: codeblocks finish roughly in
  dispatch order — fast enough that the benign-overwrite pattern
  still holds.
- **Scalar multithreaded**: slower. Workers finish codeblocks
  out-of-order. A later-starting block's row-0 write arrives before
  an earlier-starting block's row-1 overflow, and the overflow
  clobbers correct output.

The ``comp_p1_ht_07_11a`` conformance test (tolerance-0 exact PGX
match) fails under streaming-mode MT scalar decode — PAE=64,
PSNR=17 dB vs. reference.

## Diagnosis

ThreadSanitizer pinpointed the race exactly: two threads both inside
``ht_cleanup_decode`` writing to the same ``i_samples`` address at
the boundary between vertically-adjacent codeblocks. Trace
instrumentation (now removed) confirmed no double-dispatch — each
block was queued once; the race was strictly the out-of-bounds
second-row write colliding with the adjacent block's legitimate
row-0 write.

## Fix

Gate the fused-dequant fast path on ``(block->size.y & 1) == 0`` at
the dispatch site in ``htj2k_decode``. Odd-height blocks fall back
to the non-fused path, which writes into the block-local
``sample_buf`` scratch (properly padded) and then runs a separate
dequant pass that respects block bounds.

Slight extra memory traffic for odd-height blocks only. Most real
workloads are subsampled-luma images where this only triggers on
the narrow chroma components.

## Validation

- [x] **Scalar build** (``-DENABLE_ARM_NEON=OFF``): **603/603 tests pass**
      (was 602/603 — ``comp_p1_ht_07_11a`` fixed).
- [x] **Default NEON build**: **618/618 tests pass** (no regression —
      NEON's fast-enough ordering on the batch path was already
      correct, and streaming narrow-component codestreams aren't in
      routine CI).
- [x] **ThreadSanitizer run** (``-DENABLE_ARM_NEON=OFF
      -fsanitize=thread``) with ``-num_threads 2`` on
      ``ds1_ht_07_b11.j2k``: **no race reported** (was 3+ races per
      run before).

## Test plan
- [ ] CI (9-platform matrix).
- [x] Local scalar conformance.
- [x] Local NEON conformance.
- [x] Local TSAN on the formerly-failing codestream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)