### PR TITLE
ci(cmake): bump actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -77,7 +77,7 @@ jobs:
             c_compiler: cl
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set reusable strings
         # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
@@ -122,15 +122,15 @@ jobs:
   wasm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Emscripten
         uses: mymindstorm/setup-emsdk@v14
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Build WASM (scalar + SIMD)
         run: |

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -125,7 +125,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Setup Emscripten
-        uses: mymindstorm/setup-emsdk@v14
+        uses: mymindstorm/setup-emsdk@v16
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,11 +39,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -68,4 +68,4 @@ jobs:
        cmake --build /home/runner/work/OpenHTJ2K/OpenHTJ2K/build --config Release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/deploy-wasm-demo.yml
+++ b/.github/workflows/deploy-wasm-demo.yml
@@ -19,19 +19,19 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Cloudflare's wrangler CLI now requires Node 22+; the runner's default
       # Node is still 20.x, which made `npm install -g wrangler@latest`
       # succeed but `wrangler pages deploy` fail with "requires at least
       # Node.js v22.0.0".  Pin Node 22 so the deploy step stays green even
       # as wrangler bumps its minimum.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
 
       - name: Setup Emscripten
-        uses: mymindstorm/setup-emsdk@v14
+        uses: mymindstorm/setup-emsdk@v16
         with:
           version: 3.1.61
           actions-cache-folder: emsdk-cache

--- a/.github/workflows/warm-rtp-cache.yml
+++ b/.github/workflows/warm-rtp-cache.yml
@@ -23,7 +23,7 @@ jobs:
       github.event_name != 'workflow_run' ||
       github.event.workflow_run.conclusion == 'success'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Warm each URL listed in rtp-samples.txt
         run: |
           while IFS= read -r url; do

--- a/.github/workflows/wt_viewer.yml
+++ b/.github/workflows/wt_viewer.yml
@@ -37,7 +37,7 @@ jobs:
       run:
         working-directory: tools/wt_bridge
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -84,18 +84,18 @@ jobs:
     name: WASM build + viewer API surface
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Emscripten
-        uses: mymindstorm/setup-emsdk@v14
+        uses: mymindstorm/setup-emsdk@v16
         with:
           version: 3.1.61
           actions-cache-folder: emsdk-cache
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Build WASM (mt_simd target only — what the viewer actually loads)
         run: |
@@ -178,7 +178,7 @@ jobs:
     name: end-to-end (replay → bridge → viewer → decode)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -188,15 +188,15 @@ jobs:
           cache-dependency-path: tools/wt_bridge/go.sum
 
       - name: Setup Emscripten
-        uses: mymindstorm/setup-emsdk@v14
+        uses: mymindstorm/setup-emsdk@v16
         with:
           version: 3.1.61
           actions-cache-folder: emsdk-cache
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Build bridge
         working-directory: tools/wt_bridge


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` v4 → v5 and `actions/setup-node` v4 → v5 in `cmake.yml`
- Update WASM job Node.js from 20 → 22 (current LTS)
- Silences the GitHub deprecation warning (Node.js 20 enforcement starts 2026-06-02, removal 2026-09-16)

## Test plan
- [ ] All matrix jobs pass (build + test)
- [ ] WASM job builds and passes conformance tests on Node.js 22
- [ ] No Node.js 20 deprecation warning in job logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)