### PR TITLE
fix(jpip): fix green tint in GPU color path

### DIFF
--- a/source/core/interface/decoder.cpp
+++ b/source/core/interface/decoder.cpp
@@ -107,6 +107,9 @@ class openhtj2k_decoder_impl {
   OPENHTJ2K_NODISCARD uint8_t get_component_depth(uint16_t) const;
   OPENHTJ2K_NODISCARD bool get_component_signedness(uint16_t) const;
   OPENHTJ2K_NODISCARD uint32_t get_colorspace() const { return enum_cs; }
+  OPENHTJ2K_NODISCARD uint8_t get_mct() const {
+    return main_header.COD ? main_header.COD->use_color_trafo() : 0;
+  }
   uint8_t get_minimum_DWT_levels();
   uint8_t get_max_safe_reduce_NL();
 
@@ -483,6 +486,7 @@ bool openhtj2k_decoder::get_component_signedness(uint16_t c) {
 uint8_t openhtj2k_decoder::get_minumum_DWT_levels() { return this->impl->get_minimum_DWT_levels(); }
 uint8_t openhtj2k_decoder::get_max_safe_reduce_NL() { return this->impl->get_max_safe_reduce_NL(); }
 uint32_t openhtj2k_decoder::get_colorspace() { return this->impl->get_colorspace(); }
+uint8_t openhtj2k_decoder::get_mct() { return this->impl->get_mct(); }
 
 void openhtj2k_decoder::invoke(std::vector<int32_t *> &buf, std::vector<uint32_t> &width,
                                std::vector<uint32_t> &height, std::vector<uint8_t> &depth,

--- a/source/core/interface/decoder.hpp
+++ b/source/core/interface/decoder.hpp
@@ -69,6 +69,9 @@ class openhtj2k_decoder {
   // Returns the EnumCS value from the JPH/JP2 colour specification box, or 0 for raw codestreams.
   // Compare against open_htj2k::ENUMCS_SRGB / ENUMCS_GRAYSCALE / ENUMCS_YCBCR.
   OPENHTJ2K_EXPORT uint32_t get_colorspace();
+  // Returns the MCT byte from the COD marker (0 = no transform, 1 = ICT/RCT).
+  // Valid after parse().
+  OPENHTJ2K_EXPORT uint8_t get_mct();
   OPENHTJ2K_EXPORT void invoke(std::vector<int32_t *> &, std::vector<uint32_t> &, std::vector<uint32_t> &,
                                std::vector<uint8_t> &, std::vector<bool> &);
   // Line-based decode: same signature as invoke() but uses stateful row-pull

--- a/web/jpip_demo.html
+++ b/web/jpip_demo.html
@@ -588,6 +588,7 @@ function drawFramePlanar(w, h, isYCbCr) {
   function uploadR8(tex, unit, data) {
     gl.activeTexture(gl.TEXTURE0 + unit);
     gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.pixelStorei(gl.UNPACK_ALIGNMENT, 1);
     if (texW !== w || texH !== h)
       gl.texImage2D(gl.TEXTURE_2D, 0, gl.R8, w, h, 0, gl.RED, gl.UNSIGNED_BYTE, data);
     else

--- a/web/jpip_viewer.html
+++ b/web/jpip_viewer.html
@@ -997,6 +997,7 @@ function paintDecodedRegion(regionX, regionY, regionW, regionH, outW, outH) {
     function uploadR8(tex, unit, data) {
       gl.activeTexture(gl.TEXTURE0 + unit);
       gl.bindTexture(gl.TEXTURE_2D, tex);
+      gl.pixelStorei(gl.UNPACK_ALIGNMENT, 1);
       if (outW !== texW || outH !== texH)
         gl.texImage2D(gl.TEXTURE_2D, 0, gl.R8, outW, outH, 0, gl.RED, gl.UNSIGNED_BYTE, data);
       else

--- a/web/src/jpip_wrapper.cpp
+++ b/web/src/jpip_wrapper.cpp
@@ -749,9 +749,7 @@ int jpip_end_frame_planar(void *handle, uint8_t *y_out, uint8_t *cb_out, uint8_t
   dec.parse();
 
   const uint16_t nc = dec.get_num_component();
-  const uint32_t cs = dec.get_colorspace();
-  const bool is_ycbcr = (nc >= 3 && cs != open_htj2k::ENUMCS_SRGB
-                                  && cs != open_htj2k::ENUMCS_GRAYSCALE);
+  const bool is_ycbcr = (nc >= 3 && dec.get_mct() != 0);
   if (is_ycbcr) dec.set_skip_mct(true);
 
   std::vector<uint32_t> widths, heights;
@@ -851,9 +849,7 @@ int jpip_end_frame_region_planar(void *handle, uint8_t *y_out, uint8_t *cb_out, 
   dec.parse();
 
   const uint16_t nc = dec.get_num_component();
-  const uint32_t cs = dec.get_colorspace();
-  const bool is_ycbcr = (nc >= 3 && cs != open_htj2k::ENUMCS_SRGB
-                                  && cs != open_htj2k::ENUMCS_GRAYSCALE);
+  const bool is_ycbcr = (nc >= 3 && dec.get_mct() != 0);
   if (is_ycbcr) dec.set_skip_mct(true);
 
   std::vector<uint32_t> widths, heights;


### PR DESCRIPTION
## Summary

- Fix green tint in the JPIP viewer/demo GPU color path caused by missing `UNPACK_ALIGNMENT=1` for R8 texture uploads.
- Add `get_mct()` to the decoder public API and use the MCT flag (instead of the colorspace heuristic) for YCbCr detection in the JPIP WASM wrapper.

## Root cause

WebGL's default `UNPACK_ALIGNMENT` is 4, meaning each texture row must start on a 4-byte boundary. For R8 textures (1 byte per pixel), any width not divisible by 4 causes the GL to read phantom padding bytes, shifting every row after the first. This scrambles Y/Cb/Cr values and produces a green tint after the BT.601 matrix is applied.

The bug was latent since the GPU color path was added (0168b46) but only manifested on viewports whose width % 4 != 0.

## Changes

1. **`gl.pixelStorei(gl.UNPACK_ALIGNMENT, 1)`** before every R8 `texImage2D` / `texSubImage2D` in both `jpip_viewer.html` and `jpip_demo.html`.
2. **New `get_mct()` API** on `openhtj2k_decoder` — reads the COD marker's MCT byte after `parse()`. The WASM wrapper now uses `dec.get_mct() != 0` instead of `get_colorspace() != SRGB && != GRAYSCALE`, which was wrong for JPIP-reassembled codestreams (always raw J2C, `get_colorspace()` returns 0).

## Test plan

- [x] 670/670 native tests pass
- [x] WASM build compiles cleanly
- [x] Verified on macOS: green tint eliminated with `?gpu=1` (default)
- [x] `?gpu=0` (legacy RGBA path) still works correctly
- [x] Native pixel comparison: < 1 LSB mean error between MCT and skip-MCT+BT.601 paths on 8-bit test images

🤖 Generated with [Claude Code](https://claude.com/claude-code)