### PR TITLE
fix(coding): resolve 12 CodeQL integer-multiplication-cast-to-long alerts

### DIFF
--- a/source/core/coding/coding_units.cpp
+++ b/source/core/coding/coding_units.cpp
@@ -5789,15 +5789,15 @@ void j2k_tile::decode_line_based_predecoded(j2k_main_header &hdr, uint8_t reduce
             const bool is_ht = (block->Cmodes & HT) >> 6;
             if (!is_ht) {
               // EBCOT: all three buffers must be pre-zeroed.
-              memset(block->sample_buf, 0, QWx2 * QHx2 * sizeof(int32_t));
-              memset(block->block_states, 0, (QWx2 + 2) * (QHx2 + 2));
+              memset(block->sample_buf, 0, static_cast<size_t>(QWx2) * QHx2 * sizeof(int32_t));
+              memset(block->block_states, 0, static_cast<size_t>(QWx2 + 2) * (QHx2 + 2));
               memset(block->block_contexts, 0,
-                     (QHx2 / 4 + 2) * (QWx2 + 2) * sizeof(uint32_t));
+                     static_cast<size_t>(QHx2 / 4 + 2) * (QWx2 + 2) * sizeof(uint32_t));
             } else if (block->num_passes > 1) {
               // HT multi-pass: sigprop/magref read the block_states border
               // (written by cleanup only for the interior). Zero block_states;
               // sample_buf is fully written by cleanup before sigprop reads it.
-              memset(block->block_states, 0, (QWx2 + 2) * (QHx2 + 2));
+              memset(block->block_states, 0, static_cast<size_t>(QWx2 + 2) * (QHx2 + 2));
             }
             // HT single-pass: ht_cleanup_decode initialises all positions
             // before reading — no pre-zeroing needed.

--- a/source/core/coding/subband_row_buf.cpp
+++ b/source/core/coding/subband_row_buf.cpp
@@ -310,12 +310,12 @@ void j2k_subband_row_buf::decode_strip_core(sprec_t *target_buf, int32_t y0, int
             bt.block->i_samples = target_buf + bt.row_off + bt.col_off;
           const bool is_ht = (bt.block->Cmodes & HT) >> 6;
           if (!is_ht) {
-            std::memset(bt.block->sample_buf, 0, bt.QWx2 * bt.QHx2 * sizeof(int32_t));
-            std::memset(bt.block->block_states, 0, (bt.QWx2 + 2) * (bt.QHx2 + 2));
+            std::memset(bt.block->sample_buf, 0, static_cast<size_t>(bt.QWx2) * bt.QHx2 * sizeof(int32_t));
+            std::memset(bt.block->block_states, 0, static_cast<size_t>(bt.QWx2 + 2) * (bt.QHx2 + 2));
             std::memset(bt.block->block_contexts, 0,
-                        (bt.QHx2 / 4 + 2) * (bt.QWx2 + 2) * sizeof(uint32_t));
+                        static_cast<size_t>(bt.QHx2 / 4 + 2) * (bt.QWx2 + 2) * sizeof(uint32_t));
           } else if (bt.block->num_passes > 1) {
-            std::memset(bt.block->block_states, 0, (bt.QWx2 + 2) * (bt.QHx2 + 2));
+            std::memset(bt.block->block_states, 0, static_cast<size_t>(bt.QWx2 + 2) * (bt.QHx2 + 2));
           }
         }
         // Batch-push all tasks under a single mutex lock + notify_all.
@@ -655,12 +655,12 @@ void j2k_subband_row_buf::trigger_prefetch(int32_t next_y0) {
     pb.block->i_samples             = pbuf + pb.row_off + pb.col_off;
     const bool is_ht = (pb.block->Cmodes & HT) >> 6;
     if (!is_ht) {
-      std::memset(pb.block->sample_buf, 0, pb.QWx2 * pb.QHx2 * sizeof(int32_t));
-      std::memset(pb.block->block_states, 0, (pb.QWx2 + 2) * (pb.QHx2 + 2));
+      std::memset(pb.block->sample_buf, 0, static_cast<size_t>(pb.QWx2) * pb.QHx2 * sizeof(int32_t));
+      std::memset(pb.block->block_states, 0, static_cast<size_t>(pb.QWx2 + 2) * (pb.QHx2 + 2));
       std::memset(pb.block->block_contexts, 0,
-                  (pb.QHx2 / 4 + 2) * (pb.QWx2 + 2) * sizeof(uint32_t));
+                  static_cast<size_t>(pb.QHx2 / 4 + 2) * (pb.QWx2 + 2) * sizeof(uint32_t));
     } else if (pb.block->num_passes > 1) {
-      std::memset(pb.block->block_states, 0, (pb.QWx2 + 2) * (pb.QHx2 + 2));
+      std::memset(pb.block->block_states, 0, static_cast<size_t>(pb.QWx2 + 2) * (pb.QHx2 + 2));
     }
   }
   // Batch-push all tasks under a single mutex lock + notify_all.


### PR DESCRIPTION
## Summary
- Cast the first operand to `size_t` in 12 `memset` size expressions where `uint32_t × uint32_t` was implicitly widened after the multiplication
- Affects `coding_units.cpp` (4 sites) and `subband_row_buf.cpp` (8 sites)
- Resolves all 12 open `cpp/integer-multiplication-cast-to-long` CodeQL alerts

## Test plan
- [ ] All matrix build + test jobs pass
- [ ] CodeQL scan on main shows 0 open alerts after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)