### PR TITLE
fix(wasm): rebase timeline anchor after pace-drop to prevent playback stall

### DIFF
--- a/web/rtp_demo.html
+++ b/web/rtp_demo.html
@@ -1547,10 +1547,16 @@ function startDisplayLoop(myGen) {
       const target = wallStart + totalPausedMs + dtMs;
       const period = entry.framePeriodMs || (1000 / 60);
 
-      // Pace-drop: too far behind?  Discard and re-check next entry.
+      // Pace-drop: too far behind?  Discard and rebase the timeline
+      // anchor so the next surviving frame is scheduled relative to
+      // "now" — without this, every subsequent frame stays behind the
+      // stale anchor and gets pace-dropped too, stalling playback.
+      // Mirrors the "runaway rebase" in the native RTP receiver.
       if (paceDropEnabled() && rafTimestamp - target > PACE_DROP_PERIODS * period) {
         ringPop();
         droppedByPace++;
+        wallStart = rafTimestamp;
+        rtpStart  = (_ringCount > 0) ? ringPeek().rtpTimestamp : rtpStart;
         continue;
       }
 


### PR DESCRIPTION
## Summary
- The rAF display loop in `rtp_demo.html` dropped late frames without rebasing `wallStart`/`rtpStart`, causing a cascade where every subsequent frame was also pace-dropped until the ring emptied and playback froze
- Adds a timeline rebase after each pace-drop (mirrors the native RTP receiver's "runaway rebase" at `pipeline_multi_threaded.cpp:445-452`)
- Particularly visible with the AWS CloudFront 150-frame fixture

## Test plan
- [ ] Play the CloudFront 150-frame content in the WASM rtp_demo with pace-drop enabled (`?drop=1`)
- [ ] Verify playback recovers after pace drops instead of stalling
- [ ] Confirm `droppedByPace` counter increments but frames continue rendering

🤖 Generated with [Claude Code](https://claude.ai/claude-code)