### PR TITLE
tests: fix ctest race conditions under -j

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -476,9 +476,33 @@ install(FILES "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${PROJECT_NAME}.pc"
 ################################################################################################
 # Testing
 ################################################################################################
-# conformance testing
+# Snapshot the test list before any tests/*.cmake include so we can attach the
+# `test_artifacts` cleanup fixture to every test added below — without this,
+# tests added by sibling files (batch_validation, jpip_phase1, encoder_test,
+# row_range_validation) escaped the FIXTURES_REQUIRED loop that used to live
+# inside decoder_conformance.cmake, letting cleanup_artifacts race their
+# decoder output and produce intermittent "file X not found" failures under
+# `ctest -j`.
+get_property(_tests_before_conformance DIRECTORY PROPERTY TESTS)
+
+# conformance testing — declares the `test_artifacts` cleanup fixture and the
+# main HT/Part-1/Part-2/WASM test sets.
 include(${CMAKE_CURRENT_SOURCE_DIR}/tests/decoder_conformance.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/tests/batch_validation.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/tests/encoder_test.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/tests/jpip_phase1.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/tests/row_range_validation.cmake)
+
+# Auto-attach the cleanup fixture to every test added by the includes above.
+# Skip cleanup_artifacts itself (it IS the fixture), and skip tests that
+# already declared FIXTURES_REQUIRED explicitly (encoder_test does this so
+# its DEPENDS chain is preserved).
+get_property(_tests_after_conformance DIRECTORY PROPERTY TESTS)
+foreach(_t IN LISTS _tests_after_conformance)
+  if(NOT _t IN_LIST _tests_before_conformance AND NOT _t STREQUAL "cleanup_artifacts")
+    get_test_property(${_t} FIXTURES_REQUIRED _existing)
+    if(NOT _existing OR NOT "test_artifacts" IN_LIST _existing)
+      set_tests_properties(${_t} PROPERTIES FIXTURES_REQUIRED test_artifacts)
+    endif()
+  endif()
+endforeach()

--- a/tests/decoder_conformance.cmake
+++ b/tests/decoder_conformance.cmake
@@ -2,16 +2,15 @@
 enable_testing()
 set(CONFORMANCE_DATA_DIR "${CMAKE_CURRENT_SOURCE_DIR}/conformance_data")
 
-# Remove stale test artifacts (*.pgx, *.ppm, *.pgm, *.j2c) before tests run.
-# Attached via CTest fixtures so it executes once before the first decode test.
+# Remove stale test artifacts (*.pgx, *.ppm, *.pgm) before tests run.  Attached
+# via the CTest `test_artifacts` fixture so it executes once before any test
+# that depends on it.  The fixture is auto-attached to every other test by the
+# loop at the end of CMakeLists.txt — that loop runs AFTER every tests/*.cmake
+# include site, so it covers tests defined by sibling files (batch_validation,
+# jpip_phase1, row_range_validation, encoder_test) too.
 add_test(NAME cleanup_artifacts
   COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cleanup_artifacts.cmake)
 set_tests_properties(cleanup_artifacts PROPERTIES FIXTURES_SETUP test_artifacts)
-
-# Collect all test names added by included files so we can attach the cleanup
-# fixture to them after all includes.  We snapshot the test list before and
-# after to compute the delta.
-get_property(_tests_before DIRECTORY PROPERTY TESTS)
 
 ## Conformance tests for HT
 # PROFILE 0
@@ -54,11 +53,3 @@ if(NODE_EXECUTABLE)
 else()
   message(STATUS "Node.js not found -- skipping WASM conformance tests")
 endif()
-
-# Attach the cleanup fixture to every test added above.
-get_property(_tests_after DIRECTORY PROPERTY TESTS)
-foreach(_t IN LISTS _tests_after)
-  if(NOT _t IN_LIST _tests_before AND NOT _t STREQUAL "cleanup_artifacts")
-    set_tests_properties(${_t} PROPERTIES FIXTURES_REQUIRED test_artifacts)
-  endif()
-endforeach()

--- a/tests/jpip_phase1.cmake
+++ b/tests/jpip_phase1.cmake
@@ -23,6 +23,19 @@ add_test(NAME jpip_tcp_loopback COMMAND jpip_tcp_check)
 # recovers the JPP-stream bit-for-bit.
 add_test(NAME jpip_chunked_roundtrip COMMAND jpip_chunked_check)
 
+# Both jpip_tcp_loopback and jpip_chunked_roundtrip bind a fixed TCP port
+# on 127.0.0.1 (kTestPort=19283 / 19285 in tests/tools/jpip_*_check/main.cpp).
+# RESOURCE_LOCK serializes them against each other under `ctest -j` so two
+# concurrent runs can't EADDRINUSE; RUN_SERIAL TRUE additionally pauses the
+# whole suite while these run, so a TIME_WAIT residue from a prior test in
+# the same `ctest` invocation can't collide.  Without these properties
+# `ctest -j` on a fast CI runner intermittently reports "bind: address
+# already in use" on the second test to start.
+set_tests_properties(jpip_tcp_loopback jpip_chunked_roundtrip
+  PROPERTIES
+    RESOURCE_LOCK jpip_loopback_ports
+    RUN_SERIAL    TRUE)
+
 # ── StreamingJppParser split-at-every-offset stress (issue #297) ──
 # For every possible two-chunk split of a real JPP-stream, verifies that
 # StreamingJppParser reconstructs the same DataBinSet the one-shot parser


### PR DESCRIPTION
## Summary

Two structural problems in the test suite produced intermittent failures under `ctest -j`. Both fixed, no conformance test behaviour changed — only ctest scheduling.

### 1. cleanup_artifacts fixture coverage gap (the dominant race)

`tests/decoder_conformance.cmake` declared the `FIXTURES_SETUP` for `cleanup_artifacts`, then snapshotted the test list before its own includes and looped over the delta to attach `FIXTURES_REQUIRED` to each new test. **That snapshot ran inside the file**, before the sibling includes (`batch_validation.cmake`, `encoder_test.cmake`, `jpip_phase1.cmake`, `row_range_validation.cmake`) ran from `CMakeLists.txt`. So ~250 tests were unprotected — ctest was free to schedule `cleanup_artifacts` (which globs `*.pgx` / `*.ppm` / `*.pgm` in the build dir and deletes everything matching) at any point after suite start, including between `dec_X` writing a file and `comp_X` reading it.

Symptom: intermittent "File X not found" on `comp_lossless` / `batch_comp_*` / `rr_*` / `jpip_*` that vanished on serial reruns.

Fixed by moving the snapshot+attach loop out of `decoder_conformance.cmake` and into `CMakeLists.txt`, wrapping every `tests/*.cmake` include site. The loop now skips tests that already declare `FIXTURES_REQUIRED test_artifacts` (`encoder_test` does this explicitly) so existing per-file fixtures are preserved.

### 2. JPIP test port collision

`jpip_tcp_loopback` and `jpip_chunked_roundtrip` both bind a fixed TCP port on 127.0.0.1 (`kTestPort = 19283 / 19285` in `tests/tools/jpip_*_check/main.cpp`). Under `ctest -j` they could start concurrently and one would `EADDRINUSE`; even sequentially, a fast rerun could hit the previous bind's `TIME_WAIT`. Added `RESOURCE_LOCK jpip_loopback_ports` + `RUN_SERIAL TRUE` to serialize them against each other and the rest of the suite.

## Verification

`ctest --show-only=json-v1` confirms previously-unprotected tests now have the fixture (with `cleanup_artifacts` correctly listed in their auto-derived `DEPENDS`):

| Test | Fixture | Resource lock | Run serial |
|---|---|---|---|
| `batch_dec_p0_ht_01_11` | `test_artifacts` ✅ (was missing) | — | — |
| `jpip_chunked_roundtrip` | `test_artifacts` ✅ (was missing) | `jpip_loopback_ports` ✅ | `TRUE` ✅ |
| `jpip_tcp_loopback` | `test_artifacts` ✅ (was missing) | `jpip_loopback_ports` ✅ | `TRUE` ✅ |
| `rr_p0_ht_05_11` | `test_artifacts` ✅ (was missing) | — | — |
| `comp_lossless` | `test_artifacts` ✅ (still — encoder_test sets it explicitly) | — | — |

## Out of scope (separate follow-ups)

- **`comp_p1_ht_05_11{r,g,b}` reproducibly fail on `ubuntu-24.04-arm/gcc`.** Deterministic (not a race), pre-dates this branch, NOT caused by the cleanup race — those tests already had `FIXTURES_REQUIRED`. Likely a floating-point codegen difference vs the `imgcmp` PAE/MSE thresholds in `tests/ht_profile1.cmake:45-47`. Same tests pass on `ubuntu-24.04-arm/clang` (same OS, different compiler), `ubuntu-latest/{gcc,clang}`, both macOS, and `windows-11-arm`.
- **`tests/lb_stream_validation.cmake` is never included from `CMakeLists.txt`** — dead file with valid Windows-ARM64 `WILL_FAIL` markers (lines 43-45, 73-75) that suggest it WAS used previously. Re-enable in a separate PR after sanity-checking it still passes on every config.
- **CI runs `ctest -VV` without `-j`** in `.github/workflows/cmake.yml`, so the race we fixed never surfaced in CI — only locally. Add `-j $(nproc) --output-on-failure` in a separate PR so future races are caught upstream.

## Test plan

- [ ] CI green on every config (the fixes are scheduling-only, no behaviour change).
- [ ] On a developer machine, `ctest -j$(nproc) --repeat until-fail:10` no longer reproduces the intermittent "File X not found" symptom on `comp_*` / `batch_comp_*` / `rr_*` / `jpip_chunked_roundtrip`.
- [ ] `ctest -N` lists the same 476 tests as before (no test additions / removals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)