### PR TITLE
docs: clarify build prerequisites for every app

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,12 @@ on modern x86-64**.
 ## Quick build
 
 ```bash
-cmake -B build -DCMAKE_BUILD_TYPE=Release -DOPENHTJ2K_THREAD=ON
+cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j
 ```
+
+The built-in thread pool is enabled automatically when CMake's
+`find_package(Threads)` succeeds (every supported platform).
 
 Executables land in `build/bin/`. For the full CMake flag reference,
 the WebAssembly build, and the experimental RTP receiver build (GLFW

--- a/docs/building.md
+++ b/docs/building.md
@@ -6,7 +6,10 @@ receiver.
 
 ## Requirements
 
-CMake 3.13 or later and a compiler supporting **C++11 or later**.
+**Mandatory:**
+
+- CMake 3.13 or later
+- A compiler supporting **C++11 or later** (GCC 4.8+, Clang 3.3+, MSVC 2015+, Apple Clang 6+)
 
 CMake automatically selects the highest standard supported by the
 compiler (C++17 → C++14 → C++11). All three modes have been verified to
@@ -18,13 +21,31 @@ produce a correct build and pass the full conformance test suite.
 | C++14 | Attributes expand to nothing (no diagnostics lost at runtime); `stat()` fallback for path handling |
 | C++11 | Same as C++14; additionally uses a built-in `make_unique` shim and `std::result_of` instead of `std::invoke_result_t` |
 
+**Optional (auto-detected):**
+
+| Dependency | Enables | Install |
+|---|---|---|
+| **libtiff** | TIFF input in `open_htj2k_enc` (8/16-bit, RGB or grayscale, both planar configurations; tiled TIFFs require `-batch`) | Debian/Ubuntu: `libtiff-dev`; Fedora: `libtiff-devel`; macOS (Homebrew): `brew install libtiff`; vcpkg: `vcpkg install tiff` |
+
+When libtiff is not detected at configure time the build proceeds without
+TIFF support; the encoder will reject `.tif` / `.tiff` inputs at runtime.
+CMake prints `libtiff found` (or omits the line) so you can verify which
+mode you got.
+
+**Opt-in (explicit CMake flags):** see the table under *Common CMake
+flags* below for `-DOPENHTJ2K_RTP` and `-DOPENHTJ2K_QUIC`, and the
+dedicated sections later in this document for each one's additional
+native-dependency requirements. The built-in thread pool is enabled
+automatically whenever `find_package(Threads)` succeeds; there is no
+explicit threading flag.
+
 ## Native build
 
 `./` is the root of the cloned repository and `${BUILD_DIR}` is a build
 directory (for example `./build` or `../build`).
 
 ```bash
-cmake -G "Unix Makefiles" -B ${BUILD_DIR} -DCMAKE_BUILD_TYPE=Release -DOPENHTJ2K_THREAD=ON
+cmake -G "Unix Makefiles" -B ${BUILD_DIR} -DCMAKE_BUILD_TYPE=Release
 cmake --build ${BUILD_DIR} --config Release -j
 ```
 
@@ -37,9 +58,8 @@ on platform.
 | Flag | Default | Meaning |
 |---|---|---|
 | `-DCMAKE_BUILD_TYPE=<Release\|Debug\|RelWithDebInfo>` | (none) | Optimization and debug info level. `RelWithDebInfo` is the recommended mode for profiling. |
-| `-DOPENHTJ2K_THREAD=ON` | `OFF` | Enable the built-in thread pool for multi-threaded encode and decode. Strongly recommended. |
-| `-DOPENHTJ2K_RTP=ON` | `OFF` | Build the experimental RFC 9828 RTP receiver (see below). Adds a GLFW + OpenGL dependency. Also builds the JPIP foveation demo. |
-| `-DOPENHTJ2K_QUIC=ON` | `OFF` | Enable HTTP/3 over QUIC for the JPIP server and demo. Requires MsQuic + nghttp3 (`brew install libmsquic libnghttp3` on macOS). |
+| `-DOPENHTJ2K_RTP=ON` | `OFF` | Build the experimental RFC 9828 RTP receiver (see below). Adds a GLFW dependency on every platform; uses native Metal on macOS and OpenGL 3.3 elsewhere. Also gates `open_htj2k_jpip_demo`. |
+| `-DOPENHTJ2K_QUIC=ON` | `OFF` | Enable HTTP/3 over QUIC for the JPIP server and demo. Requires MsQuic + nghttp3; see [JPIP HTTP/3 prerequisites](#jpip-http3-prerequisites-opt-in) below. |
 | `-DENABLE_AVX2=OFF` | auto | Force-disable AVX2 dispatch. Auto-detected via `-march=native` on x86-64. |
 | `-DENABLE_ARM_NEON=OFF` | auto | Force-disable NEON dispatch on AArch64. |
 | `-DBUILD_SHARED_LIBS=OFF` | `ON` | Build a static library instead of a shared one. |
@@ -137,28 +157,79 @@ image versus ~486 MB with the batch path).
 ## Building the experimental RFC 9828 RTP receiver
 
 Adds `open_htj2k_rtp_recv`, a live HTJ2K RTP receiver per RFC 9828 that
-decodes incoming frames and displays them via GLFW/OpenGL. Off by
+decodes incoming frames and displays them in a windowed viewer. Off by
 default so the rest of the project builds without a window system.
 
 **Prerequisites:**
 
-- GLFW 3.x development headers:
+- GLFW 3.x development headers (every platform):
   - Debian/Ubuntu: `libglfw3-dev`
   - Fedora: `glfw-devel`
+  - Arch: `glfw`
   - macOS (Homebrew): `brew install glfw`
-- OpenGL 3.3 core profile at runtime
+  - Windows (vcpkg): `vcpkg install glfw3`
+- Renderer at runtime:
+  - **Linux / Windows**: OpenGL 3.3 core profile. Install the OpenGL
+    development headers (Debian/Ubuntu: `libgl1-mesa-dev`; Fedora:
+    `mesa-libGL-devel`). Use `--color-path cpu` on hosts without a
+    GL 3.3 context (the receiver auto-falls back).
+  - **macOS**: native Metal renderer via the Metal / QuartzCore / Cocoa
+    frameworks (already present in any Xcode Command Line Tools
+    install). No OpenGL dependency on Apple silicon — the
+    `OPENHTJ2K_USE_METAL` define is set automatically by CMake.
+
+The same `-DOPENHTJ2K_RTP=ON` flag also builds the
+`open_htj2k_jpip_demo` foveation viewer (it shares the GLFW renderer
+with `open_htj2k_rtp_recv`). If you only need the JPIP server +
+benchmark + browser viewer, the flag is unnecessary.
 
 ```bash
 cmake -G "Unix Makefiles" -B ${BUILD_DIR} -DCMAKE_BUILD_TYPE=Release \
-      -DOPENHTJ2K_THREAD=ON -DOPENHTJ2K_RTP=ON
+      -DOPENHTJ2K_RTP=ON
 cmake --build ${BUILD_DIR} --config Release -j
 ```
 
-Produces `${BUILD_DIR}/bin/open_htj2k_rtp_recv` and, when
-`-DOPENHTJ2K_RTP=ON`, the offline decode profiler
-`${BUILD_DIR}/bin/open_htj2k_rtp_decode_profile` for reproducing the
-performance measurements documented in
+Produces `${BUILD_DIR}/bin/open_htj2k_rtp_recv` and the offline decode
+profiler `${BUILD_DIR}/bin/open_htj2k_rtp_decode_profile` for reproducing
+the performance measurements documented in
 [cli_rtp_recv.md](cli_rtp_recv.md).
+
+## JPIP HTTP/3 prerequisites (opt-in)
+
+`-DOPENHTJ2K_QUIC=ON` enables HTTP/3 over QUIC for both
+`open_htj2k_jpip_server` and `open_htj2k_jpip_demo`. The HTTP/1.1
+transport is always available; this flag only adds the H3 path.
+
+**Required libraries:**
+
+- **MsQuic** — Microsoft's QUIC implementation, used for the transport.
+- **nghttp3** — HTTP/3 framing on top of MsQuic.
+
+| Platform | Install |
+|---|---|
+| macOS (Homebrew) | `brew install libmsquic libnghttp3` |
+| Debian/Ubuntu | No official package yet. Build MsQuic from <https://github.com/microsoft/msquic> and nghttp3 from <https://github.com/ngtcp2/nghttp3>; install to `/usr/local`. |
+| Fedora / RHEL | Same as Debian — build from source. |
+| Windows (vcpkg) | `vcpkg install ms-quic nghttp3` |
+
+CMake calls `find_library(msquic)` and `find_path(msquic.h)` (likewise
+for nghttp3); when either is missing it prints a `WARNING` and silently
+omits the H3 transport. Verify the configure log contains
+`OPENHTJ2K_QUIC: MsQuic found` and the matching nghttp3 line before
+running the H3 demos.
+
+The HTTP/1.1 server has no extra dependencies beyond the core library.
+
+## WebTransport browser viewer (experimental)
+
+A separate stack — Go relay (`tools/wt_bridge/`) plus a single-page
+WebTransport viewer (`web/wt_viewer/`) — lets a Chromium browser display
+RFC 9828 streams without any native binary on the viewing host. Build
+prerequisites (Go ≥ 1.22, Node.js ≥ 18, Emscripten, OpenSSL, Python 3),
+the LAN launcher, and the URL parameter reference live in
+[**wt_viewer.md**](wt_viewer.md). The viewer reuses the
+multi-threaded SIMD WASM artefact built by the WebAssembly section
+above, so build that first.
 
 ## Running the test suite
 

--- a/docs/jpip.md
+++ b/docs/jpip.md
@@ -18,14 +18,36 @@ Three demos ship with the library:
 All three share the same [`open_htj2k_jpip_server`](#server-open_htj2k_jpip_server)
 and the core `source/core/jpip/` library.
 
+## Build prerequisites
+
+The three native binaries have different build-flag requirements:
+
+| Binary | Build flag | Native deps |
+|---|---|---|
+| `open_htj2k_jpip_server` | none (always built) | None beyond the core library |
+| `open_htj2k_jpip_benchmark` | none (always built) | None beyond the core library |
+| `open_htj2k_jpip_demo` | **`-DOPENHTJ2K_RTP=ON`** (shares the GLFW renderer with `open_htj2k_rtp_recv`) | GLFW 3.x; OpenGL 3.3 on Linux/Windows or Metal on macOS — see [building.md](building.md#building-the-experimental-rfc-9828-rtp-receiver) |
+
+For HTTP/3 over QUIC on either the server or the native demo, add
+`-DOPENHTJ2K_QUIC=ON`. Required libraries (MsQuic + nghttp3) and
+per-platform install commands are documented in
+[building.md → JPIP HTTP/3 prerequisites](building.md#jpip-http3-prerequisites-opt-in).
+The HTTP/1.1 transport is always available.
+
 ## Quick start
 
-Build the server, native demo, and benchmark:
+Build the server, benchmark, and native demo (the demo needs the
+extra `-DOPENHTJ2K_RTP=ON` flag because it shares its renderer with
+`open_htj2k_rtp_recv`):
 
 ```bash
-cmake -B build -DCMAKE_BUILD_TYPE=Release -DOPENHTJ2K_THREAD=ON
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DOPENHTJ2K_RTP=ON
 cmake --build build -j
 ```
+
+If you only need the server and benchmark (e.g. for CI or headless
+deployment), drop `-DOPENHTJ2K_RTP=ON` and the cmake step has no
+window-system or GPU dependencies.
 
 Serve a codestream and drive it from the native demo:
 
@@ -44,9 +66,11 @@ exercises every byte of the JPP-stream wire format):
 ./build/bin/open_htj2k_jpip_demo input.j2c
 ```
 
-Browser demos are deployed at `https://htj2k-demo.pages.dev/`; point
-them at your own server with the `?server=` URL parameter or the
-**Server** field in the top bar.
+Browser demos are deployed at `https://htj2k-demo.pages.dev/` and run
+in any current Chromium- or Firefox-based browser; point them at your
+own server with the `?server=` URL parameter or the **Server** field
+in the top bar. Building the browser demos locally requires
+Emscripten — see [building.md → Building for WebAssembly](building.md#building-for-webassembly-wasm).
 
 ## Server — `open_htj2k_jpip_server`
 

--- a/docs/wasm_bench.md
+++ b/docs/wasm_bench.md
@@ -16,6 +16,12 @@ decodes and optionally dumps planar buffers for comparison.
 
 ## Prerequisites
 
+- **Node.js ≥ 18** to run the bench driver (uses modern ESM, top-level
+  await, and the `node:test` shape consistent with the rest of the
+  WASM tooling in this repo).
+- **Emscripten** to build the WASM artefacts the driver loads — see
+  [building.md → Building for WebAssembly](building.md#building-for-webassembly-wasm).
+
 Build at least one WASM variant first. The bench driver looks in
 `${WEB_DIR}/../build_wasm_prof/html/` by default; override with
 `--build-dir` to point elsewhere.

--- a/docs/wt_viewer.md
+++ b/docs/wt_viewer.md
@@ -33,6 +33,18 @@ change.
                                                          └────────────────┘
 ```
 
+## Prerequisites
+
+| Component | Required for | Minimum version | Notes |
+|---|---|---|---|
+| **Go** | Building `wt_bridge` | **1.22** | Pinned by `tools/wt_bridge/go.mod`. `go build` will refuse older toolchains. |
+| **Node.js** | Static server (`web/perf/serve.mjs`), fixture replayer (`udp_replay.mjs`) | **18** | Modern ESM + WebCrypto APIs are used. |
+| **Emscripten** | WASM artefacts under `web/build_wt/` | 3.x or 5.x | See [building.md → Building for WebAssembly](building.md#building-for-webassembly-wasm). |
+| **OpenSSL** | HTTPS dev cert for the static server | any 1.1+ | Required by `gen_static_cert.sh`. Skip with `HTTP_NO_TLS=1` (then WebTransport works only from `http://localhost` on the bridge host). |
+| **Python 3** | URL-encoding inside `run_lan.sh` | 3.6+ | Any system `python3` works. |
+| **Chromium-based browser** | Viewer | latest stable | Firefox WebTransport is partial / behind a flag; Safari has no implementation. See [Browser support](#caveats-and-constraints). |
+| `iproute2` (`ip` command) | LAN-IP autodetect in `run_lan.sh` | — | Linux only. On macOS / BSD, set `LAN_IP=<addr>` before invoking the launcher. |
+
 ## Components
 
 - [`tools/wt_bridge/`](../tools/wt_bridge/) — Go relay. Binds a UDP

--- a/tools/wt_bridge/README.md
+++ b/tools/wt_bridge/README.md
@@ -10,6 +10,14 @@ Streams (not datagrams) because Chromium's negotiated WebTransport datagram
 size caps at ~1170 B, below typical RFC 9828 packet sizes (~1400 B). On LAN
 the head-of-line cost vs datagrams is negligible.
 
+## Prerequisites
+
+- **Go ≥ 1.22** — pinned by `go.mod`; older toolchains will refuse to build.
+- No `cgo`, no architecture-specific code — a Go toolchain is the only
+  build-time requirement.
+- For the end-to-end LAN viewer stack (browser, static server, dev cert),
+  see [`docs/wt_viewer.md`](../../docs/wt_viewer.md#prerequisites).
+
 ## Quick start (dev mode)
 
 ```sh


### PR DESCRIPTION
## Summary

Audit pass over the user-facing build/run docs after a report that the wt_viewer instructions never mention the required Go version. Pure docs change — no source code, tests, or conformance suite touched.

**Prerequisite gaps closed**

- `docs/wt_viewer.md` — new Prerequisites table: Go ≥ 1.22, Node.js ≥ 18, Emscripten, OpenSSL, Python 3, Chromium, `iproute2` for the Linux LAN-IP autodetect in `run_lan.sh`.
- `tools/wt_bridge/README.md` — Prerequisites block above Quick start, with back-link to `wt_viewer.md`.
- `docs/building.md` — adds a "WebTransport browser viewer" pointer so the wt stack is discoverable from the main build doc.
- `docs/building.md` — Requirements section now lists **libtiff** (auto-detected, gates TIFF input in `open_htj2k_enc`) with per-distro install commands.
- `docs/building.md` — new "JPIP HTTP/3 prerequisites" section with Linux/Windows/macOS install paths for MsQuic + nghttp3, replacing the macOS-only `brew install` blurb.
- `docs/building.md` — RTP receiver section splits renderer requirements into Linux/Windows (OpenGL 3.3) vs macOS (native Metal, no OpenGL), matching `CMakeLists.txt`.
- `docs/wasm_bench.md` — pins Node.js ≥ 18 explicitly.

**Bug fix flagged in the same audit**

- `docs/jpip.md` Quick start told users to run `open_htj2k_jpip_demo`, but that binary is gated on `-DOPENHTJ2K_RTP=ON` (it shares the GLFW renderer with `open_htj2k_rtp_recv`). Added a Build prerequisites table and corrected the cmake invocation; users following Quick start would otherwise hit `No such file or directory`.

**Doc-vs-reality cleanup**

- `-DOPENHTJ2K_THREAD=ON` is no longer a CMake option — `CMakeLists.txt` has no `option(OPENHTJ2K_THREAD ...)` declaration (only `OPENHTJ2K_QUIC`, `OPENHTJ2K_RTP`, `BUILD_SHARED_LIBS`, `ENABLE_AVX2`, `ENABLE_ARM_NEON` are). Threading is enabled internally whenever `find_package(Threads)` succeeds, so the `-D` flag was being silently ignored. Removed from `README.md`, `docs/building.md` (4 sites), `docs/jpip.md`.

## Test plan

- [ ] Render `docs/building.md`, `docs/wt_viewer.md`, `docs/jpip.md`, `docs/wasm_bench.md`, `tools/wt_bridge/README.md`, and `README.md` on GitHub and visually check formatting (tables, code fences, anchor links).
- [ ] Verify the new intra-doc anchors resolve: `building.md#building-for-webassembly-wasm`, `building.md#building-the-experimental-rfc-9828-rtp-receiver`, `building.md#jpip-http3-prerequisites-opt-in`, `wt_viewer.md#caveats-and-constraints`, `wt_viewer.md#prerequisites`.
- [ ] Confirm a fresh clone + `cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j` (no `-DOPENHTJ2K_THREAD=ON`) still produces a multi-threaded library on Linux/macOS — i.e. the doc cleanup matches the auto-detection behaviour.
- [ ] Confirm `cmake -B build -DCMAKE_BUILD_TYPE=Release -DOPENHTJ2K_RTP=ON && cmake --build build -j` produces both `open_htj2k_rtp_recv` and `open_htj2k_jpip_demo`, validating the corrected `docs/jpip.md` Quick start.
- [ ] On a system without libtiff installed, confirm CMake configure prints no `libtiff found` line and the encoder rejects `.tif` inputs at runtime — matches the new "Optional (auto-detected)" subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)