### PR TITLE
feat(jpip): GPU YCbCr→RGB color conversion for JPIP demos

### DIFF
--- a/web/CMakeLists.txt
+++ b/web/CMakeLists.txt
@@ -209,7 +209,7 @@ target_link_libraries(libopen_htj2k_mt_simd PRIVATE open_htj2k_mt_simd_lib)
 # ── JPIP browser demo ────────────────────────────────────────────────────────
 # Exposes the JPIP client-side pipeline (parse → reassemble → decode) via
 # a thin C API that the JS side calls per frame.
-set(JPIP_EXPORTED_FUNCTIONS "[_malloc,_free,_jpip_create_context,_jpip_get_canvas_width,_jpip_get_canvas_height,_jpip_get_num_components,_jpip_get_total_precincts,_jpip_set_reduce,_jpip_get_cache_model,_jpip_begin_frame,_jpip_reset_cache,_jpip_get_response_buffer,_jpip_add_response,_jpip_feed_stream_begin,_jpip_feed_stream,_jpip_feed_stream_end,_jpip_track_precincts_in_cache,_jpip_set_precinct_cache_budget,_jpip_get_precinct_cache_count,_jpip_end_frame,_jpip_end_frame_region,_jpip_destroy_context]")
+set(JPIP_EXPORTED_FUNCTIONS "[_malloc,_free,_jpip_create_context,_jpip_get_canvas_width,_jpip_get_canvas_height,_jpip_get_num_components,_jpip_get_total_precincts,_jpip_set_reduce,_jpip_get_cache_model,_jpip_begin_frame,_jpip_reset_cache,_jpip_get_response_buffer,_jpip_add_response,_jpip_feed_stream_begin,_jpip_feed_stream,_jpip_feed_stream_end,_jpip_track_precincts_in_cache,_jpip_set_precinct_cache_budget,_jpip_get_precinct_cache_count,_jpip_end_frame,_jpip_end_frame_region,_jpip_end_frame_planar,_jpip_end_frame_region_planar,_jpip_destroy_context]")
 set(JPIP_INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR}/../source/core/jpip
     ${CMAKE_CURRENT_SOURCE_DIR}/../source/core/interface

--- a/web/jpip_demo.html
+++ b/web/jpip_demo.html
@@ -425,8 +425,10 @@
   }
 </script>
 <script type="module">
-// Auto-detect the best WASM variant: multi-threaded SIMD if available,
-// otherwise single-threaded SIMD.  ?variant=st forces single-threaded.
+// WASM variant selection.  Default: single-threaded SIMD.  The JPIP demos
+// decode on the main thread (no Web Worker), so MT would block on the
+// pthreads condition variable and trigger Emscripten's main-thread-blocking
+// warning.  ?variant=mt forces MT if you want to test it anyway.
 // ?wasmBase=/wasm-full/ for local dev under web/perf/serve.mjs (which
 // routes /wasm-full/ to web/build/html/).
 const _wasmBaseQ = new URLSearchParams(location.search).get('wasmBase');
@@ -434,7 +436,7 @@ const WASM_BASE  = _wasmBaseQ || new URL('./', location.href).href;
 const hasSimd = await wasmFeatureDetect.simd();
 const hasMt = window.crossOriginIsolated && (typeof SharedArrayBuffer !== 'undefined');
 const forceVariant = new URLSearchParams(location.search).get('variant');
-const useMt = forceVariant === 'mt' ? true : forceVariant === 'st' ? false : (hasSimd && hasMt);
+const useMt = forceVariant === 'mt' ? (hasSimd && hasMt) : false;
 const wasmName = useMt ? 'libopen_htj2k_jpip_mt_simd.js' : 'libopen_htj2k_jpip.js';
 const {default: createModule} = await import(WASM_BASE + wasmName);
 
