### PR TITLE
feat(wasm): configurable ring, drop/underrun stats, pre-decode skip

### DIFF
--- a/web/rtp_demo.html
+++ b/web/rtp_demo.html
@@ -538,6 +538,18 @@
       <span id="statDropsPace">0</span>
     </div>
     <div class="stat-chip">
+      <label>Drop rate</label>
+      <span id="statDropRate">—</span>
+    </div>
+    <div class="stat-chip">
+      <label>Pre-skip</label>
+      <span id="statPreSkip">0</span>
+    </div>
+    <div class="stat-chip">
+      <label>Underruns</label>
+      <span id="statUnderruns">0</span>
+    </div>
+    <div class="stat-chip">
       <label>Seq gaps</label>
       <span id="statGaps">0</span>
     </div>
@@ -808,6 +820,9 @@ const PACE_DROP_PERIODS = Math.max(1,
 const PRE_ROLL_FRAMES = Math.max(0,
     Number(new URLSearchParams(location.search).get('preroll')) || 3);
 let droppedByPace = 0;
+let _prevDroppedByPace = 0;     // previous stats-tick value for drop-rate delta
+let _underrunCount = 0;         // cumulative rebuffer events
+let _lastSkipInterval = 0;      // last pre-decode skip interval sent to worker
 let framePeriodMs = 0;          // derived from inter-frame RTP Δts; 0 before second frame arrives
 // Paced-mode backpressure counter: incremented for each marker packet pushed
 // to the worker; throttle holds the for-await loop while
@@ -867,7 +882,8 @@ const verboseLog = new URLSearchParams(window.location.search).has('verbose');
 // can't hold multiple frames there) and pushed into this ring; the rAF
 // loop consumes them in order at VSync ticks.
 // ASAP mode bypasses the ring entirely and renders inline as before.
-const RING_CAPACITY = 4;
+const RING_CAPACITY = Math.max(2, Math.min(32,
+    Number(new URLSearchParams(location.search).get('ring')) || 4));
 const _ring = new Array(RING_CAPACITY).fill(null);
 let _ringHead = 0;   // next write index (producer)
 let _ringTail = 0;   // next read index (consumer)
@@ -1433,6 +1449,21 @@ function onFrameFromWorker(frame) {
   lastDecodeTimes.push(decodeMs);
   if (lastDecodeTimes.length > FPS_WIN) lastDecodeTimes.shift();
   decodeCount++;
+
+  // Pre-decode skip interval: when decode is consistently slower than source,
+  // tell the worker to skip every Nth frame before decoding.
+  if (currentPacing === 'paced' && lastDecodeTimes.length >= 10 && framePeriodMs > 0) {
+    const decodeAvg = lastDecodeTimes.reduce((a, b) => a + b, 0) / lastDecodeTimes.length;
+    let newInterval = 0;
+    if (decodeAvg > framePeriodMs * 1.05) {
+      newInterval = Math.max(2, Math.round(framePeriodMs / (decodeAvg - framePeriodMs)));
+    }
+    if (newInterval !== _lastSkipInterval) {
+      _lastSkipInterval = newInterval;
+      if (dec) dec.setSkipInterval(newInterval);
+    }
+  }
+
   setStat('imgWidth',  w);
   setStat('imgHeight', h);
   setStat('imgDepth',  depth + ' bpc');
@@ -1574,6 +1605,7 @@ function startDisplayLoop(myGen) {
       _starvedTicks++;
       if (_starvedTicks >= 2 && !_rebuffering) {
         _rebuffering = true;
+        _underrunCount++;
         setStarved(true);
       }
     } else {
@@ -1713,6 +1745,12 @@ function startStatsTicker() {
     setStat('statFrames',  frameCount);                         // displayed
     setStat('statDrops',   workerStats.framesDropped);
     setStat('statDropsPace', droppedByPace);
+    const dropDelta = droppedByPace - _prevDroppedByPace;
+    const dropRate = dt > 0 ? dropDelta / dt : 0;
+    _prevDroppedByPace = droppedByPace;
+    setStat('statDropRate', dropRate.toFixed(1) + ' /s');
+    setStat('statPreSkip', workerStats.skippedByPreDecode || 0);
+    setStat('statUnderruns', _underrunCount);
     setStat('statGaps',    workerStats.seqGaps);
     // Pending = worker reassembler ready queue + decoded-but-undisplayed ring.
     setStat('statPending', workerStats.readyCount + _ringCount);
@@ -1762,8 +1800,11 @@ async function startPlayback(source) {
   _bpResolve = null;
   _starvedTicks = 0;
   _rebuffering = false;
+  _prevDroppedByPace = 0;
+  _underrunCount = 0;
+  _lastSkipInterval = 0;
   setStarved(false);
-  workerStats = { framesEmitted: 0, framesDropped: 0, seqGaps: 0, readyCount: 0, lastError: '' };
+  workerStats = { framesEmitted: 0, framesDropped: 0, seqGaps: 0, readyCount: 0, lastError: '', skippedByPreDecode: 0 };
   // rAF-path state (see module-scope declarations).
   decodeCount = 0;
   decodeFinished = false;

--- a/web/shared/decoder_client.mjs
+++ b/web/shared/decoder_client.mjs
@@ -132,6 +132,11 @@ export class DecoderClient {
     this.worker.postMessage({ type: 'setReduceNL', value: n | 0 });
   }
 
+  setSkipInterval(n) {
+    this._flushBatch();
+    this.worker.postMessage({ type: 'setSkipInterval', value: n | 0 });
+  }
+
   pushPacket(bytes) {
     const len = bytes.byteLength;
     // Defensive: an oversized packet shouldn't reach here (rtp_demo caps at

--- a/web/shared/decoder_worker.mjs
+++ b/web/shared/decoder_worker.mjs
@@ -35,6 +35,9 @@ let lastStatsAt = 0;
 let threadCount = 4;
 let isMtBuild   = true;   // false for 'simd' / 'scalar' — disables create_decoder_mt path
 let reduceNL    = 0;      // resolution-reduce; 0 = full, 1 = half, 2 = quarter
+let skipInterval = 0;     // pre-decode cadence skip: drop every Nth frame (0 = disabled)
+let skipCounter  = 0;
+let skippedByPreDecode = 0;
 // 'planar' = post Y/Cb/Cr buffers (cheap; renderer applies matrix in shader)
 // 'rgba'   = post a single RGBA8 buffer with WASM-side matrix already applied
 //            (used by the Canvas2D fallback; ~2× the bytes but no main-thread work)
@@ -189,6 +192,15 @@ function drainReady() {
   while (true) {
     const fsz = F.rtp_peek(session);
     if (!fsz) return;
+    if (skipInterval > 0) {
+      skipCounter++;
+      if (skipCounter >= skipInterval) {
+        skipCounter = 0;
+        F.rtp_drop_ready(session);
+        skippedByPreDecode++;
+        continue;
+      }
+    }
     if (fsz > FRAME_BUF) {
       self.postMessage({ type: 'error', msg: `frame too large: ${fsz}`, fatal: false });
       F.rtp_drop_ready(session);
@@ -285,6 +297,7 @@ function maybePostStats() {
     seqGaps:       F.rtp_gaps(session),
     readyCount:    F.rtp_ready_count(session),
     lastError:     F.rtp_last_error(session) || '',
+    skippedByPreDecode,
   });
 }
 
@@ -305,6 +318,10 @@ self.addEventListener('message', async ({ data }) => {
         break;
       case 'setReduceNL':
         setReduceNL(data.value);
+        break;
+      case 'setSkipInterval':
+        skipInterval = Math.max(0, data.value | 0);
+        skipCounter = 0;
         break;
       case 'drain':
         // postMessage delivery is FIFO, and pushPacket()'s decode runs


### PR DESCRIPTION
## Summary

- **Configurable ring capacity** via `?ring=N` (default 4, clamped 2-32) — larger values trade latency for smoother playback on high-jitter links
- **New stats**: "Drop rate" (pace-drops/sec), "Underruns" (rebuffer event count), "Pre-skip" (frames skipped before decode) — visible in the on-page stats panel
- **Pre-decode frame skip**: when decode EMA > source period × 1.05, the worker drops every Nth reassembled frame before decoding, saving ~40 ms of wasted CPU per skipped frame

## Test plan

- [ ] `?ring=8&verbose=1` + 4K@30fps paced + drop → confirm ring=8 works, console logs skip interval changes
- [ ] Verify "Drop rate" shows ~5/s when decode is bottleneck (25 fps decode vs 30 fps source)
- [ ] Verify "Pre-skip" increments (worker skipping frames)
- [ ] Throttle to Slow 3G → "Underruns" counter increments
- [ ] `?ring=2` → backpressure engages frequently, no crash
- [ ] ASAP mode → pre-decode skip does NOT activate (paced-only)
- [ ] 1080p content (decode > source rate) → skip interval stays at 0, no pre-skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)