### PR TITLE
feat(wasm): SharedArrayBuffer zero-copy plane delivery

### DIFF
--- a/web/rtp_demo.html
+++ b/web/rtp_demo.html
@@ -893,6 +893,7 @@ function ringPush(entry) {
   if (_ringCount >= RING_CAPACITY) {
     // Defensive: consumer fell behind despite the producer's backpressure
     // yield.  Drop the oldest so we never block indefinitely.
+    releaseSabSlot(_ring[_ringTail]);
     _ring[_ringTail] = null;
     _ringTail = (_ringTail + 1) % RING_CAPACITY;
     _ringCount--;
@@ -911,7 +912,10 @@ function ringPop() {
   return entry;
 }
 function ringClear() {
-  _ring.fill(null);
+  for (let i = 0; i < RING_CAPACITY; i++) {
+    if (_ring[i]) releaseSabSlot(_ring[i]);
+    _ring[i] = null;
+  }
   _ringHead = _ringTail = _ringCount = 0;
 }
 
@@ -1469,10 +1473,25 @@ function onFrameFromWorker(frame) {
   setStat('imgDepth',  depth + ' bpc');
   setStat('numComps',  nc);
 
-  // Build the ring entry.  Worker-delivered ArrayBuffers were transferred,
-  // so wrapping them in Uint8Array doesn't copy.
+  // Build the ring entry.
   let entry;
-  if (mode === 'planar') {
+  if (mode === 'sab') {
+    // SAB zero-copy path: planes live in the shared buffer at slot offset.
+    const base = frame.slot * dec.sabSlotSize + dec.sabFlagBytes;
+    entry = {
+      planar: true, sabSlot: frame.slot,
+      yData:  new Uint8Array(dec.sab, base, w * h),
+      cbData: new Uint8Array(dec.sab, base + dec.sabPlaneMax, frame.cw * frame.ch),
+      crData: new Uint8Array(dec.sab, base + 2 * dec.sabPlaneMax, frame.cw * frame.ch),
+      lumaW: w, lumaH: h,
+      chromaW: frame.cw, chromaH: frame.ch,
+      W: w, H: h, D: depth,
+      matrix, range, ycbcrMode, NC: nc,
+      rtpTimestamp: rtpTs >>> 0,
+      framePeriodMs,
+    };
+  } else if (mode === 'planar') {
+    // Transfer path: ArrayBuffers were transferred, wrapping doesn't copy.
     entry = {
       planar: true,
       yData:  new Uint8Array(frame.y),
@@ -1518,6 +1537,13 @@ function renderEntry(entry) {
                     entry.matrix, entry.range, entry.ycbcrMode, entry.NC);
   }
   frameCount++;
+  releaseSabSlot(entry);
+}
+
+function releaseSabSlot(entry) {
+  if (entry.sabSlot != null && dec && dec.sabFlags) {
+    Atomics.store(dec.sabFlags, entry.sabSlot, 0);
+  }
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -1656,7 +1682,7 @@ function startDisplayLoop(myGen) {
       const dropThresholdMs = cantKeepUp ? 2 * period : PACE_DROP_PERIODS * period;
 
       if (paceDropEnabled() && rafTimestamp - target > dropThresholdMs) {
-        ringPop();
+        releaseSabSlot(ringPop());
         droppedByPace++;
         // Advance the timeline to absorb the lateness, leaving one period
         // of margin.  This prevents the next frame from also exceeding the

--- a/web/shared/decoder_client.mjs
+++ b/web/shared/decoder_client.mjs
@@ -120,12 +120,38 @@ export class DecoderClient {
       if (this._batchOffs.length > 0) this._flushBatch();
     };
 
+    // SharedArrayBuffer plane ring: eliminates per-frame allocation by
+    // reusing a fixed set of slots for decoded plane data.
+    const SAB_SLOTS     = 3;
+    const SAB_PLANE_MAX = 3840 * 2160;
+    const SAB_SLOT_SIZE = SAB_PLANE_MAX * 3;
+    const SAB_FLAG_BYTES = SAB_SLOTS * 4;
+    const SAB_TOTAL     = SAB_FLAG_BYTES + SAB_SLOTS * SAB_SLOT_SIZE;
+    if (typeof SharedArrayBuffer !== 'undefined' && self.crossOriginIsolated) {
+      this._sab      = new SharedArrayBuffer(SAB_TOTAL);
+      this._sabFlags = new Int32Array(this._sab, 0, SAB_SLOTS);
+      this._sabSlots = SAB_SLOTS;
+      this._sabPlaneMax = SAB_PLANE_MAX;
+      this._sabSlotSize = SAB_SLOT_SIZE;
+      this._sabFlagBytes = SAB_FLAG_BYTES;
+    } else {
+      this._sab = null;
+      this._sabFlags = null;
+    }
+
     this.worker.postMessage({
       type: 'init',
       wasmBase: absBase,
       variant, threadCount, reduceNL, output,
+      sab: this._sab,
     });
   }
+
+  get sab()      { return this._sab; }
+  get sabFlags() { return this._sabFlags; }
+  get sabSlotSize()  { return this._sabSlotSize; }
+  get sabPlaneMax()  { return this._sabPlaneMax; }
+  get sabFlagBytes() { return this._sabFlagBytes; }
 
   setReduceNL(n) {
     this._flushBatch();

--- a/web/shared/decoder_worker.mjs
+++ b/web/shared/decoder_worker.mjs
@@ -28,6 +28,11 @@ const FRAME_BUF  = 16 << 20;
 const PLANE_BUF  = 3840 * 2160;
 const RGBA_BUF   = 3840 * 2160 * 4;
 
+const SAB_SLOTS      = 3;
+const SAB_PLANE_MAX  = PLANE_BUF;
+const SAB_SLOT_SIZE  = SAB_PLANE_MAX * 3;
+const SAB_FLAG_BYTES = SAB_SLOTS * 4;
+
 // Stats throttling: post a snapshot at most every STATS_PERIOD_MS.
 const STATS_PERIOD_MS = 500;
 let lastStatsAt = 0;
@@ -38,6 +43,8 @@ let reduceNL    = 0;      // resolution-reduce; 0 = full, 1 = half, 2 = quarter
 let skipInterval = 0;     // pre-decode cadence skip: drop every Nth frame (0 = disabled)
 let skipCounter  = 0;
 let skippedByPreDecode = 0;
+let sab = null, sabFlags = null, sabU8 = null;
+let sabWriteIdx = 0;
 // 'planar' = post Y/Cb/Cr buffers (cheap; renderer applies matrix in shader)
 // 'rgba'   = post a single RGBA8 buffer with WASM-side matrix already applied
 //            (used by the Canvas2D fallback; ~2× the bytes but no main-thread work)
@@ -51,10 +58,15 @@ const VARIANT_FILE = {
 };
 
 async function init({ wasmBase = '/wasm/', threadCount: tc = 4, output = 'planar',
-                      variant = 'mt_simd', reduceNL: rn = 0 }) {
+                      variant = 'mt_simd', reduceNL: rn = 0, sab: sabIn = null }) {
   threadCount = tc;
   outputMode = output;
   reduceNL   = rn | 0;
+  if (sabIn) {
+    sab      = sabIn;
+    sabFlags = new Int32Array(sab, 0, SAB_SLOTS);
+    sabU8    = new Uint8Array(sab, SAB_FLAG_BYTES);
+  }
   const file = VARIANT_FILE[variant] || VARIANT_FILE.mt_simd;
   isMtBuild  = (variant === 'mt_simd' || variant === 'mt');
   // mt_simd works in a nested worker as long as Emscripten's pthread
@@ -269,8 +281,32 @@ function drainReady() {
       // uploaded on main; the fragment shader does the matrix.
       F.invoke_planar_u8(decoder, yPtr, cbPtr, crPtr);
       const decodeMs = performance.now() - t0;
-      // .slice() copies; the result owns its buffer and is transferable.
-      // Subarray would share storage with the WASM heap and can't be transferred.
+
+      // SAB zero-copy path: write planes into a pre-allocated shared slot.
+      if (sab) {
+        let slot = -1;
+        for (let i = 0; i < SAB_SLOTS; i++) {
+          const idx = (sabWriteIdx + i) % SAB_SLOTS;
+          if (Atomics.load(sabFlags, idx) === 0) { slot = idx; break; }
+        }
+        if (slot >= 0) {
+          const base = slot * SAB_SLOT_SIZE;
+          sabU8.set(M.HEAPU8.subarray(yPtr,  yPtr  + w * h),   base);
+          sabU8.set(M.HEAPU8.subarray(cbPtr, cbPtr + cw * ch), base + SAB_PLANE_MAX);
+          sabU8.set(M.HEAPU8.subarray(crPtr, crPtr + cw * ch), base + 2 * SAB_PLANE_MAX);
+          Atomics.store(sabFlags, slot, 1);
+          sabWriteIdx = (slot + 1) % SAB_SLOTS;
+          self.postMessage(
+            { type: 'frame', mode: 'sab', slot, w, h, cw, ch, fullW, fullH, nc, colorspace, depth,
+              compW, compH, compS, compD,
+              isRGB, isYCbCr,
+              matrix, range, primaries, transfer, rtpTs, decodeMs });
+          maybePostStats();
+          continue;
+        }
+      }
+
+      // Fallback: .slice() + transfer (SAB unavailable or all slots busy).
       const yBuf  = M.HEAPU8.slice(yPtr,  yPtr  + w  * h ).buffer;
       const cbBuf = M.HEAPU8.slice(cbPtr, cbPtr + cw * ch).buffer;
       const crBuf = M.HEAPU8.slice(crPtr, crPtr + cw * ch).buffer;


### PR DESCRIPTION
## Summary

- Pre-allocate a 3-slot SharedArrayBuffer ring (~75 MB for 4K) shared between decoder worker and main thread
- Worker copies decoded planes into SAB slots (same single memcpy from WASM heap) then posts a lightweight notification — no per-frame allocation, no ArrayBuffer transfer
- Main thread creates Uint8Array views directly into the SAB for WebGL texture upload
- Eliminates ~75 multi-MB allocations/sec at 4K@25fps, removing GC pressure that caused frame-time jitter

Graceful degradation:
- No COI / no SharedArrayBuffer → falls back to existing .slice() + transfer
- All 3 SAB slots busy → falls back to .slice() for that frame
- RGBA output mode (Canvas2D) → unaffected, still uses transfer

## Test plan

- [ ] Play 4K@30fps paced mode → verify correct rendering (no corruption)
- [ ] Chrome DevTools Performance → confirm no multi-MB allocations per frame in steady state
- [ ] Verify `frame.mode === 'sab'` in verbose console log (SAB path active)
- [ ] Test Canvas2D fallback → confirm transfer path still works (mode=rgba)
- [ ] Serve without coi-serviceworker (no COI) → confirm graceful fallback to transfer (mode=planar)
- [ ] Stress: `?ring=2` with 4K → confirm no slot exhaustion deadlock (fallback fires instead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)