### PR TITLE
fix(web/rtp_demo): drain worker + paced backpressure so playback completes

### DIFF
--- a/web/rtp_demo.html
+++ b/web/rtp_demo.html
@@ -775,6 +775,12 @@ const PRE_ROLL_FRAMES = Math.max(0,
     Number(new URLSearchParams(location.search).get('preroll')) || 3);
 let droppedByPace = 0;
 let framePeriodMs = 0;          // derived from inter-frame RTP Δts; 0 before second frame arrives
+// Paced-mode backpressure counter: incremented for each marker packet pushed
+// to the worker; throttle holds the for-await loop while
+// (pacedFramesPushed - frameCount) >= RING_CAPACITY so the worker can't
+// buffer more in-flight frames than the rAF consumer can drain.  Reset per
+// playback in startPlayback().
+let pacedFramesPushed = 0;
 
 // Has the one-shot per-playback diagnostic dump been printed?
 let firstFrameDiagnosticsDumped = false;
@@ -1654,6 +1660,7 @@ async function startPlayback(source) {
   totalPausedMs = 0; pauseStartedAt = 0;
   droppedByPace = 0;
   framePeriodMs = 0;
+  pacedFramesPushed = 0;
   workerStats = { framesEmitted: 0, framesDropped: 0, seqGaps: 0, readyCount: 0, lastError: '' };
   // rAF-path state (see module-scope declarations).
   decodeCount = 0;
@@ -1740,6 +1747,29 @@ async function startPlayback(source) {
         console.warn('packet', b.length, 'bytes — exceeds PKT_BUF_SZ, skipping');
         continue;
       }
+
+      // Paced-mode backpressure: cap total pipeline depth (markers pushed
+      // minus frames rendered) at RING_CAPACITY.  Gating on the ring alone
+      // is insufficient because by the time the ring fills (~½ s in), main
+      // has already shovelled dozens of frames' worth of markers into the
+      // worker's postMessage queue; the decoder churns through that backlog
+      // at decoder rate, ringPush keeps overflowing on drop-oldest, the
+      // ring ends up holding only frames whose RTP-target is far in the
+      // future, target advances faster than wall time and playback freezes
+      // after pre-roll.  Throttling on (pushed - rendered) prevents the
+      // worker from ever buffering more than RING_CAPACITY frames worth of
+      // markers, so the decoder rate-matches the consumer end to end.
+      // ASAP mode skips the gate (user opted in to "as fast as possible").
+      if (pacing === 'paced' && pkt.marker) {
+        while (pacedFramesPushed - frameCount >= RING_CAPACITY) {
+          if (playbackGen !== myGen || !running) break;
+          if (paused) { await waitIfPaused(); continue; }
+          await new Promise(r => setTimeout(r, 8));   // ~½ vsync at 60 Hz
+        }
+        if (playbackGen !== myGen || !running) break;
+        pacedFramesPushed++;
+      }
+
       pktCount++;
       byteCount += b.length;
 
@@ -1748,8 +1778,8 @@ async function startPlayback(source) {
       if ((pktCount & 0xFF) === 0) await fastYield();
 
       // Push to the worker.  Worker reassembles + decodes; frames arrive
-      // asynchronously via onFrameFromWorker.  Worker drops surplus frames
-      // (>1 ready) so a slow consumer can't backlog packets indefinitely.
+      // asynchronously via onFrameFromWorker (ASAP renders inline; paced
+      // pushes onto the ring drained by the rAF tick).
       dec.pushPacket(b);
     }
   } catch (e) {
@@ -1762,6 +1792,22 @@ async function startPlayback(source) {
       }
     }
   }
+
+  // The for-await loop ends as soon as the packet stream is exhausted, but
+  // dec.pushPacket() is fire-and-forget across postMessage — the worker still
+  // holds queued packets and is decoding the tail.  Drain the worker so all
+  // resulting 'frame' messages have been delivered to onFrameFromWorker (and,
+  // in ASAP mode, rendered) before we tear playback down.  Without this:
+  //   • ASAP shows "Playback finished. N frames decoded." with N below the
+  //     real total (and the dark overlay covers frames still being painted).
+  //   • Paced sets decodeFinished prematurely, so the rAF tick can hit
+  //     "_ringCount === 0" between frame arrivals and run cleanup before
+  //     the rest of the stream lands — playback freezes after pre-roll.
+  if (dec) {
+    try { await dec.drain(); } catch (e) { /* ignore */ }
+  }
+  // Bail if a Stop / new Play landed during the drain.
+  if (playbackGen !== myGen) return;
 
   if (pacing === 'paced') {
     // Hand UI cleanup off to the rAF loop — it will run once the ring

--- a/web/shared/decoder_client.mjs
+++ b/web/shared/decoder_client.mjs
@@ -20,6 +20,7 @@
 //   dec.pushPacket(uint8array); // send one RFC 9828 RTP packet
 //   dec.setReduceNL(n);          // change DWT resolution-reduce (rebuilds decoder)
 //   dec.reset();                 // discard in-flight state (e.g. on stream switch)
+//   await dec.drain();           // wait for queued packets/frames to finish
 //   dec.close();                 // tear the worker down
 
 export class DecoderClient {
@@ -86,6 +87,12 @@ export class DecoderClient {
       }
     });
 
