### PR TITLE
feat(jpip_viewer): ?cb= cache-buster for dev iteration

### DIFF
--- a/subprojects/jpip_viewer.html
+++ b/subprojects/jpip_viewer.html
@@ -294,6 +294,7 @@
         <tr><td><code>?midPaintMs=</code></td><td><code>200</code></td><td>Show a partial render (whatever precincts have arrived) if a fetch takes longer than <i>N</i> ms. Gives feedback on slow first-time loads; costs one extra decoder run. Fast (LAN / cached) fetches never trigger it. Set <code>0</code> to disable.</td></tr>
         <tr><td><code>?thumbnail=</code></td><td><code>1</code></td><td>Small bottom-right overview showing the full image (fetched once at connect time from the coarsest reduce level) with a rectangle marking the current viewport. Rectangle updates locally on every pan/zoom — no extra server round-trips. Set <code>0</code> to hide.</td></tr>
         <tr><td><code>?thumbnailSize=</code></td><td><code>160</code></td><td>CSS-pixel size of the thumbnail on its long side. Decoder output resolution is independent — only the displayed size changes.</td></tr>
+        <tr><td><code>?cb=</code></td><td>off</td><td>Cache-buster for dev iteration. <code>auto</code> or <code>1</code> appends <code>?v=&lt;Date.now()&gt;</code> to the WASM/JS fetches so the browser refetches after every rebuild. Any other value is used verbatim (snapshot at a build hash). Default (no <code>?cb</code>): full HTTP caching, identical to before.</td></tr>
       </tbody>
     </table>
   </details>
@@ -373,7 +374,21 @@ const hasSimd = await wasmFeatureDetect.simd();
 const hasMt = window.crossOriginIsolated && (typeof SharedArrayBuffer !== 'undefined');
 const forceVariant = new URLSearchParams(location.search).get('variant');
 const useMt = forceVariant === 'mt' ? true : forceVariant === 'st' ? false : (hasSimd && hasMt);
-const wasmFile = useMt ? './libopen_htj2k_jpip_mt_simd.js' : './libopen_htj2k_jpip.js';
+
+// Cache-buster for dev iteration.  `?cb=auto` or `?cb=1` appends Date.now()
+// to WASM/JS URLs so the browser refetches after every rebuild — bypasses
+// the (correct) HTTP caching that production relies on.  Default (no `?cb`):
+// no suffix, full caching, identical behaviour to before this knob existed.
+// `?cb=<arbitrary>`: uses the literal value, useful for "snapshot at this
+// build hash" scenarios.  The cache-buster is propagated to both the JS
+// shim import and the .wasm fetch (via Emscripten's locateFile hook).
+const _cbParam = new URLSearchParams(location.search).get('cb');
+const cacheBuster =
+    (_cbParam === 'auto' || _cbParam === '1') ? `?v=${Date.now()}`
+  : _cbParam ? `?v=${encodeURIComponent(_cbParam)}`
+  : '';
+const wasmFile = (useMt ? './libopen_htj2k_jpip_mt_simd.js'
+                        : './libopen_htj2k_jpip.js') + cacheBuster;
 const {default: createModule} = await import(wasmFile);
 const $ = id => document.getElementById(id);
 
@@ -1086,7 +1101,14 @@ async function fetchView() {
 async function init() {
   $('info').textContent = 'Loading WASM…';
   try {
-    M = await createModule();
+    // Propagate the cache-buster to the .wasm and worker fetches so a `?cb`
+    // dev iteration also picks up rebuilt WASM, not just the JS shim.
+    // Default (cacheBuster='') — locateFile returns prefix+path verbatim,
+    // matching Emscripten's built-in default.
+    const moduleArgs = cacheBuster
+      ? { locateFile: (path, prefix) => prefix + path + cacheBuster }
+      : {};
+    M = await createModule(moduleArgs);
     $('info').textContent = `WASM ready (${useMt?'MT+SIMD':'SIMD'}).`;
   } catch (e) { $('info').textContent = 'WASM load failed: ' + e.message; }
   $('connectBtn').onclick = connect;


### PR DESCRIPTION
## Summary

- Adds a `?cb=` URL param to `subprojects/jpip_viewer.html` that appends a cache-busting suffix to WASM/JS fetches, so a rebuild → reload cycle no longer requires service-worker unregister + Cmd-Shift-R rituals.
- **`coi-serviceworker.js` is untouched.** It's still required for SharedArrayBuffer (WASM threads) on Cloudflare Pages and any other static host that can't set COOP/COEP headers directly.
- Default behavior unchanged: no `?cb` → no suffix → full HTTP caching, same as before.

## Why

`coi-serviceworker.js` doesn't cache responses itself — it just intercepts every fetch and injects COOP/COEP headers via `fetch(e.request).then(res => new Response(res.body, {headers: ...}))`. The actual cache pain is the browser's HTTP cache serving stale `libopen_htj2k_jpip_mt_simd.wasm` by URL. Cmd-Shift-R is supposed to bypass it but the service worker indirection makes that flaky.

The fix: parameterize URLs with a per-load query suffix when the user opts in.

## Usage

| URL | Behavior |
|---|---|
| `…/jpip_viewer.html` | No cache-buster — full HTTP caching (production default) |
| `…/jpip_viewer.html?cb=1` or `?cb=auto` | Appends `?v=<Date.now()>` to every WASM/JS fetch — always fresh |
| `…/jpip_viewer.html?cb=abc123` | Appends `?v=abc123` literally — useful for "snapshot at this build hash" |

The cache-buster propagates to:
- The JS shim import (`libopen_htj2k_jpip[_mt_simd].js`)
- The `.wasm` fetch + worker scripts (via Emscripten's `locateFile` hook)

## Production safety

`htj2k-demo.pages.dev/jpip_viewer.html` (no `?cb`) gets the exact same code path as before — same import URL, same `createModule()` call (no `locateFile` override). Visitors who don't opt in are unaffected. Cloudflare's CDN keeps caching the WASM normally.

## Test plan

- [x] Default URL (no `?cb`): JS+WASM imports byte-identical to pre-change.
- [x] `?cb=1`: WASM/JS URLs include `?v=<timestamp>`, so a rebuild + reload picks up the new bundle without service-worker juggling.
- [x] `?cb=foo`: WASM/JS URLs include `?v=foo` literally.
- [x] `node --check` passes on the inline JS blocks.
- [ ] Manual: open `?cb=1`, rebuild WASM, reload, see new behavior take effect (vs default URL still serving old).

## Why not also on `jpip_demo.html` / `rtp_demo.html`?

Kept scope tight — the user's pain point was the gigapixel viewer specifically. Happy to mirror to the other demos in a follow-up if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)