### PR TITLE
fix(coding): add missing height-parity guard to AVX2 fused-dequant

### DIFF
--- a/source/core/coding/ht_block_decoding_avx2.cpp
+++ b/source/core/coding/ht_block_decoding_avx2.cpp
@@ -1130,7 +1130,8 @@ bool htj2k_decode(j2k_codeblock *block, const uint8_t ROIshift) {
     // adjacent blocks' column range in the shared output buffer (subband or ring buffer).
     // This is safe in single-threaded decode (sequential order overwrites correctly) but
     // causes a data race in multi-threaded decode.  Gate on width % 4 == 0 to avoid this.
-    if (num_ht_passes == 1 && ROIshift == 0 && (block->size.x & 3) == 0) {
+    if (num_ht_passes == 1 && ROIshift == 0 && (block->size.x & 3) == 0
+        && (block->size.y & 1u) == 0) {
       ht_cleanup_decode<true, true>(block, static_cast<uint8_t>(30 - S_blk), Lcup, Pcup, Scup);
       dequant_done = true;
     } else if (num_ht_passes == 1) {


### PR DESCRIPTION
## Summary

- Add `(block->size.y & 1u) == 0` guard to the AVX2 fused-dequant condition, matching NEON and WASM variants.
- Fixes flaky `comp_p1_ht_05_11{r,g,b}` CI failures caused by a data race when odd-height blocks overflow one row past their `i_samples` region under multi-threaded `decode_strip_core` dispatch.

## Root cause

The fused-dequant kernel processes samples in 2-row quad-pairs, writing both rows unconditionally. When block height is odd, the last pair's second-row store lands `band_stride` bytes past the block's final row — into the adjacent block's `i_samples` region. Under concurrent thread-pool dispatch (≥3 threads), blocks complete out-of-order and the stale overflow clobbers adjacent decoded data.

Triggered specifically by `ds1_ht_05_b11.j2k` (37×37 tiles, 8×64 codeblocks, 16×16 precincts, 7 DWT levels) which creates odd-height blocks at precinct boundaries.

## Test plan

- [x] 50-iteration stress test at `num_threads=4` — zero failures (was ~15% failure rate before)
- [x] Full 670-test CTest suite passes
- [x] ThreadSanitizer reports zero data races (was detecting race at `dequant_store_128`)
- [x] CI (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)