### PR TITLE
fix(web): drop stale COI SW (v2) — 304 short-circuit + remove controller gate

### DIFF
--- a/web/coi-serviceworker.js
+++ b/web/coi-serviceworker.js
@@ -20,6 +20,24 @@ self.addEventListener("fetch", (e) => {
         // opaque responses (status 0) cannot have headers modified
         if (res.status === 0) return res;
 
+        // 304 Not Modified responses MUST be passed through unchanged.
+        // The browser pairs a 304 with its disk-cache entry to fill in
+        // the body; constructing a fresh `new Response(res.body, …)` here
+        // gives the browser an *empty* body it can't pair with the cache,
+        // and any consumer (especially `new Worker(url)`) ends up loading
+        // empty content and silently failing.  This is what broke the
+        // multi-threaded WASM mode for pthread Worker spawns.
+        if (res.status === 304) return res;
+
+        // If the response already carries COOP/COEP (e.g. when the host
+        // sets them via response headers), pass through unchanged — there
+        // is no value in proxying through a fresh Response, and doing so
+        // adds bug surface (see 304 case above).
+        if (res.headers.get("Cross-Origin-Embedder-Policy") &&
+            res.headers.get("Cross-Origin-Opener-Policy")) {
+          return res;
+        }
+
         const headers = new Headers(res.headers);
         headers.set("Cross-Origin-Embedder-Policy", "credentialless");
         headers.set("Cross-Origin-Opener-Policy", "same-origin");

--- a/web/index.html
+++ b/web/index.html
@@ -28,17 +28,17 @@
         },
         function (err) { console.warn("COI service worker failed:", err); }
       );
-    } else if (window.crossOriginIsolated && navigator.serviceWorker
-                                          && navigator.serviceWorker.controller) {
+    } else if (window.crossOriginIsolated && navigator.serviceWorker) {
       // Page is already cross-origin isolated via response headers, but a
-      // stale COI service worker from a pre-headers visit is still
-      // controlling it.  The SW proxies every fetch via
-      // `new Response(res.body, …)`, which gives the browser an empty body
-      // for 304 responses (the SW's Response isn't paired with the disk
-      // cache).  pthread Worker scripts then load as empty content and the
-      // multi-threaded WASM module hangs at `default()` with no error.
-      // Unregister and reload once to recover.
+      // COI service worker from a pre-headers visit may still be registered
+      // — and even if it isn't controlling the parent window, it can still
+      // intercept fetches initiated by pthread `new Worker(url)` calls,
+      // breaking multi-threaded WASM.  Unregister any leftover registration
+      // and reload once to recover.  (Don't gate on
+      // `navigator.serviceWorker.controller`: it can be null even while
+      // the SW is active for child workers.)
       navigator.serviceWorker.getRegistrations().then(function (regs) {
+        if (regs.length === 0) return;   // nothing to clean up
         Promise.all(regs.map(function (r) { return r.unregister(); }))
                .then(function () { location.reload(); });
       });

--- a/web/jpip_demo.html
+++ b/web/jpip_demo.html
@@ -412,12 +412,13 @@
       },
       function (err) { console.warn("COI service worker failed:", err); }
     );
-  } else if (window.crossOriginIsolated && navigator.serviceWorker
-                                        && navigator.serviceWorker.controller) {
-    // Stale COI service worker from a pre-`_headers` visit is still
-    // controlling this page; its fetch proxy returns empty bodies for 304
-    // responses and breaks pthread Worker spawn.  Unregister and reload.
+  } else if (window.crossOriginIsolated && navigator.serviceWorker) {
+    // Stale COI service worker from a pre-`_headers` visit may still be
+    // registered.  Even when it isn't controlling the parent window, it
+    // can still intercept pthread `new Worker(url)` fetches and break
+    // multi-threaded WASM.  Unregister and reload once if found.
     navigator.serviceWorker.getRegistrations().then(function (regs) {
+      if (regs.length === 0) return;
       Promise.all(regs.map(function (r) { return r.unregister(); }))
              .then(function () { location.reload(); });
     });

--- a/web/jpip_viewer.html
+++ b/web/jpip_viewer.html
@@ -378,12 +378,13 @@
       },
       function (err) { console.warn("COI service worker failed:", err); }
     );
-  } else if (window.crossOriginIsolated && navigator.serviceWorker
-                                        && navigator.serviceWorker.controller) {
-    // Stale COI service worker from a pre-`_headers` visit is still
-    // controlling this page; its fetch proxy returns empty bodies for 304
-    // responses and breaks pthread Worker spawn.  Unregister and reload.
+  } else if (window.crossOriginIsolated && navigator.serviceWorker) {
+    // Stale COI service worker from a pre-`_headers` visit may still be
+    // registered.  Even when it isn't controlling the parent window, it
+    // can still intercept pthread `new Worker(url)` fetches and break
+    // multi-threaded WASM.  Unregister and reload once if found.
     navigator.serviceWorker.getRegistrations().then(function (regs) {
+      if (regs.length === 0) return;
       Promise.all(regs.map(function (r) { return r.unregister(); }))
              .then(function () { location.reload(); });
     });

--- a/web/rtp_demo.html
+++ b/web/rtp_demo.html
@@ -24,14 +24,14 @@
         },
         function (err) { console.warn("COI service worker failed:", err); }
       );
