### PR TITLE
fix(web): unregister stale COI service worker on isolated pages

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -7,7 +7,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!-- Register a service worker that injects COOP/COEP headers to enable
        SharedArrayBuffer (required for multi-threaded WASM).  On first visit
-       the page reloads once after the worker activates. -->
+       the page reloads once after the worker activates.  The deployed site
+       sets COOP/COEP from Cloudflare Pages's `_headers` directly, so the SW
+       only matters for `file://` / non-Pages-hosted use. -->
   <script>
     if (!window.crossOriginIsolated && window.isSecureContext) {
       navigator.serviceWorker.register("coi-serviceworker.js").then(
@@ -26,6 +28,20 @@
         },
         function (err) { console.warn("COI service worker failed:", err); }
       );
+    } else if (window.crossOriginIsolated && navigator.serviceWorker
+                                          && navigator.serviceWorker.controller) {
+      // Page is already cross-origin isolated via response headers, but a
+      // stale COI service worker from a pre-headers visit is still
+      // controlling it.  The SW proxies every fetch via
+      // `new Response(res.body, …)`, which gives the browser an empty body
+      // for 304 responses (the SW's Response isn't paired with the disk
+      // cache).  pthread Worker scripts then load as empty content and the
+      // multi-threaded WASM module hangs at `default()` with no error.
+      // Unregister and reload once to recover.
+      navigator.serviceWorker.getRegistrations().then(function (regs) {
+        Promise.all(regs.map(function (r) { return r.unregister(); }))
+               .then(function () { location.reload(); });
+      });
     }
   </script>
   <script src="https://unpkg.com/wasm-feature-detect/dist/umd/index.js"></script>

--- a/web/jpip_demo.html
+++ b/web/jpip_demo.html
@@ -412,6 +412,15 @@
       },
       function (err) { console.warn("COI service worker failed:", err); }
     );
+  } else if (window.crossOriginIsolated && navigator.serviceWorker
+                                        && navigator.serviceWorker.controller) {
+    // Stale COI service worker from a pre-`_headers` visit is still
+    // controlling this page; its fetch proxy returns empty bodies for 304
+    // responses and breaks pthread Worker spawn.  Unregister and reload.
+    navigator.serviceWorker.getRegistrations().then(function (regs) {
+      Promise.all(regs.map(function (r) { return r.unregister(); }))
+             .then(function () { location.reload(); });
+    });
   }
 </script>
 <script type="module">

--- a/web/jpip_viewer.html
+++ b/web/jpip_viewer.html
@@ -378,6 +378,15 @@
       },
       function (err) { console.warn("COI service worker failed:", err); }
     );
+  } else if (window.crossOriginIsolated && navigator.serviceWorker
+                                        && navigator.serviceWorker.controller) {
+    // Stale COI service worker from a pre-`_headers` visit is still
+    // controlling this page; its fetch proxy returns empty bodies for 304
+    // responses and breaks pthread Worker spawn.  Unregister and reload.
+    navigator.serviceWorker.getRegistrations().then(function (regs) {
+      Promise.all(regs.map(function (r) { return r.unregister(); }))
+             .then(function () { location.reload(); });
+    });
   }
 </script>
 <script>

--- a/web/rtp_demo.html
+++ b/web/rtp_demo.html
@@ -6,7 +6,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!-- Register a service worker that injects COOP/COEP headers to enable
-       SharedArrayBuffer (required for multi-threaded WASM). -->
+       SharedArrayBuffer (required for multi-threaded WASM).  The deployed
+       site sets COOP/COEP from Cloudflare Pages's `_headers` directly; the
+       SW only matters for `file://` / non-Pages-hosted use. -->
   <script>
     if (!window.crossOriginIsolated && window.isSecureContext) {
       navigator.serviceWorker.register("coi-serviceworker.js").then(
@@ -22,6 +24,17 @@
         },
         function (err) { console.warn("COI service worker failed:", err); }
       );
+    } else if (window.crossOriginIsolated && navigator.serviceWorker
+                                          && navigator.serviceWorker.controller) {
+      // Page is already cross-origin isolated via response headers, but a
+      // stale COI service worker from a pre-headers visit is still
+      // controlling it.  The SW's `new Response(res.body, …)` proxy gives
+      // the browser an empty body for 304 responses, which breaks pthread
+      // Worker spawn for mt_simd.  Unregister and reload once to recover.
+      navigator.serviceWorker.getRegistrations().then(function (regs) {
+        Promise.all(regs.map(function (r) { return r.unregister(); }))
+               .then(function () { location.reload(); });
+      });
     }
   </script>
   <script src="https://unpkg.com/wasm-feature-detect/dist/umd/index.js"></script>


### PR DESCRIPTION
## Summary

Multi-threaded WASM (`libopen_htj2k_mt_simd.js`, `_mt.js`) silently hangs on `htj2k-demo.pages.dev` for users with a service worker registered from a previous visit. Single-threaded variants work. No console output, no exception — `Module.default()` just never resolves.

## Root cause

Each entry HTML registers `coi-serviceworker.js` to inject COOP/COEP headers when the page isn't already cross-origin isolated:

```js
if (!window.crossOriginIsolated && window.isSecureContext) {
  navigator.serviceWorker.register("coi-serviceworker.js")...
}
```

The deployed site now provides COOP/COEP via Cloudflare Pages's `_headers` directly, so the registration guard is true and no new SW is created. **But the existing SW from a pre-`_headers` visit is still active and still controls the page.**

The SW's fetch handler does `fetch(req).then(res => new Response(res.body, {...}))`. For 304 conditional responses, the browser would normally pull the body from its disk cache — but the SW constructs a fresh Response object that the browser doesn't pair with the cache entry. The proxied body is therefore *empty*. pthread Worker scripts (`new Worker(new URL(import.meta.url))`) load with empty content, the Emscripten bootstrap inside each worker never runs, and `Module.default()` waits forever for `ready` messages that never come.

Diagnosed from `rtp_demo` Network tab: 4 pthread `libopen_htj2k_mt_simd.js` re-fetches all returning **304 with ~520-byte payloads** (header-only response bodies) under the SW initiator (gear icon).

## Fix

Add an `else` branch to the SW guard in each entry HTML:

```js
} else if (window.crossOriginIsolated && navigator.serviceWorker
                                      && navigator.serviceWorker.controller) {
  // Stale SW still controlling an already-isolated page.  Unregister
  // and reload once to recover.
  navigator.serviceWorker.getRegistrations().then(regs =>
    Promise.all(regs.map(r => r.unregister())).then(() => location.reload())
  );
}
```

After the one-time reload, the SW is gone, fetches go directly to Cloudflare Pages, and pthread workers spawn normally.

## Files

Same change applied to all four entry pages: `index.html`, `rtp_demo.html`, `jpip_demo.html`, `jpip_viewer.html`.

## Test plan

- [x] Lint clean.
- [ ] After merge + deploy, `htj2k-demo.pages.dev/` (still-image) reload should drop the SW; multi-threaded mode runs.
- [ ] Same for `rtp_demo.html`, `jpip_demo.html`, `jpip_viewer.html`.
- [ ] First-time visitors see no behavior change (no stale SW to unregister, register-when-not-isolated branch unchanged).
- [ ] Local `file://` use of these pages is unaffected — still uses the SW for COOP/COEP injection (the new branch only fires when the page is already isolated AND has a controller).

## Out of scope

The SW could be removed entirely now that Cloudflare Pages handles COOP/COEP, but the fallback for `file://` / non-Pages hosting is still useful. Keeping it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)