### PR TITLE
fix(jpip_viewer): coherent X/Y signs in trackpad two-finger scroll

### DIFF
--- a/subprojects/jpip_viewer.html
+++ b/subprojects/jpip_viewer.html
@@ -1451,12 +1451,16 @@ async function connect() {
       clampPan();
       scheduleFetch();
     } else {
-      // Two-finger scroll = pan (Mac natural scrolling: flip Y).
+      // Two-finger scroll = pan.  Both axes use the same sign convention:
+      // positive delta → pan in that direction.  X and Y are coherent so a
+      // diagonal swipe feels predictable.  Whether that matches the user's
+      // OS-level "natural scrolling" preference depends on their system
+      // setting, but at least the two axes agree with each other.
       // deltaX/deltaY are CSS pixels; scale to viewport pixels.
       const sx = vpW / c.clientWidth;
       const sy = vpH / c.clientHeight;
       panX += e.deltaX * sx / zoom;
-      panY -= e.deltaY * sy / zoom;
+      panY += e.deltaY * sy / zoom;
       clampPan();
       scheduleFetch();
     }


### PR DESCRIPTION
## Summary

The wheel handler intentionally negated only `deltaY` ("Mac natural scrolling: flip Y") so X and Y used opposite sign conventions. Diagonal swipes on a trackpad felt off because horizontal followed the gesture and vertical opposed it.

Fix: both axes now use the same sign convention (`panX/Y += e.deltaX/Y`). Diagonal swipes are now predictable.

## User-visible change

Vertical trackpad two-finger scroll now pans the **opposite direction** it used to. If anyone preferred the previous behavior, system-level "natural scrolling" can be inverted in System Settings → Trackpad (which flips both axes consistently at the OS layer).

## Test plan

- [x] Two-finger swipe right → image scrolls right (unchanged).
- [x] Two-finger swipe down → image scrolls down (was: scrolled up).
- [x] Diagonal swipe → both axes follow the gesture (was: vertical opposed).
- [x] Pinch-zoom anchor / wheel-zoom unchanged (only the pan branch changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)