### PR TITLE
fix(jpip_viewer): fill viewport at initial zoom (no aspect letterbox)

### DIFF
--- a/subprojects/jpip_viewer.html
+++ b/subprojects/jpip_viewer.html
@@ -1412,7 +1412,16 @@ async function connect() {
   sizeCanvas(c);
   initWebGL(c);
 
-  zoom = vpW / canvasW;
+  // Initial zoom = fill viewport (Google Maps style), not fit-to-width.
+  // For aspect-mismatched fixtures (heic2501a 4.27:1, Blue Marble 2:1) the
+  // old `vpW / canvasW` left big near-black bars above and below the image
+  // because vpH/zoom extended past canvasH and the quad shrank to the
+  // image's aspect.  Using max() picks whichever axis would have produced
+  // the bars and zooms in to make the image edge-to-edge instead — the
+  // user starts on actual pixels and pans to see the rest, which is what
+  // every gigapixel-image viewer does (Google Maps, Zoomify, OpenSeadragon).
+  // Square-ish fixtures: max == min, behavior unchanged.
+  zoom = Math.max(vpW / canvasW, vpH / canvasH);
   panX = 0; panY = 0;
   $('info').textContent = `${canvasW}×${canvasH}, ${M._jpip_get_total_precincts(ctx)} precincts`;
 
@@ -1617,7 +1626,9 @@ async function connect() {
         break;
       }
       case 'Home': case '0':
-        zoom = vpW/canvasW; panX=0; panY=0;
+        // Reset to the same fill-viewport zoom that connect() picks, so
+        // Home goes back to the initial view exactly.
+        zoom = Math.max(vpW/canvasW, vpH/canvasH); panX=0; panY=0;
         if (computeReduce() !== decReduce) needRefetch = true; else needRedraw = true;
         break;
       default: return;


### PR DESCRIPTION
## Summary

Initial zoom is now `max(vpW/canvasW, vpH/canvasH)` instead of `vpW/canvasW`, so the image fills the viewport on whichever axis would otherwise have produced near-black letterbox bars. Home / \`0\` keyboard reset is updated to match.

## Why

For aspect-mismatched fixtures the old fit-to-width default left big visible bars at startup because `vpH/zoom` extended past `canvasH`, and `drawViewport`'s `uScale` shrank the quad to the image's aspect:

| Fixture | Dimensions | Aspect | Bars at default 1920×1080 viewport |
|---|---|---|---|
| heic2501a.j2c | 42208 × 9870 | 4.27:1 | ~58% of canvas height (huge) |
| land_shallow_topo_21600.j2c | 21600 × 10800 | 2:1 | ~12% top + bottom |
| 4096 × 4096 | 1:1 | 1:1 | none (vp aspect 1.78:1 → vertical bars instead at vpH/canvasH < vpW/canvasW for tall, but here max==min) |

The bar pixels are `gl.clearColor` (0.059, 0.066, 0.09) — looks black on most displays — and the carry-forward thumbnail layer can't fill them either: those CSS pixels are outside the image's canvasW × canvasH rect.

After the change, the user starts on actual pixels with horizontal (or vertical) pan available to see the rest — same idiom every gigapixel-image viewer uses (Google Maps, Zoomify, OpenSeadragon).

## What's unchanged

- **Square-ish fixtures** (1:1 to viewport-aspect-ratio in either direction): `max == min`, behavior unchanged.
- **Min-zoom clamps** (`Math.max(vpW/canvasW * 0.25, …)` at ctrl-wheel / keyboard `−` / pinch-out): not a fit-policy choice, just a lower bound on how far the user can zoom out. Left alone.
- **Pan, fetch, decode, carry-forward, scroll directions, touch input**: nothing else touched.

## Test plan

- [x] heic2501a.j2c: image fills viewport at startup, can pan horizontally to see the rest. No top/bottom bars.
- [x] land_shallow_topo_21600.j2c: same.
- [x] Square-ish fixture (e.g., a 4096×4096 J2C): no change at startup vs. main.
- [x] Home / `0` resets to the same view as initial connect.
- [x] Zoom out (ctrl-wheel, `−`, pinch-out) still goes well below initial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)