### PR TITLE
ci: bump codeql-action v3 → v4 and upload-artifact v4 → v7

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -68,4 +68,4 @@ jobs:
        cmake --build /home/runner/work/OpenHTJ2K/OpenHTJ2K/build --config Release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/wt_viewer.yml
+++ b/.github/workflows/wt_viewer.yml
@@ -224,7 +224,7 @@ jobs:
 
       - name: Upload smoke logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-logs
           path: |


### PR DESCRIPTION
## Summary
- Bump `github/codeql-action` v3 → v4 in `codeql-analysis.yml` (Node.js 24, v3 deprecated Dec 2026)
- Bump `actions/upload-artifact` v4 → v7 in `wt_viewer.yml`
- Eliminates all remaining Node.js 20 deprecation warnings across all workflows

## Test plan
- [ ] All cmake.yml matrix jobs pass
- [ ] All wt_viewer.yml jobs pass (bridge, wasm-exports, e2e-smoke)
- [ ] No Node.js 20 deprecation warnings in any job logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)