### PR TITLE
ci(warm-rtp-cache): chain after successful Deploy WASM demo

### DIFF
--- a/.github/workflows/warm-rtp-cache.yml
+++ b/.github/workflows/warm-rtp-cache.yml
@@ -1,11 +1,27 @@
 name: warm-rtp-cache
+
+# Fires in three cases:
+#   1. workflow_dispatch       — manual run from the Actions tab.
+#   2. push to rtp-samples.txt — the URL list itself changed.
+#   3. workflow_run            — chained after a successful "Deploy WASM
+#                                demo" so freshly-deployed assets get
+#                                warmed without a separate trigger.
 on:
   workflow_dispatch:
   push:
     paths: [.github/deploy/rtp-samples.txt]
+  workflow_run:
+    workflows: ["Deploy WASM demo"]
+    types: [completed]
+
 jobs:
   warm:
     runs-on: ubuntu-latest
+    # On a workflow_run trigger only proceed if the upstream deploy succeeded.
+    # Other triggers (manual / push) bypass this guard.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v4
       - name: Warm each URL listed in rtp-samples.txt


### PR DESCRIPTION
## Summary

Add a `workflow_run` trigger so `warm-rtp-cache` fires automatically after every successful `Deploy WASM demo` run, instead of only when `.github/deploy/rtp-samples.txt` itself changes.

The original design was conservative — fire only when the URL list changes — which kept Cloudflare cache cost down but left the cache stale after every actual deploy. With chaining, the cache is warmed automatically while still avoiding redundant runs (the workflow won't fire when nothing's been deployed).

The success guard prevents warming a half-broken page if the deploy fails. Manual triggers (`workflow_dispatch`) and direct edits to `rtp-samples.txt` still work as before — the `if` clause exempts them.

## Test plan

- [x] YAML validates (`python3 -c 'import yaml; yaml.safe_load(...)'`)
- [ ] (post-merge) Confirm: a push that touches `web/**` triggers Deploy WASM demo → and warm-rtp-cache fires after it completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)