### PR TITLE
docs(wasm): add missing URL params to rtp_demo table

### DIFF
--- a/web/rtp_demo.html
+++ b/web/rtp_demo.html
@@ -608,10 +608,22 @@
           <td>Frames decoded back-to-back before the paced wall clock anchors. Absorbs cold-start decode spikes (SIMD warmup, WASM JIT).</td>
         </tr>
         <tr>
+          <td><code>?ring=</code></td>
+          <td><code>4</code></td>
+          <td>integer 2–32</td>
+          <td>Decode→display ring buffer depth. Larger values add latency but absorb decode jitter on slow or high-variance links.</td>
+        </tr>
+        <tr>
           <td><code>?verbose=1</code></td>
           <td>off</td>
           <td>presence toggle</td>
           <td>Emit one <code>[rtp_demo t=Ns …]</code> line per second to the browser console with full pipeline stats.</td>
+        </tr>
+        <tr>
+          <td><code>?wasmBase=</code></td>
+          <td><code>/wasm/</code></td>
+          <td>URL path</td>
+          <td>Override the directory where <code>libopen_htj2k_*.{js,wasm}</code> are served from.</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
## Summary

- Add `?ring=` (ring buffer depth, 2-32, default 4) to the URL parameters table
- Add `?wasmBase=` (override WASM directory path) to the URL parameters table

Both params already functioned but were missing from the on-page reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)