@@ -526,15 +528,6 @@ function initWebGL(canvas, w, h) {
 
   glProgram = linkProg(vs, fsPassthrough);
 
-  glTex = gl.createTexture();
-  gl.bindTexture(gl.TEXTURE_2D, glTex);
-  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, w, h, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
-  texW = w; texH = h;
-
   if (useGpuColor) {
     glProgPlanar = linkProg(vs, fsPlanar);
     gl.useProgram(glProgPlanar);
@@ -556,6 +549,14 @@ function initWebGL(canvas, w, h) {
     texCb = mkR8();
     texCr = mkR8();
   } else {
+    glTex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, glTex);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, w, h, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    texW = w; texH = h;
     gl.useProgram(glProgram);
   }
 

--- a/web/jpip_demo.html
+++ b/web/jpip_demo.html
@@ -448,11 +448,30 @@ let running = false;
 let serverUrl = '';
 let busy = false;  // guard against overlapping fetch/decode
 
+// GPU color conversion — skip inverse MCT in WASM, apply BT.601 in shader.
+// Disable with ?gpu=0 to A/B test against the CPU colour path.
+const useGpuColor = new URLSearchParams(location.search).get('gpu') !== '0';
+
+const _MAT_BT601F = new Float32Array([
+  1, 1, 1,
+  0, -5638 / 16384, 29032 / 16384,
+  22970 / 16384, -11698 / 16384, 0,
+]);
+const _MAT_IDENTITY = new Float32Array([1, 0, 0, 0, 1, 0, 0, 0, 1]);
+const _OFF_HALF = 128.0 / 255.0;
+const _OFF_FULL = new Float32Array([0, _OFF_HALF, _OFF_HALF]);
+const _OFF_ZERO = new Float32Array([0, 0, 0]);
+
 // WebGL2 state
 let gl = null;
-let glTex = null;
-let glProgram = null;
+let glTex = null;     // RGBA passthrough texture (fallback path)
+let glProgram = null;  // passthrough program
 let texW = 0, texH = 0;
+// Planar path state
+let glProgPlanar = null;
+let texY = null, texCb = null, texCr = null;
+let uMatrixLoc = null, uOffsetLoc = null;
+let yPtr = 0, cbPtr = 0, crPtr = 0;
 
 function initWebGL(canvas, w, h) {
   gl = canvas.getContext('webgl2', { antialias: false, alpha: false });
@@ -463,12 +482,27 @@ function initWebGL(canvas, w, h) {
     const vec2 uv[4]  = vec2[](vec2(0,1),vec2(1,1),vec2(0,0),vec2(1,0));
     out vec2 vUV;
     void main() { vUV = uv[gl_VertexID]; gl_Position = vec4(pos[gl_VertexID],0,1); }`;
-  const fs = `#version 300 es
+  const fsPassthrough = `#version 300 es
     precision mediump float;
     uniform sampler2D uTex;
     in vec2 vUV;
     out vec4 fragColor;
     void main() { fragColor = texture(uTex, vUV); }`;
+  const fsPlanar = `#version 300 es
+    precision highp float;
+    uniform sampler2D u_y;
+    uniform sampler2D u_cb;
+    uniform sampler2D u_cr;
+    uniform mat3      u_matrix;
+    uniform vec3      u_offset;
+    in  vec2 vUV;
+    out vec4 fragColor;
+    void main() {
+      vec3 ycc = vec3(texture(u_y, vUV).r,
+                      texture(u_cb, vUV).r,
+                      texture(u_cr, vUV).r) - u_offset;
+      fragColor = vec4(clamp(u_matrix * ycc, 0.0, 1.0), 1.0);
+    }`;
 
   function compile(type, src) {
     const s = gl.createShader(type);
@@ -478,11 +512,15 @@ function initWebGL(canvas, w, h) {
       console.error(gl.getShaderInfoLog(s));
     return s;
   }
-  glProgram = gl.createProgram();
-  gl.attachShader(glProgram, compile(gl.VERTEX_SHADER, vs));
-  gl.attachShader(glProgram, compile(gl.FRAGMENT_SHADER, fs));
-  gl.linkProgram(glProgram);
-  gl.useProgram(glProgram);
+  function linkProg(vsSrc, fsSrc) {
+    const p = gl.createProgram();
+    gl.attachShader(p, compile(gl.VERTEX_SHADER, vsSrc));
+    gl.attachShader(p, compile(gl.FRAGMENT_SHADER, fsSrc));
+    gl.linkProgram(p);
+    return p;
+  }
+
+  glProgram = linkProg(vs, fsPassthrough);
 
   glTex = gl.createTexture();
   gl.bindTexture(gl.TEXTURE_2D, glTex);
@@ -493,6 +531,30 @@ function initWebGL(canvas, w, h) {
   gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, w, h, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
   texW = w; texH = h;
 
+  if (useGpuColor) {
+    glProgPlanar = linkProg(vs, fsPlanar);
+    gl.useProgram(glProgPlanar);
+    gl.uniform1i(gl.getUniformLocation(glProgPlanar, 'u_y'), 0);
+    gl.uniform1i(gl.getUniformLocation(glProgPlanar, 'u_cb'), 1);
+    gl.uniform1i(gl.getUniformLocation(glProgPlanar, 'u_cr'), 2);
+    uMatrixLoc = gl.getUniformLocation(glProgPlanar, 'u_matrix');
+    uOffsetLoc = gl.getUniformLocation(glProgPlanar, 'u_offset');
+    function mkR8() {
+      const t = gl.createTexture();
+      gl.bindTexture(gl.TEXTURE_2D, t);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+      return t;
+    }
+    texY  = mkR8();
+    texCb = mkR8();
+    texCr = mkR8();
+  } else {
+    gl.useProgram(glProgram);
+  }
+
   gl.bindVertexArray(gl.createVertexArray());
   gl.viewport(0, 0, canvas.width, canvas.height);
   return true;
@@ -500,15 +562,38 @@ function initWebGL(canvas, w, h) {
 
 function drawFrame(rgba, w, h) {
   if (!gl) {
-    // Canvas 2D fallback
     const c = $('canvas');
     const ctx2d = c.getContext('2d');
     const img = new ImageData(new Uint8ClampedArray(rgba.buffer, rgba.byteOffset, rgba.byteLength), w, h);
     ctx2d.putImageData(img, 0, 0);
     return;
   }
+  gl.useProgram(glProgram);
+  gl.activeTexture(gl.TEXTURE0);
   gl.bindTexture(gl.TEXTURE_2D, glTex);
   gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, w, h, gl.RGBA, gl.UNSIGNED_BYTE, rgba);
+  gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+}
+
+function drawFramePlanar(w, h, isYCbCr) {
+  gl.useProgram(glProgPlanar);
+  const yData  = new Uint8Array(M.HEAPU8.buffer, yPtr,  w * h);
+  const cbData = new Uint8Array(M.HEAPU8.buffer, cbPtr, w * h);
+  const crData = new Uint8Array(M.HEAPU8.buffer, crPtr, w * h);
+  function uploadR8(tex, unit, data) {
+    gl.activeTexture(gl.TEXTURE0 + unit);
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    if (texW !== w || texH !== h)
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.R8, w, h, 0, gl.RED, gl.UNSIGNED_BYTE, data);
+    else
+      gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, w, h, gl.RED, gl.UNSIGNED_BYTE, data);
+  }
+  uploadR8(texY,  0, yData);
+  uploadR8(texCb, 1, cbData);
+  uploadR8(texCr, 2, crData);
+  texW = w; texH = h;
+  gl.uniformMatrix3fv(uMatrixLoc, false, isYCbCr ? _MAT_BT601F : _MAT_IDENTITY);
+  gl.uniform3fv(uOffsetLoc, isYCbCr ? _OFF_FULL : _OFF_ZERO);
   gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
 }
 
@@ -601,10 +686,18 @@ async function connect() {
   c.style.width = '100%';
   c.style.height = 'auto';
 
-  rgbPtr = M._malloc(canvasW * canvasH * 4);
   initWebGL(c, canvasW, canvasH);
+  const gpuActive = gl && useGpuColor && glProgPlanar;
+  if (gpuActive) {
+    const planeSize = canvasW * canvasH;
+    yPtr  = M._malloc(planeSize);
+    cbPtr = M._malloc(planeSize);
+    crPtr = M._malloc(planeSize);
+  } else {
+    rgbPtr = M._malloc(canvasW * canvasH * 4);
+  }
   $('info').textContent = `${canvasW}×${canvasH}, ${totalP} precincts` +
-      (gl ? ' [WebGL2]' : ' [Canvas 2D]');
+      (gpuActive ? ' [WebGL2 GPU color]' : gl ? ' [WebGL2]' : ' [Canvas 2D]');
 
   running = true;
   let lastGx = -1, lastGy = -1;
@@ -681,15 +774,24 @@ async function connect() {
       }
       const tFetch = performance.now();
 
-      const rc = M._jpip_end_frame(ctx, rgbPtr, c.width, c.height);
+      let rc;
+      if (gpuActive) {
+        rc = M._jpip_end_frame_planar(ctx, yPtr, cbPtr, crPtr, c.width, c.height);
+      } else {
+        rc = M._jpip_end_frame(ctx, rgbPtr, c.width, c.height);
+      }
       const tDecode = performance.now();
-      if (rc !== 0) {
+      if (rc < 0) {
         $('stats').textContent = `decode error: ${rc}`;
         return;
       }
 
-      const rgba = new Uint8Array(M.HEAPU8.buffer, rgbPtr, c.width * c.height * 4);
-      drawFrame(rgba, c.width, c.height);
+      if (gpuActive) {
+        drawFramePlanar(c.width, c.height, rc === 1);
+      } else {
+        const rgba = new Uint8Array(M.HEAPU8.buffer, rgbPtr, c.width * c.height * 4);
+        drawFrame(rgba, c.width, c.height);
+      }
 
       frameCount++;
       const fetchMs = (tFetch - t0).toFixed(0);

--- a/web/jpip_demo.html
+++ b/web/jpip_demo.html
@@ -427,12 +427,16 @@
 <script type="module">
 // Auto-detect the best WASM variant: multi-threaded SIMD if available,
 // otherwise single-threaded SIMD.  ?variant=st forces single-threaded.
+// ?wasmBase=/wasm-full/ for local dev under web/perf/serve.mjs (which
+// routes /wasm-full/ to web/build/html/).
+const _wasmBaseQ = new URLSearchParams(location.search).get('wasmBase');
+const WASM_BASE  = _wasmBaseQ || new URL('./', location.href).href;
 const hasSimd = await wasmFeatureDetect.simd();
 const hasMt = window.crossOriginIsolated && (typeof SharedArrayBuffer !== 'undefined');
 const forceVariant = new URLSearchParams(location.search).get('variant');
 const useMt = forceVariant === 'mt' ? true : forceVariant === 'st' ? false : (hasSimd && hasMt);
-const wasmFile = useMt ? './libopen_htj2k_jpip_mt_simd.js' : './libopen_htj2k_jpip.js';
-const {default: createModule} = await import(wasmFile);
+const wasmName = useMt ? 'libopen_htj2k_jpip_mt_simd.js' : 'libopen_htj2k_jpip.js';
+const {default: createModule} = await import(WASM_BASE + wasmName);
 
 const $ = id => document.getElementById(id);
 

--- a/web/jpip_demo.html
+++ b/web/jpip_demo.html
@@ -425,10 +425,10 @@
   }
 </script>
 <script type="module">
-// WASM variant selection.  Default: single-threaded SIMD.  The JPIP demos
-// decode on the main thread (no Web Worker), so MT would block on the
-// pthreads condition variable and trigger Emscripten's main-thread-blocking
-// warning.  ?variant=mt forces MT if you want to test it anyway.
+// Auto-detect the best WASM variant: multi-threaded SIMD if available,
+// otherwise single-threaded SIMD.  ?variant=st forces single-threaded.
+// The main-thread blocking warning from Emscripten is expected — the
+// thread pool workers finish quickly and the 30% MT speedup is worth it.
 // ?wasmBase=/wasm-full/ for local dev under web/perf/serve.mjs (which
 // routes /wasm-full/ to web/build/html/).
 const _wasmBaseQ = new URLSearchParams(location.search).get('wasmBase');
@@ -436,7 +436,7 @@ const WASM_BASE  = _wasmBaseQ || new URL('./', location.href).href;
 const hasSimd = await wasmFeatureDetect.simd();
 const hasMt = window.crossOriginIsolated && (typeof SharedArrayBuffer !== 'undefined');
 const forceVariant = new URLSearchParams(location.search).get('variant');
-const useMt = forceVariant === 'mt' ? (hasSimd && hasMt) : false;
+const useMt = forceVariant === 'mt' ? true : forceVariant === 'st' ? false : (hasSimd && hasMt);
 const wasmName = useMt ? 'libopen_htj2k_jpip_mt_simd.js' : 'libopen_htj2k_jpip.js';
 const {default: createModule} = await import(WASM_BASE + wasmName);
 

--- a/web/jpip_demo.html
+++ b/web/jpip_demo.html
@@ -489,7 +489,7 @@ function initWebGL(canvas, w, h) {
     out vec2 vUV;
     void main() { vUV = uv[gl_VertexID]; gl_Position = vec4(pos[gl_VertexID],0,1); }`;
   const fsPassthrough = `#version 300 es
-    precision mediump float;
+    precision highp float;
     uniform sampler2D uTex;
     in vec2 vUV;
     out vec4 fragColor;

--- a/web/jpip_viewer.html
+++ b/web/jpip_viewer.html
@@ -709,7 +709,7 @@ function initWebGL(canvas) {
   // planar YCbCr→RGB (GPU color path).  The thumbnail layer is always RGBA
   // in both variants.
   const fsLegacy = `#version 300 es
-    precision mediump float;
+    precision highp float;
     uniform sampler2D uTex;
     uniform sampler2D uThumb;
     uniform vec4 uViewport;

--- a/web/jpip_viewer.html
+++ b/web/jpip_viewer.html
@@ -1481,19 +1481,18 @@ async function fetchView() {
   // arrived during the await above, fire one more fetch with the current
   // (freshest) panX/panY/zoom.  No debounce — the user already waited the
   // full network+decode round-trip, they don't need another 60 ms.
-  if (pendingFetch) {
-    pendingFetch = false;
-    queueMicrotask(fetchView);
-    return;
-  }
-  // Kick the one-time thumbnail fetch on idle, after the first successful
-  // main-view paint.  Uses its own busy-lock to coexist with any later
-  // user-driven fetch.  Skip the adjacent-halo prefetch this round —
-  // fetchThumbnail owns the decoder for the next hop; the next pan will
-  // set up a new prefetch anyway.
+  // Thumbnail takes priority over pending scrolls — it's a one-time fetch
+  // and on fast local servers the pendingFetch drain can indefinitely
+  // preempt it (user is still scrolling during the short decode window,
+  // setting pendingFetch every cycle).
   if (thumbnailPending) {
     thumbnailPending = false;
     queueMicrotask(fetchThumbnail);
+    return;
+  }
+  if (pendingFetch) {
+    pendingFetch = false;
+    queueMicrotask(fetchView);
     return;
   }
   // Otherwise: schedule an idle-delay prefetch of the adjacent halo.

--- a/web/jpip_viewer.html
+++ b/web/jpip_viewer.html
@@ -401,12 +401,10 @@
   })();
 </script>
 <script type="module">
-// Default to ST — JPIP demos decode on the main thread, MT would block.
-// ?variant=mt to force MT if you want to test it.
 const hasSimd = await wasmFeatureDetect.simd();
 const hasMt = window.crossOriginIsolated && (typeof SharedArrayBuffer !== 'undefined');
 const forceVariant = new URLSearchParams(location.search).get('variant');
-const useMt = forceVariant === 'mt' ? (hasSimd && hasMt) : false;
+const useMt = forceVariant === 'mt' ? true : forceVariant === 'st' ? false : (hasSimd && hasMt);
 
 // ?wasmBase=/wasm-full/ for local dev under web/perf/serve.mjs (which
 // routes /wasm-full/ to web/build/html/).

--- a/web/jpip_viewer.html
+++ b/web/jpip_viewer.html
@@ -406,6 +406,11 @@ const hasMt = window.crossOriginIsolated && (typeof SharedArrayBuffer !== 'undef
 const forceVariant = new URLSearchParams(location.search).get('variant');
 const useMt = forceVariant === 'mt' ? true : forceVariant === 'st' ? false : (hasSimd && hasMt);
 
+// ?wasmBase=/wasm-full/ for local dev under web/perf/serve.mjs (which
+// routes /wasm-full/ to web/build/html/).
+const _wasmBaseQ = new URLSearchParams(location.search).get('wasmBase');
+const WASM_BASE  = _wasmBaseQ || new URL('./', location.href).href;
+
 // Cache-buster for dev iteration.  `?cb=auto` or `?cb=1` appends Date.now()
 // to WASM/JS URLs so the browser refetches after every rebuild — bypasses
 // the (correct) HTTP caching that production relies on.  Default (no `?cb`):
@@ -418,9 +423,9 @@ const cacheBuster =
     (_cbParam === 'auto' || _cbParam === '1') ? `?v=${Date.now()}`
   : _cbParam ? `?v=${encodeURIComponent(_cbParam)}`
   : '';
-const wasmFile = (useMt ? './libopen_htj2k_jpip_mt_simd.js'
-                        : './libopen_htj2k_jpip.js') + cacheBuster;
-const {default: createModule} = await import(wasmFile);
+const wasmName = (useMt ? 'libopen_htj2k_jpip_mt_simd.js'
+                        : 'libopen_htj2k_jpip.js') + cacheBuster;
+const {default: createModule} = await import(WASM_BASE + wasmName);
 const $ = id => document.getElementById(id);
 
 let M = null, ctx = 0, canvasW = 0, canvasH = 0;

--- a/web/jpip_viewer.html
+++ b/web/jpip_viewer.html
@@ -401,10 +401,12 @@
   })();
 </script>
 <script type="module">
+// Default to ST — JPIP demos decode on the main thread, MT would block.
+// ?variant=mt to force MT if you want to test it.
 const hasSimd = await wasmFeatureDetect.simd();
 const hasMt = window.crossOriginIsolated && (typeof SharedArrayBuffer !== 'undefined');
 const forceVariant = new URLSearchParams(location.search).get('variant');
-const useMt = forceVariant === 'mt' ? true : forceVariant === 'st' ? false : (hasSimd && hasMt);
+const useMt = forceVariant === 'mt' ? (hasSimd && hasMt) : false;
 
 // ?wasmBase=/wasm-full/ for local dev under web/perf/serve.mjs (which
 // routes /wasm-full/ to web/build/html/).

--- a/web/jpip_viewer.html
+++ b/web/jpip_viewer.html
@@ -569,6 +569,20 @@ let thumbnailPending = false;
 let vpW = 0, vpH = 0, panX = 0, panY = 0, zoom = 1.0;
 let decReduce = -1, rgbPtr = 0, rgbBufSz = 0;
 
+// GPU color conversion (same as jpip_demo).
+const useGpuColor = new URLSearchParams(location.search).get('gpu') !== '0';
+const _MAT_BT601F = new Float32Array([
+  1, 1, 1,
+  0, -5638 / 16384, 29032 / 16384,
+  22970 / 16384, -11698 / 16384, 0,
+]);
+const _MAT_IDENTITY = new Float32Array([1, 0, 0, 0, 1, 0, 0, 0, 1]);
+const _OFF_HALF = 128.0 / 255.0;
+const _OFF_FULL = new Float32Array([0, _OFF_HALF, _OFF_HALF]);
+const _OFF_ZERO = new Float32Array([0, 0, 0]);
+let gpuIsYCbCr = true;  // updated on first decode
+let plYPtr = 0, plCbPtr = 0, plCrPtr = 0, plBufSz = 0;
+
 // Drag state shared between the canvas (set up in connect()) and the
 // thumbnail (set up in fetchThumbnail() once the overview decodes).
 // Lifted to module scope so the two handlers can share the same
@@ -637,16 +651,14 @@ function sizeCanvas(c) {
 }
 
 // ── WebGL2: layered draw with previous-frame texture + thumbnail ────────
-// Two textures combine in one fragment-shader pass.  Sampling priority:
-//   (1) glTex   — last-decoded viewport pixels, mapped from texRect to
-//                 the *image-coord region* the texture was decoded for
-//                 (NOT the current viewport).  Stays anchored to image
-//                 position even as the user pans, so motion is smooth.
-//   (2) glThumb — coarse full-image overview, fills areas the previous
-//                 frame doesn't cover (typical when the user pans into
-//                 unseen regions or zooms out past the prior viewport).
-//   (3) bg      — background color for fragments outside the image
-//                 itself (zoom-out beyond canvasW × canvasH).
+// Sampling priority (both legacy and GPU-color variants):
+//   (1) Main layer — last-decoded viewport pixels, anchored to image
+//       coordinates.  Legacy path: single RGBA texture (glTex).
+//       GPU-color path (?gpu=1, default): three R8 textures
+//       (glTexY/glTexCb/glTexCr) with YCbCr→RGB matrix in the shader.
+//   (2) glThumb — coarse full-image overview (always RGBA), fills areas
+//       the previous frame doesn't cover.
+//   (3) bg — background color for fragments outside the image.
 //
 // Uniforms:
 //   uViewport   — image-coord (x0, y0, x1, y1) of the CURRENT viewport
@@ -658,6 +670,9 @@ function sizeCanvas(c) {
 //   bounds-check division — neither texture sample is used.
 let gl = null, glTex = null, glThumb = null, glProgram = null, texW = 0, texH = 0;
 let uScaleLoc, uViewportLoc, uTexRectLoc, uThumbRectLoc;
+// Planar textures (GPU color path)
+let glTexY = null, glTexCb = null, glTexCr = null;
+let uMatrixLoc = null, uOffsetLoc = null;
 
 // Image-coord rect of glTex's CURRENT decoded contents.  Independent of
 // panX/panY/zoom so the previous frame's pixels stay anchored to their
@@ -682,38 +697,64 @@ function initWebGL(canvas) {
     const vec2 pos[4] = vec2[](vec2(-1,-1),vec2(1,-1),vec2(-1,1),vec2(1,1));
     out vec2 vT;
     void main() {
-      // vT.x ∈ [0,1] left→right; vT.y ∈ [0,1] bottom→top (NDC y is up).
-      // Image y grows downward, so the fragment shader flips when computing
-      // imgPos from vT.
       vT = vec2(gl_VertexID & 1, gl_VertexID >> 1);
       gl_Position = vec4(pos[gl_VertexID] * uScale, 0, 1);
     }`;
-  const fs = `#version 300 es
+  // Two fragment shader variants: passthrough RGBA (legacy / ?gpu=0) and
+  // planar YCbCr→RGB (GPU color path).  The thumbnail layer is always RGBA
+  // in both variants.
+  const fsLegacy = `#version 300 es
     precision mediump float;
     uniform sampler2D uTex;
     uniform sampler2D uThumb;
-    uniform vec4 uViewport;    // image coords (x0, y0, x1, y1) — y0 is top
-    uniform vec4 uTexRect;     // image coords of glTex contents
-    uniform vec4 uThumbRect;   // image coords of glThumb contents
+    uniform vec4 uViewport;
+    uniform vec4 uTexRect;
+    uniform vec4 uThumbRect;
     in vec2 vT;
     out vec4 fragColor;
     void main() {
-      // Map the (uScale-shrunk) quad position to image-space.  Y is flipped
-      // because vT.y = 0 is screen bottom but uViewport.y is image top.
       vec2 imgPos = vec2(
         mix(uViewport.x, uViewport.z, vT.x),
         mix(uViewport.w, uViewport.y, vT.y)
       );
       vec4 col = vec4(0.059, 0.066, 0.09, 1.0);
-      // Thumbnail layer: covers full canvas.  Empty thumbRect (zero w/h)
-      // produces NaN/Inf in the divide → bounds check fails → skipped.
       vec2 t = (imgPos - uThumbRect.xy) / (uThumbRect.zw - uThumbRect.xy);
       if (all(greaterThanEqual(t, vec2(0.0))) && all(lessThanEqual(t, vec2(1.0))))
         col = texture(uThumb, t);
-      // Previous-frame layer: overlays the thumbnail wherever it covers.
       vec2 u = (imgPos - uTexRect.xy) / (uTexRect.zw - uTexRect.xy);
       if (all(greaterThanEqual(u, vec2(0.0))) && all(lessThanEqual(u, vec2(1.0))))
         col = texture(uTex, u);
+      fragColor = col;
+    }`;
+  const fsPlanar = `#version 300 es
+    precision highp float;
+    uniform sampler2D uTexY;
+    uniform sampler2D uTexCb;
+    uniform sampler2D uTexCr;
+    uniform sampler2D uThumb;
+    uniform mat3      uMatrix;
+    uniform vec3      uOffset;
+    uniform vec4 uViewport;
+    uniform vec4 uTexRect;
+    uniform vec4 uThumbRect;
+    in vec2 vT;
+    out vec4 fragColor;
+    void main() {
+      vec2 imgPos = vec2(
+        mix(uViewport.x, uViewport.z, vT.x),
+        mix(uViewport.w, uViewport.y, vT.y)
+      );
+      vec4 col = vec4(0.059, 0.066, 0.09, 1.0);
+      vec2 t = (imgPos - uThumbRect.xy) / (uThumbRect.zw - uThumbRect.xy);
+      if (all(greaterThanEqual(t, vec2(0.0))) && all(lessThanEqual(t, vec2(1.0))))
+        col = texture(uThumb, t);
+      vec2 u = (imgPos - uTexRect.xy) / (uTexRect.zw - uTexRect.xy);
+      if (all(greaterThanEqual(u, vec2(0.0))) && all(lessThanEqual(u, vec2(1.0)))) {
+        vec3 ycc = vec3(texture(uTexY, u).r,
+                        texture(uTexCb, u).r,
+                        texture(uTexCr, u).r) - uOffset;
+        col = vec4(clamp(uMatrix * ycc, 0.0, 1.0), 1.0);
+      }
       fragColor = col;
     }`;
   function compile(type, src) {
@@ -722,9 +763,10 @@ function initWebGL(canvas) {
     if (!gl.getShaderParameter(s, gl.COMPILE_STATUS)) console.error(gl.getShaderInfoLog(s));
     return s;
   }
+  const usePlanar = useGpuColor;
   glProgram = gl.createProgram();
   gl.attachShader(glProgram, compile(gl.VERTEX_SHADER, vs));
-  gl.attachShader(glProgram, compile(gl.FRAGMENT_SHADER, fs));
+  gl.attachShader(glProgram, compile(gl.FRAGMENT_SHADER, usePlanar ? fsPlanar : fsLegacy));
   gl.linkProgram(glProgram); gl.useProgram(glProgram);
   uScaleLoc     = gl.getUniformLocation(glProgram, 'uScale');
   uViewportLoc  = gl.getUniformLocation(glProgram, 'uViewport');
@@ -735,12 +777,8 @@ function initWebGL(canvas) {
   gl.uniform4f(uTexRectLoc,   0, 0, 0, 0);
   gl.uniform4f(uThumbRectLoc, 0, 0, 0, 0);
 
-  // Both textures share filtering / wrap settings.  Initialise each with a
-  // 1×1 placeholder so the samplers are complete (an unbound or incomplete
-  // texture sampler returns implementation-defined values; the shader's
-  // bounds check would still gate usage, but better to be explicit).
   const placeholder = new Uint8Array([0, 0, 0, 255]);
-  function makeTex() {
+  function makeRGBATex() {
     const t = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D, t);
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, placeholder);
@@ -750,18 +788,44 @@ function initWebGL(canvas) {
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
     return t;
   }
-  glTex   = makeTex();
-  glThumb = makeTex();
-  // Bind glTex to unit 0 (uTex), glThumb to unit 1 (uThumb).  Bindings are
-  // persistent in WebGL state, so we only set the sampler-uniform indices
-  // once here.  Subsequent texImage2D / texSubImage2D calls re-bind via
-  // gl.activeTexture before uploading.
-  gl.activeTexture(gl.TEXTURE0); gl.bindTexture(gl.TEXTURE_2D, glTex);
-  gl.activeTexture(gl.TEXTURE1); gl.bindTexture(gl.TEXTURE_2D, glThumb);
-  gl.uniform1i(gl.getUniformLocation(glProgram, 'uTex'),   0);
-  gl.uniform1i(gl.getUniformLocation(glProgram, 'uThumb'), 1);
-  // Restore active unit to TEXTURE0 so paintDecodedRegion's existing
-  // gl.bindTexture(glTex) targets the right unit.
+  function makeR8Tex() {
+    const t = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, t);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.R8, 1, 1, 0, gl.RED, gl.UNSIGNED_BYTE, new Uint8Array([0]));
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    return t;
+  }
+
+  if (usePlanar) {
+    // Planar path: units 0-2 = Y/Cb/Cr (R8), unit 3 = thumbnail (RGBA).
+    glTexY  = makeR8Tex();
+    glTexCb = makeR8Tex();
+    glTexCr = makeR8Tex();
+    glThumb = makeRGBATex();
+    gl.activeTexture(gl.TEXTURE0); gl.bindTexture(gl.TEXTURE_2D, glTexY);
+    gl.activeTexture(gl.TEXTURE1); gl.bindTexture(gl.TEXTURE_2D, glTexCb);
+    gl.activeTexture(gl.TEXTURE2); gl.bindTexture(gl.TEXTURE_2D, glTexCr);
+    gl.activeTexture(gl.TEXTURE3); gl.bindTexture(gl.TEXTURE_2D, glThumb);
+    gl.uniform1i(gl.getUniformLocation(glProgram, 'uTexY'),  0);
+    gl.uniform1i(gl.getUniformLocation(glProgram, 'uTexCb'), 1);
+    gl.uniform1i(gl.getUniformLocation(glProgram, 'uTexCr'), 2);
+    gl.uniform1i(gl.getUniformLocation(glProgram, 'uThumb'), 3);
+    uMatrixLoc = gl.getUniformLocation(glProgram, 'uMatrix');
+    uOffsetLoc = gl.getUniformLocation(glProgram, 'uOffset');
+    gl.uniformMatrix3fv(uMatrixLoc, false, _MAT_BT601F);
+    gl.uniform3fv(uOffsetLoc, _OFF_FULL);
+  } else {
+    // Legacy path: unit 0 = RGBA main tex, unit 1 = RGBA thumbnail.
+    glTex   = makeRGBATex();
+    glThumb = makeRGBATex();
+    gl.activeTexture(gl.TEXTURE0); gl.bindTexture(gl.TEXTURE_2D, glTex);
+    gl.activeTexture(gl.TEXTURE1); gl.bindTexture(gl.TEXTURE_2D, glThumb);
+    gl.uniform1i(gl.getUniformLocation(glProgram, 'uTex'),   0);
+    gl.uniform1i(gl.getUniformLocation(glProgram, 'uThumb'), 1);
+  }
   gl.activeTexture(gl.TEXTURE0);
 
   gl.bindVertexArray(gl.createVertexArray());
@@ -904,33 +968,61 @@ function scheduleFetch() {
   }, DEBOUNCE_MS);
 }
 
-// Decode the current DataBinSet into `rgbPtr` and upload to the WebGL
-// texture.  Shared between the mid-decode paint (fired during a slow
-// fetch to show the user something before the full response arrives)
-// and the final paint at end-of-response.  Returns true on success.
+// Decode the current DataBinSet and upload to WebGL textures.  When GPU
+// color is active, outputs 3 R8 planes and skips the CPU colour matrix;
+// otherwise falls back to the legacy packed-RGBA path.
 function paintDecodedRegion(regionX, regionY, regionW, regionH, outW, outH) {
-  const needBytes = outW * outH * 4;
-  if (needBytes > rgbBufSz) {
-    if (rgbPtr) M._free(rgbPtr);
-    rgbPtr = M._malloc(needBytes);
-    rgbBufSz = needBytes;
-  }
-  const rc = M._jpip_end_frame_region(ctx, rgbPtr, outW, outH,
-                                       regionX, regionY, regionW, regionH);
-  if (rc !== 0) return false;
-  const rgba = new Uint8Array(M.HEAPU8.buffer, rgbPtr, outW * outH * 4);
-  gl.activeTexture(gl.TEXTURE0);
-  gl.bindTexture(gl.TEXTURE_2D, glTex);
-  if (outW !== texW || outH !== texH) {
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, outW, outH, 0, gl.RGBA, gl.UNSIGNED_BYTE, rgba);
+  if (useGpuColor) {
+    const planeBytes = outW * outH;
+    if (planeBytes > plBufSz) {
+      if (plYPtr) { M._free(plYPtr); M._free(plCbPtr); M._free(plCrPtr); }
+      plYPtr  = M._malloc(planeBytes);
+      plCbPtr = M._malloc(planeBytes);
+      plCrPtr = M._malloc(planeBytes);
+      plBufSz = planeBytes;
+    }
+    const rc = M._jpip_end_frame_region_planar(ctx, plYPtr, plCbPtr, plCrPtr,
+                                                outW, outH,
+                                                regionX, regionY, regionW, regionH);
+    if (rc < 0) return false;
+    gpuIsYCbCr = (rc === 1);
+    const yData  = new Uint8Array(M.HEAPU8.buffer, plYPtr,  planeBytes);
+    const cbData = new Uint8Array(M.HEAPU8.buffer, plCbPtr, planeBytes);
+    const crData = new Uint8Array(M.HEAPU8.buffer, plCrPtr, planeBytes);
+    function uploadR8(tex, unit, data) {
+      gl.activeTexture(gl.TEXTURE0 + unit);
+      gl.bindTexture(gl.TEXTURE_2D, tex);
+      if (outW !== texW || outH !== texH)
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.R8, outW, outH, 0, gl.RED, gl.UNSIGNED_BYTE, data);
+      else
+        gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, outW, outH, gl.RED, gl.UNSIGNED_BYTE, data);
+    }
+    uploadR8(glTexY,  0, yData);
+    uploadR8(glTexCb, 1, cbData);
+    uploadR8(glTexCr, 2, crData);
     texW = outW; texH = outH;
+    gl.uniformMatrix3fv(uMatrixLoc, false, gpuIsYCbCr ? _MAT_BT601F : _MAT_IDENTITY);
+    gl.uniform3fv(uOffsetLoc, gpuIsYCbCr ? _OFF_FULL : _OFF_ZERO);
   } else {
-    gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, outW, outH, gl.RGBA, gl.UNSIGNED_BYTE, rgba);
+    const needBytes = outW * outH * 4;
+    if (needBytes > rgbBufSz) {
+      if (rgbPtr) M._free(rgbPtr);
+      rgbPtr = M._malloc(needBytes);
+      rgbBufSz = needBytes;
+    }
+    const rc = M._jpip_end_frame_region(ctx, rgbPtr, outW, outH,
+                                         regionX, regionY, regionW, regionH);
+    if (rc !== 0) return false;
+    const rgba = new Uint8Array(M.HEAPU8.buffer, rgbPtr, outW * outH * 4);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, glTex);
+    if (outW !== texW || outH !== texH) {
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, outW, outH, 0, gl.RGBA, gl.UNSIGNED_BYTE, rgba);
+      texW = outW; texH = outH;
+    } else {
+      gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, outW, outH, gl.RGBA, gl.UNSIGNED_BYTE, rgba);
+    }
   }
-  // Record the IMAGE-COORD rect this texture represents.  drawViewport
-  // uses these to anchor the previous-frame pixels to their image position
-  // even after the user pans/zooms, so motion is smooth instead of frozen-
-  // and-jump on each fetch boundary.
   texImgX = regionX; texImgY = regionY;
   texImgW = regionW; texImgH = regionH;
   drawViewport();
@@ -1056,11 +1148,12 @@ async function fetchThumbnail() {
     // FULL canvas image-coord rect — the thumbnail is the same image at
     // a coarser resolution, not a sub-region.
     if (gl && glThumb) {
-      gl.activeTexture(gl.TEXTURE1);
+      const thumbUnit = useGpuColor ? gl.TEXTURE3 : gl.TEXTURE1;
+      gl.activeTexture(thumbUnit);
       gl.bindTexture(gl.TEXTURE_2D, glThumb);
       gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, fW, fH, 0, gl.RGBA, gl.UNSIGNED_BYTE,
                     new Uint8Array(copy.buffer));
-      gl.activeTexture(gl.TEXTURE0);  // restore default for paintDecodedRegion
+      gl.activeTexture(gl.TEXTURE0);
       thumbImgW = canvasW; thumbImgH = canvasH;
       // First sign of life: redraw immediately so the thumbnail appears
       // behind whatever (possibly empty) glTex content is there.  Bypass

--- a/web/src/jpip_wrapper.cpp
+++ b/web/src/jpip_wrapper.cpp
@@ -707,6 +707,243 @@ int jpip_end_frame_region(void *handle, uint8_t *rgb_out, int out_w, int out_h,
   return 0;
 }
 
+// ── Planar YCbCr output variants ─────────────────────────────────────────
+// Same decode pipeline as jpip_end_frame / jpip_end_frame_region, but output
+// three separate uint8 planes (Y/Cb/Cr) and skip the inverse MCT so the GPU
+// fragment shader can apply the colour matrix instead.
+//
+// Return value:
+//   1  — planes contain raw YCbCr  (JS applies BT.601 matrix in shader)
+//   0  — planes contain RGB        (JS uses identity matrix)
+//  <0  — error (same codes as jpip_end_frame)
+
+static inline uint8_t clamp8(int32_t v) {
+  return static_cast<uint8_t>(v < 0 ? 0 : (v > 255 ? 255 : v));
+}
+
+EMSCRIPTEN_KEEPALIVE
+int jpip_end_frame_planar(void *handle, uint8_t *y_out, uint8_t *cb_out, uint8_t *cr_out,
+                          int out_w, int out_h) {
+  if (!handle || !y_out || !cb_out || !cr_out || out_w <= 0 || out_h <= 0) return -1;
+  auto *ctx = static_cast<JpipContext *>(handle);
+
+  if (ctx->dirty || ctx->sparse_cs.empty()) {
+    ctx->sparse_cs.clear();
+    auto rc = open_htj2k::jpip::reassemble_codestream_client(ctx->set, *ctx->idx, ctx->sparse_cs);
+    if (rc != open_htj2k::jpip::ReassembleStatus::Ok) return -2;
+  }
+
+  jpip_maybe_invalidate_reuse(ctx);
+  auto &dec = ctx->dec;
+  if (!ctx->dec_initialized) {
+#ifdef OPENHTJ2K_THREAD
+    dec.init(ctx->sparse_cs.data(), ctx->sparse_cs.size(), ctx->reduce_NL, 0);
+#else
+    dec.init(ctx->sparse_cs.data(), ctx->sparse_cs.size(), ctx->reduce_NL, 1);
+#endif
+    ctx->dec_initialized = true;
+  } else {
+    dec.init(ctx->sparse_cs.data(), ctx->sparse_cs.size(), ctx->reduce_NL, 1);
+  }
+  ctx->last_reduce_NL = ctx->reduce_NL;
+  dec.parse();
+
+  const uint16_t nc = dec.get_num_component();
+  const uint32_t cs = dec.get_colorspace();
+  const bool is_ycbcr = (nc >= 3 && cs != open_htj2k::ENUMCS_SRGB
+                                  && cs != open_htj2k::ENUMCS_GRAYSCALE);
+  if (is_ycbcr) dec.set_skip_mct(true);
+
+  std::vector<uint32_t> widths, heights;
+  std::vector<uint8_t>  depths;
+  std::vector<bool>     signeds;
+  const uint32_t ow = static_cast<uint32_t>(out_w);
+  const uint32_t oh = static_cast<uint32_t>(out_h);
+
+  std::vector<uint32_t> xc_lut;
+  uint32_t last_ch = 0;
+
+  try {
+    dec.invoke_line_based_stream_reuse(
+        [&](uint32_t y, int32_t *const *rows, uint16_t nc_cb) {
+          if (nc_cb < 3 || widths.empty() || heights.empty()) return;
+          const uint32_t cw = widths[0];
+          const uint32_t ch = heights[0];
+          if (xc_lut.size() != ow || last_ch != ch) {
+            xc_lut.resize(ow);
+            for (uint32_t xw = 0; xw < ow; ++xw) {
+              xc_lut[xw] = static_cast<uint32_t>(
+                  static_cast<uint64_t>(xw) * cw / (ow > 0 ? ow : 1));
+            }
+            last_ch = ch;
+          }
+          int32_t shift[3], bias[3];
+          for (int c = 0; c < 3; ++c) {
+            const int32_t d = depths.size() > static_cast<size_t>(c) ? depths[c] : 8;
+            shift[c] = (d >= 8) ? (d - 8) : 0;
+            const int32_t half   = (d > 8) ? (1 << (shift[c] - 1)) : 0;
+            const int32_t offset = (signeds.size() > static_cast<size_t>(c) && signeds[c])
+                                       ? (1 << (d - 1))
+                                       : 0;
+            bias[c] = half + offset;
+          }
+          const uint32_t ty0 =
+              static_cast<uint32_t>(static_cast<uint64_t>(y) * oh / (ch > 0 ? ch : 1));
+          const uint32_t ty1 =
+              static_cast<uint32_t>(static_cast<uint64_t>(y + 1) * oh / (ch > 0 ? ch : 1));
+          if (ty0 >= oh) return;
+          uint8_t *dy = y_out  + static_cast<size_t>(ty0) * ow;
+          uint8_t *dc = cb_out + static_cast<size_t>(ty0) * ow;
+          uint8_t *dr = cr_out + static_cast<size_t>(ty0) * ow;
+          const int32_t *__restrict__ r0 = rows[0];
+          const int32_t *__restrict__ r1 = rows[1];
+          const int32_t *__restrict__ r2 = rows[2];
+          const uint32_t *__restrict__ lut = xc_lut.data();
+          for (uint32_t xw = 0; xw < ow; ++xw) {
+            const uint32_t xc = lut[xw];
+            dy[xw] = clamp8((r0[xc] + bias[0]) >> shift[0]);
+            dc[xw] = clamp8((r1[xc] + bias[1]) >> shift[1]);
+            dr[xw] = clamp8((r2[xc] + bias[2]) >> shift[2]);
+          }
+          for (uint32_t ty = ty0 + 1; ty < ty1 && ty < oh; ++ty) {
+            std::memcpy(y_out  + static_cast<size_t>(ty) * ow, dy, ow);
+            std::memcpy(cb_out + static_cast<size_t>(ty) * ow, dc, ow);
+            std::memcpy(cr_out + static_cast<size_t>(ty) * ow, dr, ow);
+          }
+        },
+        widths, heights, depths, signeds);
+  } catch (...) {
+    if (is_ycbcr) dec.set_skip_mct(false);
+    return -3;
+  }
+  if (is_ycbcr) dec.set_skip_mct(false);
+  ctx->dirty = false;
+  return is_ycbcr ? 1 : 0;
+}
+
+EMSCRIPTEN_KEEPALIVE
+int jpip_end_frame_region_planar(void *handle, uint8_t *y_out, uint8_t *cb_out, uint8_t *cr_out,
+                                 int out_w, int out_h,
+                                 int region_x, int region_y, int region_w, int region_h) {
+  if (!handle || !y_out || !cb_out || !cr_out || out_w <= 0 || out_h <= 0) return -1;
+  if (region_w <= 0 || region_h <= 0) return -1;
+  auto *ctx = static_cast<JpipContext *>(handle);
+
+  if (ctx->dirty || ctx->sparse_cs.empty()) {
+    ctx->sparse_cs.clear();
+    auto rc = open_htj2k::jpip::reassemble_codestream_client(ctx->set, *ctx->idx, ctx->sparse_cs);
+    if (rc != open_htj2k::jpip::ReassembleStatus::Ok) return -2;
+  }
+
+  jpip_maybe_invalidate_reuse(ctx);
+  auto &dec = ctx->dec;
+  if (!ctx->dec_initialized) {
+#ifdef OPENHTJ2K_THREAD
+    dec.init(ctx->sparse_cs.data(), ctx->sparse_cs.size(), ctx->reduce_NL, 0);
+#else
+    dec.init(ctx->sparse_cs.data(), ctx->sparse_cs.size(), ctx->reduce_NL, 1);
+#endif
+    ctx->dec_initialized = true;
+  } else {
+    dec.init(ctx->sparse_cs.data(), ctx->sparse_cs.size(), ctx->reduce_NL, 1);
+  }
+  ctx->last_reduce_NL = ctx->reduce_NL;
+  dec.parse();
+
+  const uint16_t nc = dec.get_num_component();
+  const uint32_t cs = dec.get_colorspace();
+  const bool is_ycbcr = (nc >= 3 && cs != open_htj2k::ENUMCS_SRGB
+                                  && cs != open_htj2k::ENUMCS_GRAYSCALE);
+  if (is_ycbcr) dec.set_skip_mct(true);
+
+  std::vector<uint32_t> widths, heights;
+  std::vector<uint8_t>  depths;
+  std::vector<bool>     signeds;
+  const uint32_t ow = static_cast<uint32_t>(out_w);
+  const uint32_t oh = static_cast<uint32_t>(out_h);
+  const uint32_t red = ctx->reduce_NL;
+
+  const uint32_t cw_at_red = (ctx->canvas_w + ((1u << red) - 1)) >> red;
+  const uint32_t ch_at_red = (ctx->canvas_h + ((1u << red) - 1)) >> red;
+
+  const uint32_t ry0_u = static_cast<uint32_t>(region_y) >> red;
+  uint32_t ry1 = (static_cast<uint32_t>(region_y + region_h) + ((1u << red) - 1)) >> red;
+  const uint32_t rx0_u = static_cast<uint32_t>(region_x) >> red;
+  uint32_t rx1 = (static_cast<uint32_t>(region_x + region_w) + ((1u << red) - 1)) >> red;
+  if (ry1 > ch_at_red) ry1 = ch_at_red;
+  if (rx1 > cw_at_red) rx1 = cw_at_red;
+  const uint32_t ry0 = ry0_u;
+  const uint32_t rx0 = rx0_u;
+  if (rx1 <= rx0 || ry1 <= ry0) {
+    if (is_ycbcr) dec.set_skip_mct(false);
+    return -1;
+  }
+  const uint32_t rw = rx1 - rx0;
+  const uint32_t rh = ry1 - ry0;
+
+  const bool full_coverage =
+      (region_x == 0 && region_y == 0
+       && static_cast<uint32_t>(region_x + region_w) >= ctx->canvas_w
+       && static_cast<uint32_t>(region_y + region_h) >= ctx->canvas_h);
+  if (!full_coverage) {
+    std::memset(y_out,  0, static_cast<size_t>(ow) * oh);
+    std::memset(cb_out, 0, static_cast<size_t>(ow) * oh);
+    std::memset(cr_out, 0, static_cast<size_t>(ow) * oh);
+  }
+
+  std::vector<uint32_t> xc_lut(ow);
+  for (uint32_t xw = 0; xw < ow; ++xw) {
+    xc_lut[xw] = rx0 + static_cast<uint32_t>(static_cast<uint64_t>(xw) * rw / ow);
+  }
+
+  dec.set_row_range(ry0, ry1);
+  dec.set_col_range(rx0, rx1);
+  try {
+    dec.invoke_line_based_stream_reuse(
+        [&](uint32_t y, int32_t *const *rows, uint16_t nc_cb) {
+          if (nc_cb < 3 || widths.empty() || heights.empty()) return;
+          int32_t shift[3], bias[3];
+          for (int c = 0; c < 3; ++c) {
+            const int32_t d = depths.size() > static_cast<size_t>(c) ? depths[c] : 8;
+            shift[c] = (d >= 8) ? (d - 8) : 0;
+            const int32_t half   = (d > 8) ? (1 << (shift[c] - 1)) : 0;
+            const int32_t offset = (signeds.size() > static_cast<size_t>(c) && signeds[c])
+                                       ? (1 << (d - 1))
+                                       : 0;
+            bias[c] = half + offset;
+          }
+          const uint32_t ty = static_cast<uint32_t>(static_cast<uint64_t>(y - ry0) * oh / rh);
+          if (ty >= oh) return;
+          uint8_t *dy = y_out  + static_cast<size_t>(ty) * ow;
+          uint8_t *dc = cb_out + static_cast<size_t>(ty) * ow;
+          uint8_t *dr = cr_out + static_cast<size_t>(ty) * ow;
+          const int32_t *__restrict__ r0 = rows[0];
+          const int32_t *__restrict__ r1 = rows[1];
+          const int32_t *__restrict__ r2 = rows[2];
+          const uint32_t *__restrict__ lut = xc_lut.data();
+          for (uint32_t xw = 0; xw < ow; ++xw) {
+            const uint32_t xc = lut[xw];
+            dy[xw] = clamp8((r0[xc] + bias[0]) >> shift[0]);
+            dc[xw] = clamp8((r1[xc] + bias[1]) >> shift[1]);
+            dr[xw] = clamp8((r2[xc] + bias[2]) >> shift[2]);
+          }
+          const uint32_t ty1_out = static_cast<uint32_t>(static_cast<uint64_t>(y - ry0 + 1) * oh / rh);
+          for (uint32_t ty2 = ty + 1; ty2 < ty1_out && ty2 < oh; ++ty2) {
+            std::memcpy(y_out  + static_cast<size_t>(ty2) * ow, dy, ow);
+            std::memcpy(cb_out + static_cast<size_t>(ty2) * ow, dc, ow);
+            std::memcpy(cr_out + static_cast<size_t>(ty2) * ow, dr, ow);
+          }
+        },
+        widths, heights, depths, signeds);
+  } catch (...) {
+    if (is_ycbcr) dec.set_skip_mct(false);
+    return -3;
+  }
+  if (is_ycbcr) dec.set_skip_mct(false);
+  ctx->dirty = false;
+  return is_ycbcr ? 1 : 0;
+}
+
 EMSCRIPTEN_KEEPALIVE
 void jpip_destroy_context(void *handle) {
   delete static_cast<JpipContext *>(handle);


### PR DESCRIPTION
## Summary

- **GPU color conversion**: skip the inverse MCT in the WASM decoder and apply the BT.601 colour matrix in a WebGL2 fragment shader for both `jpip_demo.html` and `jpip_viewer.html`. Same approach as `rtp_demo.html` (measured 29% decode speedup on 4K content). Controlled via `?gpu=0` URL param for A/B testing.
- **`?wasmBase=` support**: both JPIP demos now support `?wasmBase=/wasm-full/` for local dev under `serve.mjs`, matching `rtp_demo.html`.
- **`precision highp float`**: fix blocky interpolation on Nvidia/Linux GPUs that implement `mediump` as true FP16 (Apple GPUs silently promote to FP32, masking the issue on macOS).
- **Thumbnail fetch priority**: fix indefinite deferral of thumbnail fetch on fast local servers where `pendingFetch` preempted `thumbnailPending` every cycle.

### C++ (`web/src/jpip_wrapper.cpp`)
- `jpip_end_frame_planar()` / `jpip_end_frame_region_planar()` — planar Y/Cb/Cr output with `set_skip_mct(true)`, per-component signed bias. Returns 1 (YCbCr, apply matrix) or 0 (RGB, identity).

### JS (`jpip_demo.html`, `jpip_viewer.html`)
- Planar fragment shader with `u_matrix` / `u_offset` uniforms and three R8 textures
- `jpip_viewer.html`: layered carry-forward shader extended — main layer samples planar Y/Cb/Cr → RGB via matrix; thumbnail layer stays RGBA passthrough

## Test plan

- [x] `jpip_demo.html` with `?gpu=0` vs default — visual comparison, no green tint
- [x] `jpip_viewer.html` pan/zoom — carry-forward texture anchored correctly
- [x] `jpip_viewer.html` — thumbnail appears reliably on localhost
- [x] Nvidia/Linux — no blocky interpolation artifacts
- [ ] Grayscale codestream — graceful fallback (nc < 3)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)