### PR TITLE
fix(wasm): only rebase timeline when pace-drops drain the ring

### DIFF
--- a/web/rtp_demo.html
+++ b/web/rtp_demo.html
@@ -1547,16 +1547,14 @@ function startDisplayLoop(myGen) {
       const target = wallStart + totalPausedMs + dtMs;
       const period = entry.framePeriodMs || (1000 / 60);
 
-      // Pace-drop: too far behind?  Discard and rebase the timeline
-      // anchor so the next surviving frame is scheduled relative to
-      // "now" — without this, every subsequent frame stays behind the
-      // stale anchor and gets pace-dropped too, stalling playback.
-      // Mirrors the "runaway rebase" in the native RTP receiver.
+      // Pace-drop: too far behind?  Discard and re-check next entry.
+      // If the ring drains completely, reset the anchor so the next
+      // decoded frame starts a fresh timeline instead of cascading
+      // into further drops that stall playback.
       if (paceDropEnabled() && rafTimestamp - target > PACE_DROP_PERIODS * period) {
         ringPop();
         droppedByPace++;
-        wallStart = rafTimestamp;
-        rtpStart  = (_ringCount > 0) ? ringPeek().rtpTimestamp : rtpStart;
+        if (_ringCount === 0) { wallStart = 0; totalPausedMs = 0; }
         continue;
       }
 


### PR DESCRIPTION
## Summary
- Replaces the per-drop timeline rebase from #358 with a ring-drain-only rebase
- Individual pace-drops no longer disrupt the timeline — surviving frames stay on-schedule, avoiding the sawtooth choppiness visible at 25 fps decode vs 30 fps source
- When drops drain the ring completely (catastrophic stall), `wallStart = 0` triggers a fresh anchor on the next decoded frame, preventing the original cascade-to-stall bug

## Test plan
- [ ] Play CloudFront 150-frame 4K@30fps content with "Paced (RTP clock) + Drop late frames"
- [ ] Verify playback is smooth (no sawtooth choppiness) when decode throughput is near source rate
- [ ] Verify playback recovers after a network stall that drains the ring
- [ ] Confirm ASAP mode behavior is unchanged

🤖 Generated with [Claude Code](https://claude.ai/claude-code)