### PR TITLE
ci(deploy): pin Node 22 so wrangler can deploy

### DIFF
--- a/.github/workflows/deploy-wasm-demo.yml
+++ b/.github/workflows/deploy-wasm-demo.yml
@@ -21,6 +21,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Cloudflare's wrangler CLI now requires Node 22+; the runner's default
+      # Node is still 20.x, which made `npm install -g wrangler@latest`
+      # succeed but `wrangler pages deploy` fail with "requires at least
+      # Node.js v22.0.0".  Pin Node 22 so the deploy step stays green even
+      # as wrangler bumps its minimum.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Setup Emscripten
         uses: mymindstorm/setup-emsdk@v14
         with:


### PR DESCRIPTION
## Summary

The Cloudflare Pages deploy step has been failing since wrangler bumped its minimum Node version. Run [25179175232](https://github.com/osamu620/OpenHTJ2K/actions/runs/25179175232) failed with:

```
Wrangler requires at least Node.js v22.0.0. You are using v20.20.2.
```

`npm install --global wrangler@latest` succeeded silently — the install step doesn't enforce the engines constraint — and the actual `wrangler pages deploy` then exited 1.

Result: the most recent push to main (perf-batched-packets, `846bbda`) didn't ship to `htj2k-demo.pages.dev`. The deployed site is still on `079bfa4`.

## Change

Add `actions/setup-node@v4` with `node-version: '22'` before the emsdk and wrangler steps in `.github/workflows/deploy-wasm-demo.yml`. No other changes.

## Test plan

- [x] Workflow lints clean.
- [ ] Once merged, the next push-to-main triggers a deploy that should reach the "Deploy to Cloudflare Pages" step with Node 22 and proceed past the version check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)