### PR TITLE
perf(dec): cap CLI default thread count at 8

### DIFF
--- a/source/apps/decoder/main_dec.cpp
+++ b/source/apps/decoder/main_dec.cpp
@@ -31,12 +31,14 @@
 //
 // (c) 2019 - 2021 Osamu Watanabe, Takushoku University, Vrije Universiteit Brussels
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <vector>
 #ifdef _OPENMP
   #include <omp.h>
@@ -538,7 +540,8 @@ int main(int argc, char *argv[]) {
 
   uint32_t num_threads;
   if (nullptr == (tmp_param = get_command_option(argc, argv, "-num_threads"))) {
-    num_threads = 0;
+    unsigned hwc = std::thread::hardware_concurrency();
+    num_threads  = (hwc > 0) ? std::min(hwc, 8u) : 0;
   } else {
     tmp_val = strtol(tmp_param, &endptr, 10);
     if (tmp_param == endptr) {

--- a/source/apps/decoder/main_dec.cpp
+++ b/source/apps/decoder/main_dec.cpp
@@ -466,7 +466,7 @@ void print_help(char *cmd) {
   printf("-o: Output file. Supported formats are PPM, PGM, PGX and RAW.\n");
   printf("-reduce n: Number of DWT resolution reduction.\n");
   printf("-iter n: Repeat decoding n times (for benchmarking). Output is written once.\n");
-  printf("-num_threads n: Number of threads (0 = auto).\n");
+  printf("-num_threads n: Number of threads (0 = auto, capped at 8).\n");
   printf("-batch: Use batch (full-image buffer) decode path instead of the default streaming path.\n");
   printf("-ycbcr bt601|bt709: [EXPERIMENTAL] Convert YCbCr to RGB (PPM output only).\n");
 }
@@ -540,8 +540,7 @@ int main(int argc, char *argv[]) {
 
   uint32_t num_threads;
   if (nullptr == (tmp_param = get_command_option(argc, argv, "-num_threads"))) {
-    unsigned hwc = std::thread::hardware_concurrency();
-    num_threads  = (hwc > 0) ? std::min(hwc, 8u) : 0;
+    num_threads = 0;
   } else {
     tmp_val = strtol(tmp_param, &endptr, 10);
     if (tmp_param == endptr) {
@@ -552,8 +551,11 @@ int main(int argc, char *argv[]) {
       printf("ERROR: -num_threads takes non-negative integer ( < UINT32_MAX).\n");
       exit(EXIT_FAILURE);
     }
-    //    num_iterations = static_cast<int32_t>(tmp_val);
-    num_threads = static_cast<uint32_t>(tmp_val);  // strtoul(tmp_param, nullptr, 10);
+    num_threads = static_cast<uint32_t>(tmp_val);
+  }
+  if (num_threads == 0) {
+    unsigned hwc = std::thread::hardware_concurrency();
+    num_threads  = (hwc > 0) ? std::min(hwc, 8u) : 0;
   }
   // Reject any unrecognised flags.
   {


### PR DESCRIPTION
## Summary

- Cap the CLI decoder's default thread count at `min(hardware_concurrency, 8)` when `-num_threads` is not specified.
- Beyond ~8 threads, 4K decode wall time plateaus while system overhead (`sched_yield` spin-waits, `futex`, `clone3`) grows linearly with thread count.
- Explicit `-num_threads N` still overrides to any value; the library API is unchanged.

## Motivation

Profiling on a 32-core machine showed ~33% of total CPU time in system calls, dominated by `sched_yield` from spin-wait barriers in the decode path. Benchmarking across thread counts:

| Threads | Wall (10 iter) | Sys | sched_yield time |
|---|---|---|---|
| 8 (new default) | 0.26s | 0.12s | 9.3 ms |
| 32 (old default) | 0.24s | 0.26s | 23.8 ms |

The new default trades ~2 ms per-decode wall time for 54% less system overhead.

## Test plan

- [x] 670/670 tests pass (`ctest` full suite)
- [x] Verified 8 `clone3` calls via `strace` (was 32)
- [x] Verified explicit `-num_threads 1`, `-num_threads 2`, `-num_threads 32` still work
- [x] Benchmarked with `-iter 10` across thread counts 1/2/4/8/16/32

🤖 Generated with [Claude Code](https://claude.com/claude-code)