### PR TITLE
perf(web/shared): batch decoder packets to cut postMessage overhead

### DIFF
--- a/web/shared/decoder_client.mjs
+++ b/web/shared/decoder_client.mjs
@@ -93,6 +93,33 @@ export class DecoderClient {
     this._closed         = false;
     this._pendingDrains  = new Set();
 
+    // Batched-packet ingest staging.  pushPacket() copies each packet into
+    // _batchBuf and records its end-offset in _batchOffs; the batch is
+    // flushed (one postMessage) when it hits BATCH_PACKETS or BATCH_BYTES,
+    // when drain()/reset()/close() is called, or by a deferred macrotask
+    // so a low-rate producer's trailing partial batch reaches the worker
+    // promptly.  Reduces postMessage overhead ~Nx for a high-bitrate stream
+    // where N == batch size.
+    //
+    // Deferred flush uses MessageChannel — like fastYield in rtp_demo, this
+    // is the cheapest macrotask we can schedule.  It must be a macrotask
+    // (not queueMicrotask): a tight `for await` loop hits a microtask
+    // boundary on every `await iter.next()`, so a microtask flush would
+    // fire between every packet push and destroy the batching.  Macrotasks
+    // wait until the loop yields control to the event loop, which is when
+    // we actually want a partial batch to drain.
+    this._BATCH_PACKETS = 16;
+    this._BATCH_BYTES   = 24 * 1024;     // 16 packets × ~1500 B headroom
+    this._batchBuf      = new Uint8Array(this._BATCH_BYTES);
+    this._batchOffs     = [];
+    this._batchLen      = 0;
+    this._flushScheduled = false;
+    this._flushChan     = new MessageChannel();
+    this._flushChan.port1.onmessage = () => {
+      this._flushScheduled = false;
+      if (this._batchOffs.length > 0) this._flushBatch();
+    };
+
     this.worker.postMessage({
       type: 'init',
       wasmBase: absBase,
@@ -100,22 +127,65 @@ export class DecoderClient {
     });
   }
 
-  setReduceNL(n) { this.worker.postMessage({ type: 'setReduceNL', value: n | 0 }); }
+  setReduceNL(n) {
+    this._flushBatch();
+    this.worker.postMessage({ type: 'setReduceNL', value: n | 0 });
+  }
 
   pushPacket(bytes) {
-    // Transfer when possible (caller-owned buffer), else copy.  The worker
-    // re-wraps into a Uint8Array at the receive side.
-    if (bytes.byteOffset === 0 && bytes.byteLength === bytes.buffer.byteLength) {
-      this.worker.postMessage({ type: 'packet', bytes: bytes.buffer }, [bytes.buffer]);
-    } else {
-      // Sliced view of a larger buffer — copy, can't transfer a partial.
-      const copy = new Uint8Array(bytes.byteLength);
+    const len = bytes.byteLength;
+    // Defensive: an oversized packet shouldn't reach here (rtp_demo caps at
+    // 2048), but if it does, send it as its own batch rather than corrupting
+    // the staging buffer.
+    if (len > this._BATCH_BYTES) {
+      this._flushBatch();
+      const copy = new Uint8Array(len);
       copy.set(bytes);
-      this.worker.postMessage({ type: 'packet', bytes: copy.buffer }, [copy.buffer]);
+      this.worker.postMessage(
+        { type: 'packet_batch', bytes: copy.buffer, offsets: [len] },
+        [copy.buffer]
+      );
+      return;
+    }
+    // Flush before this packet would overflow the staging buffer.
+    if (this._batchLen + len > this._BATCH_BYTES ||
+        this._batchOffs.length >= this._BATCH_PACKETS) {
+      this._flushBatch();
+    }
+    this._batchBuf.set(bytes, this._batchLen);
+    this._batchLen += len;
+    this._batchOffs.push(this._batchLen);
+    if (this._batchOffs.length >= this._BATCH_PACKETS) {
+      this._flushBatch();
+    } else if (!this._flushScheduled) {
+      this._flushScheduled = true;
+      this._flushChan.port2.postMessage(0);   // macrotask deferred flush
     }
   }
 
-  reset() { this.worker.postMessage({ type: 'reset' }); }
+  _flushBatch() {
+    if (this._batchOffs.length === 0) return;
+    // Transfer the staging buffer as-is; the worker only reads up to the
+    // last entry in `offsets`, so trailing bytes don't matter.  Allocate a
+    // fresh staging buffer for the next batch (transferring detaches the
+    // old one).  Avoiding a trim-copy saves ~BATCH_BYTES of memcpy per
+    // flush — at sustained 30 000 packets/s that's tens of MB/s of memory
+    // traffic we don't have to do.
+    const buf     = this._batchBuf;
+    const offsets = this._batchOffs;
+    this._batchBuf  = new Uint8Array(this._BATCH_BYTES);
+    this._batchOffs = [];
+    this._batchLen  = 0;
+    this.worker.postMessage(
+      { type: 'packet_batch', bytes: buf.buffer, offsets },
+      [buf.buffer]
+    );
+  }
+
+  reset() {
+    this._flushBatch();
+    this.worker.postMessage({ type: 'reset' });
+  }
 
   // Wait for the worker to drain in-flight packets and emit any frames they
   // produce.  Resolves once the worker echoes 'drained' back.  postMessage
@@ -130,6 +200,10 @@ export class DecoderClient {
   drain() {
     return new Promise((resolve) => {
       if (this._closed) { resolve(); return; }
+      // Make sure any staged packets reach the worker before the 'drain'
+      // sentinel — otherwise the worker would echo 'drained' while still
+      // holding unprocessed packets in this client's batch buffer.
+      this._flushBatch();
       let finish;
       const handler = (ev) => {
         if (ev.data?.type === 'drained') finish();
@@ -152,6 +226,14 @@ export class DecoderClient {
     // (terminate() kills the worker; 'drained' replies in flight are lost).
     // Snapshot the Set first because each finish() removes itself.
     for (const finish of [...this._pendingDrains]) finish();
+    // Drop any staged packets — they'd be processed by a worker we're about
+    // to terminate.  Detach the flush MessageChannel so a pending notify
+    // doesn't fire after we're closed.
+    this._batchOffs = [];
+    this._batchLen  = 0;
+    this._flushChan.port1.onmessage = null;
+    this._flushChan.port1.close();
+    this._flushChan.port2.close();
     this.worker.postMessage({ type: 'close' });
     this.worker.terminate();
   }

--- a/web/shared/decoder_worker.mjs
+++ b/web/shared/decoder_worker.mjs
@@ -151,6 +151,34 @@ function pushPacket(bytes) {
   maybePostStats();
 }
 
+// Process N packets from a single ArrayBuffer in one message-handler turn.
+// `offsets[i]` is the exclusive end of packet i within `bytesBuf` (so
+// packet i spans [offsets[i-1] || 0, offsets[i])).  Reduces postMessage
+// cost ~Nx vs per-packet messages, which matters on high-bitrate streams
+// (>>10k packets/s where the IPC overhead saturates the main thread).
+//
+// drainReady() runs after every frame-completing push within the batch
+// (same as the per-packet path) — NOT just at end-of-batch.  The C++ ready
+// queue caps at 2 (wrapper.cpp:932) and silently pops the front when full;
+// if a batch contained two markers, deferring drainReady to the end would
+// silently drop the earlier frame.
+function pushPacketBatch(bytesBuf, offsets) {
+  if (!F || !session) return;
+  const u8 = new Uint8Array(bytesBuf);
+  let prev = 0;
+  for (let i = 0; i < offsets.length; i++) {
+    const end = offsets[i];
+    const len = end - prev;
+    if (len > 0 && len <= PACKET_BUF) {
+      M.HEAPU8.set(u8.subarray(prev, end), packetPtr);
+      const r = F.rtp_push(session, packetPtr, len);
+      if (r === 1) drainReady();
+    }
+    prev = end;
+  }
+  maybePostStats();
+}
+
 // Drop-old policy: when more than one frame is ready, skip everything but
 // the latest before decoding.  Mirrors the wt_viewer's behaviour pre-worker
 // (drop-on-overrun is essential for live streams under load).
@@ -268,6 +296,9 @@ self.addEventListener('message', async ({ data }) => {
         break;
       case 'packet':
         pushPacket(new Uint8Array(data.bytes));
+        break;
+      case 'packet_batch':
+        pushPacketBatch(data.bytes, data.offsets);
         break;
       case 'reset':
         reset();


### PR DESCRIPTION
## Summary

`DecoderClient.pushPacket()` was sending one `postMessage` to the decoder worker per RTP packet. At ~30 000 packets/s for a 4K HT clip the per-packet IPC cost saturates the main thread and becomes the playback bottleneck. The diagnostic comes from `rtp_demo`'s `?verbose=1` log: `parsed Mbps` falls well below `chunk Mbps` even when the parser's RollingBuffer is far from its high-water mark — bytes are sitting in RAM but the consumer-side for-await loop can't drain them fast enough.

Paced mode is hit harder than ASAP because the existing pipeline-depth backpressure in rtp_demo (PR #337) clusters ingest into bursts between marker throttles, concentrating the per-packet IPC cost into the burst windows. Reported symptom on a 4K Spark preset: `Display 2.0 fps / Decode 57.5 fps`, freeze after pre-roll.

## Change

Stage packets in a 16-packet / 24 KB ring inside `DecoderClient` and emit one `packet_batch` message per fill, on `drain()` / `reset()` / `close()`, or via a MessageChannel-deferred macrotask flush for slow producers. Worker walks the offset table and runs `rtp_push` per packet — same WASM work, ~16× fewer postMessages.

`drainReady()` still runs after every frame-completing push **inside** a batch, not just at end-of-batch, because the C++ ready queue's drop-old cap (`web/src/wrapper.cpp:932`) silently pops the front when full. If a batch happened to straddle two markers, deferring `drainReady()` would silently drop the earlier frame.

The deferred flush has to be a macrotask (MessageChannel postMessage), not `queueMicrotask`: a tight `for await (… of parser)` loop hits a microtask boundary on every `await iter.next()`, and a microtask flush would fire between every packet push and defeat the batching entirely. Macrotasks wait until the loop yields control to the event loop — which is exactly when a partial trailing batch should drain.

## Files

- `web/shared/decoder_client.mjs` — staging buffer + batch flush logic; `setReduceNL()` / `reset()` / `drain()` / `close()` now flush before signalling the worker.
- `web/shared/decoder_worker.mjs` — new `packet_batch` message handler iterating an offset table; per-packet `'packet'` path retained for back-compat.

## Caller compatibility

`dec.pushPacket(bytes)` keeps its existing signature and semantics; batching is internal. Both `web/rtp_demo.html` and `web/wt_viewer/index.html` benefit without source changes.

## Test plan

- [x] Local rtp_demo, 1080p sample via dev server, **ASAP**: parsed Mbps rises ~22% (419 → 509 Mbps in the local measurement) — the per-postMessage ceiling lifts.
- [ ] Local rtp_demo, 4K Spark preset via CDN, **Paced**: `chunk` and `parsed` should track each other within ~50 Mbps; `disp` / `dec` settle near 29.97 fps; no freeze; final overlay frame count matches the file. (Validation pending; CDN CORS issue at the local-dev origin made this harder to reproduce locally — proxy patch tracked separately.)
- [ ] wt_viewer LAN run with `tools/wt_bridge/scripts/run_lan.sh`: behaviour unchanged at FHD@30; no regression in the live-stream code path.

## Out of scope

- Parser-side throughput. With batching in place, the next bottleneck on very fast networks (chunk > ~500 Mbps) is the two `await waitForBytes(...)` per packet inside `parseRtpStream` (`web/rtp_parser.js`). Worth a synchronous fast-path when the buffer already has the bytes — separate change.
- Phase 3 (RTP-timestamp pacer for wt_viewer). Tracked in memory; will land after the rtp_demo CDN-bandwidth investigation is fully closed out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)