+    // Tracks in-flight drain() resolvers so close() can flush them — once
+    // the worker is terminated, 'drained' replies never arrive and the
+    // promises would otherwise hang forever.
+    this._closed         = false;
+    this._pendingDrains  = new Set();
+
     this.worker.postMessage({
       type: 'init',
       wasmBase: absBase,
@@ -110,7 +117,41 @@ export class DecoderClient {
 
   reset() { this.worker.postMessage({ type: 'reset' }); }
 
+  // Wait for the worker to drain in-flight packets and emit any frames they
+  // produce.  Resolves once the worker echoes 'drained' back.  postMessage
+  // is FIFO, so all 'frame' messages posted before 'drained' have already
+  // been delivered to onFrame by the time this promise resolves.
+  //
+  // No internal timeout: the drain has to wait as long as the decoder needs
+  // to chew through the backlog (tens of seconds is normal for a multi-second
+  // 1080p+ clip).  An earlier 5 s default silently truncated playback.
+  // The Stop case is handled by close() below, which flushes any pending
+  // drain promises before terminating the worker.
+  drain() {
+    return new Promise((resolve) => {
+      if (this._closed) { resolve(); return; }
+      let finish;
+      const handler = (ev) => {
+        if (ev.data?.type === 'drained') finish();
+      };
+      finish = () => {
+        this.worker.removeEventListener('message', handler);
+        this._pendingDrains.delete(finish);
+        resolve();
+      };
+      this._pendingDrains.add(finish);
+      this.worker.addEventListener('message', handler);
+      this.worker.postMessage({ type: 'drain' });
+    });
+  }
+
   close() {
+    if (this._closed) return;
+    this._closed = true;
+    // Flush any drain() promises waiting on a 'drained' that won't arrive
+    // (terminate() kills the worker; 'drained' replies in flight are lost).
+    // Snapshot the Set first because each finish() removes itself.
+    for (const finish of [...this._pendingDrains]) finish();
     this.worker.postMessage({ type: 'close' });
     this.worker.terminate();
   }

--- a/web/shared/decoder_worker.mjs
+++ b/web/shared/decoder_worker.mjs
@@ -275,6 +275,16 @@ self.addEventListener('message', async ({ data }) => {
       case 'setReduceNL':
         setReduceNL(data.value);
         break;
+      case 'drain':
+        // postMessage delivery is FIFO, and pushPacket()'s decode runs
+        // synchronously on this worker's thread.  By the time we handle
+        // 'drain', every prior 'packet' message has been processed and any
+        // resulting 'frame' message has already been posted to the main
+        // thread.  The reply lets the main thread wait for the tail of
+        // playback before tearing down (rtp_demo: avoids "Playback finished"
+        // appearing while frames are still in flight).
+        self.postMessage({ type: 'drained' });
+        break;
       case 'close':
         if (decoder) { F.release_decoder(decoder); decoder = 0; }
         if (session) { F.rtp_destroy(session); session = 0; }


### PR DESCRIPTION
## Summary

Fixes two bugs in `rtp_demo.html` that surfaced after the worker move (`f53d170`):

- **ASAP under-counted frames.** `dec.pushPacket()` is fire-and-forget across `postMessage`. When the for-await packet loop ended, the worker still held queued packets and was decoding the tail; ASAP cleanup ran straight away and re-showed the dark canvas overlay with a `frameCount` below the real total.
- **Paced mode froze after pre-roll.** When the decoder runs faster than the content's RTP-clock rate (e.g. 31.7 fps decoder vs 24 fps content), the 4-entry ring fills within ~½ s and `ringPush`'s drop-oldest policy keeps discarding the entry the rAF consumer was about to render. The "next to render" frame's RTP timestamp keeps shifting forward at decoder rate, the rAF target advances faster than wall time, `target > rafTimestamp` for the rest of playback, and nothing renders.

## Changes

- `web/shared/decoder_worker.mjs` — handle `{type:'drain'}` by echoing `{type:'drained'}` back. FIFO `postMessage` ordering guarantees every prior `'frame'` message has already been delivered to the main thread by the time `'drained'` is processed.
- `web/shared/decoder_client.mjs` — new `drain()` returning a Promise. No internal timeout (an earlier 5 s default silently truncated long playback). `close()` flushes any pending drain promises before calling `worker.terminate()` so Stop doesn't leak hanging closures.
- `web/rtp_demo.html`
  - `await dec.drain()` after the for-await loop, before either the paced `decodeFinished = true` branch or the ASAP cleanup. ASAP overlay now reports the true final count; paced sets `decodeFinished` only after every in-flight frame is in the ring.
  - **Paced backpressure.** Gate marker-packet ingest on `(pacedFramesPushed - frameCount) < RING_CAPACITY` so the worker can't buffer more than `RING_CAPACITY` frames worth of markers in its `postMessage` queue. The decoder rate-matches the consumer end-to-end. (Gating on the ring alone is insufficient: by the time the ring fills, main has already shovelled dozens of frames' worth of markers downstream and the decoder churns through that backlog.)

## Test plan

- [x] Local `node web/perf/serve.mjs`, open `http://127.0.0.1:8765/rtp_demo.html?wasmBase=/wasm-full/`, load 1080p 4:2:2 24 fps clip (744 frames).
- [x] **ASAP**: overlay reports the full 744 frames after playback ends; no frames rendered behind the dark overlay.
- [x] **Paced**: runs to completion at ~24 fps display rate; Decode FPS stays near content rate (decoder self-throttles); no freeze after pre-roll.
- [x] Stop mid-playback in either mode: UI re-enables Play promptly, no hanging drain promises.

## Out of scope

- `wt_viewer`'s rAF loop is unchanged — Phase 3 (RTP-timestamp pacer for the live-stream viewer) is a separate planned PR.
- High-fps content on a 60 Hz display still runs at the display rate (the rAF tick body renders at most one frame per VSync after pre-roll). Pre-existing limit, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)