### PR TITLE
fix(wasm): guard ycbcr cwrap against stale WASM cache

### DIFF
--- a/web/shared/decoder_worker.mjs
+++ b/web/shared/decoder_worker.mjs
@@ -111,7 +111,9 @@ async function init({ wasmBase = '/wasm/', threadCount: tc = 4, output = 'planar
     reset_decoder:     M.cwrap('reset_decoder_with_bytes','void',  ['number','number','number','number']),
     parse_j2c:         M.cwrap('parse_j2c_data',         'void',   ['number']),
     invoke_planar_u8:  M.cwrap('invoke_decoder_planar_u8','void',  ['number','number','number','number']),
-    invoke_planar_ycbcr_u8: M.cwrap('invoke_decoder_planar_ycbcr_u8','void', ['number','number','number','number']),
+    invoke_planar_ycbcr_u8: M['_invoke_decoder_planar_ycbcr_u8']
+      ? M.cwrap('invoke_decoder_planar_ycbcr_u8','void', ['number','number','number','number'])
+      : null,
     invoke_to_rgba:    M.cwrap('invoke_decoder_to_rgba', 'void',   ['number','number']),
     apply_bt601:       M.cwrap('apply_ycbcr_bt601_to_rgba','void', ['number','number']),
     apply_bt709:       M.cwrap('apply_ycbcr_bt709_to_rgba','void', ['number','number']),
@@ -281,8 +283,8 @@ function drainReady() {
       // Planar path — used by the WebGL2 renderer.  Three R8 textures get
       // uploaded on main; the fragment shader does the matrix.
       // For YCbCr codestreams, skip the CPU color transform and let the GPU
-      // shader handle YCbCr→RGB conversion — saves ~40% of decode time.
-      if (isYCbCr)
+      // shader handle YCbCr→RGB conversion — saves ~29% of decode time.
+      if (isYCbCr && F.invoke_planar_ycbcr_u8)
         F.invoke_planar_ycbcr_u8(decoder, yPtr, cbPtr, crPtr);
       else
         F.invoke_planar_u8(decoder, yPtr, cbPtr, crPtr);


### PR DESCRIPTION
## Summary

- Guard `invoke_planar_ycbcr_u8` cwrap binding with an existence check on `M['_invoke_decoder_planar_ycbcr_u8']`
- Fall back to `invoke_planar_u8` (CPU MCT) when the export is unavailable

## Problem

After merging PR #367, the osamu620.dev RTP demo crashes with `RuntimeError: memory access out of bounds at Module._malloc`. Root cause: CDN cache can serve a stale WASM binary (without the new export) alongside the updated JS (which unconditionally cwraps it). Emscripten's cwrap on a missing export corrupts the module.

## Test plan

- [ ] CI passes
- [ ] RTP demo works with both old and new WASM binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)