### PR TITLE
fix(coding): gate fused-dequant on even block height in SIMD variants

### DIFF
--- a/source/core/coding/ht_block_decoding_avx2.cpp
+++ b/source/core/coding/ht_block_decoding_avx2.cpp
@@ -1128,9 +1128,12 @@ bool htj2k_decode(j2k_codeblock *block, const uint8_t ROIshift) {
     // Fused dequant: the MagSgn SIMD stores write in units of 4 (128-bit) or 8 (256-bit)
     // elements.  When block width is not a multiple of 4, the extra elements overflow into
     // adjacent blocks' column range in the shared output buffer (subband or ring buffer).
-    // This is safe in single-threaded decode (sequential order overwrites correctly) but
-    // causes a data race in multi-threaded decode.  Gate on width % 4 == 0 to avoid this.
-    if (num_ht_passes == 1 && ROIshift == 0 && (block->size.x & 3) == 0) {
+    // Additionally, the kernel processes rows in pairs and writes both rows of every pair
+    // unconditionally; when block height is odd the last pair overflows one full row into
+    // the next block's region.  Both overflows are benign in single-threaded decode
+    // (sequential order overwrites correctly) but cause data races in multi-threaded decode.
+    if (num_ht_passes == 1 && ROIshift == 0 && (block->size.x & 3) == 0
+        && (block->size.y & 1u) == 0) {
       ht_cleanup_decode<true, true>(block, static_cast<uint8_t>(30 - S_blk), Lcup, Pcup, Scup);
       dequant_done = true;
     } else if (num_ht_passes == 1) {

--- a/source/core/coding/ht_block_decoding_neon.cpp
+++ b/source/core/coding/ht_block_decoding_neon.cpp
@@ -1009,7 +1009,10 @@ bool htj2k_decode(j2k_codeblock *block, const uint8_t ROIshift) {
     bool dequant_done = false;
     // Fused dequant gate: NEON stores write 4 elements (128-bit); when block width
     // is not a multiple of 4, the overshoot corrupts adjacent blocks in parallel decode.
-    if (num_ht_passes == 1 && ROIshift == 0 && (block->size.x & 3) == 0) {
+    // Also gate on even height: the kernel writes row-pairs unconditionally and odd
+    // height overflows one row into the next block's region.
+    if (num_ht_passes == 1 && ROIshift == 0 && (block->size.x & 3) == 0
+        && (block->size.y & 1u) == 0) {
       ht_cleanup_decode<true, true>(block, static_cast<uint8_t>(30 - S_blk), Lcup, Pcup, Scup);
       dequant_done = true;
     } else if (num_ht_passes == 1) {

--- a/source/core/coding/ht_block_decoding_wasm.cpp
+++ b/source/core/coding/ht_block_decoding_wasm.cpp
@@ -932,7 +932,10 @@ bool htj2k_decode(j2k_codeblock *block, const uint8_t ROIshift) {
     bool dequant_done = false;
     // Fused dequant gate: WASM SIMD stores write 4 elements (128-bit); when block width
     // is not a multiple of 4, the overshoot corrupts adjacent blocks in parallel decode.
-    if (num_ht_passes == 1 && ROIshift == 0 && (block->size.x & 3) == 0) {
+    // Also gate on even height: the kernel writes row-pairs unconditionally and odd
+    // height overflows one row into the next block's region.
+    if (num_ht_passes == 1 && ROIshift == 0 && (block->size.x & 3) == 0
+        && (block->size.y & 1u) == 0) {
       ht_cleanup_decode<true, true>(block, static_cast<uint8_t>(30 - S_blk), Lcup, Pcup, Scup);
       dequant_done = true;
     } else if (num_ht_passes == 1) {


### PR DESCRIPTION
## Summary

- The fused-dequant path writes samples in 2-row pairs unconditionally; odd-height blocks overflow one row into the adjacent block's output region
- Under multi-threaded decode (prefetch dispatch), blocks finish out-of-order and the overflow clobbers valid data — producing PAE 50+ on `ds1_ht_05_b11.j2k` (conformance tests #126-128)
- The scalar variant already guarded against this (`size.y & 1 == 0`); the AVX2, NEON, and WASM variants only checked width alignment and were missing the height guard

## Test plan

- [x] Full 670-test conformance suite passes locally (0 failures)
- [ ] CI `build (ubuntu-latest, Release, gcc)` — the previously-flaky job — now passes deterministically
- [ ] Confirm no perf regression on 4K decode (the non-fused fallback path is only taken for odd-height blocks, which are rare in practice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)