-    } else if (window.crossOriginIsolated && navigator.serviceWorker
-                                          && navigator.serviceWorker.controller) {
-      // Page is already cross-origin isolated via response headers, but a
-      // stale COI service worker from a pre-headers visit is still
-      // controlling it.  The SW's `new Response(res.body, …)` proxy gives
-      // the browser an empty body for 304 responses, which breaks pthread
-      // Worker spawn for mt_simd.  Unregister and reload once to recover.
+    } else if (window.crossOriginIsolated && navigator.serviceWorker) {
+      // Stale COI service worker from a pre-`_headers` visit may still be
+      // registered.  Even when it isn't controlling the parent window, it
+      // can still intercept fetches initiated by pthread `new Worker(url)`
+      // calls and break multi-threaded WASM.  Unregister and reload once
+      // if any registration is found.
       navigator.serviceWorker.getRegistrations().then(function (regs) {
+        if (regs.length === 0) return;
         Promise.all(regs.map(function (r) { return r.unregister(); }))
                .then(function () { location.reload(); });
       });


### PR DESCRIPTION
## Summary

PR #340 didn't actually recover the broken multi-threaded WASM page on `htj2k-demo.pages.dev`. The user's Network tab on the redeployed page showed:

- Document fetch: direct (no SW gear icon).
- Main `libopen_htj2k_mt_simd.js` import: direct, full body 200.
- **4 pthread re-fetches of `libopen_htj2k_mt_simd.js`: SW gear icon + 304 + ~520-byte payloads** (header-only response bodies).
- Followed by 30+ pending `libopen_htj2k_mt_simd.js` script fetches that never resolve.

So a SW *is* still registered and intercepting pthread Worker fetches, but the unregister branch in PR #340 never fired because it gated on `navigator.serviceWorker.controller` — which is null for that page reload despite the SW being live for the child Worker scripts.

## Two fixes

### 1. HTML — drop the `controller` requirement

```diff
-} else if (window.crossOriginIsolated && navigator.serviceWorker
-                                      && navigator.serviceWorker.controller) {
+} else if (window.crossOriginIsolated && navigator.serviceWorker) {
   navigator.serviceWorker.getRegistrations().then(function (regs) {
+    if (regs.length === 0) return;   // nothing to clean up
     Promise.all(regs.map(function (r) { return r.unregister(); }))
            .then(function () { location.reload(); });
   });
 }
```

Now any leftover registration triggers an unregister + reload, even if the SW isn't actively controlling the document at the moment — which matches the actual failure mode (SW intercepts only the child Worker fetches).

Applied to all four entry HTMLs: `index.html`, `rtp_demo.html`, `jpip_demo.html`, `jpip_viewer.html`.

### 2. `coi-serviceworker.js` — short-circuit 304s and pre-headered responses

The underlying SW bug: every response was wrapped in `new Response(res.body, {…})`. For 304 conditional responses, the browser would normally pair the 304 with its disk-cache entry to fill in the body, but the SW's fresh `Response` object isn't paired with the cache, so the body is empty. pthread Worker scripts load empty content and silently fail.

```diff
+// 304 Not Modified must pass through unchanged so the browser can pair
+// it with its disk cache.  A `new Response(res.body, …)` here gives an
+// empty body, which broke pthread Worker spawn for mt_simd.
+if (res.status === 304) return res;
+
+// If the response already carries COOP/COEP (Cloudflare Pages does this
+// via `_headers`), skip the proxy entirely — no value in re-wrapping,
+// and re-wrapping adds bug surface.
+if (res.headers.get("Cross-Origin-Embedder-Policy") &&
+    res.headers.get("Cross-Origin-Opener-Policy")) {
+  return res;
+}
```

So even users who don't yet get the unregister-and-reload path (very stale clients, third-party hosting) stop hitting the empty-body failure.

## Test plan

- [ ] After deploy, reload `htj2k-demo.pages.dev/`. Page should self-reload once (unregister branch). Second load: still-image demo runs with multi-threaded WASM.
- [ ] Same for `rtp_demo.html`, `jpip_demo.html`, `jpip_viewer.html`.
- [ ] First-time visitor (no stale SW): no behavior change, `regs.length === 0` short-circuits.
- [ ] `file://` use of these pages: SW still registers (page is not cross-origin isolated), still adds COOP/COEP for non-304 / no-COOP responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)