### PR TITLE
ci(wt_viewer): bump actions/setup-go v5 → v6

### DIFF
--- a/.github/workflows/wt_viewer.yml
+++ b/.github/workflows/wt_viewer.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: tools/wt_bridge/go.mod
           cache: true
@@ -181,7 +181,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: tools/wt_bridge/go.mod
           cache: true


### PR DESCRIPTION
## Summary
- Bump `actions/setup-go` v5 → v6 in `wt_viewer.yml` (bridge + e2e-smoke jobs)
- Silences the remaining Node.js 20 deprecation warning on the bridge (Go) job

## Test plan
- [ ] bridge (Go) job passes without Node.js 20 deprecation warning
- [ ] end-to-end smoke passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)