### PR TITLE
fix(wt_bridge): include host LAN IPs in dev cert SANs

### DIFF
--- a/tools/wt_bridge/cert.go
+++ b/tools/wt_bridge/cert.go
@@ -37,6 +37,17 @@ func (b *certBundle) sha256ColonHex() string {
 	return strings.Join(parts, ":")
 }
 
+func localNonLoopbackIPs() []net.IP {
+	var ips []net.IP
+	addrs, _ := net.InterfaceAddrs()
+	for _, a := range addrs {
+		if ipn, ok := a.(*net.IPNet); ok && !ipn.IP.IsLoopback() {
+			ips = append(ips, ipn.IP)
+		}
+	}
+	return ips
+}
+
 func generateDevCert() (*certBundle, error) {
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
@@ -59,7 +70,7 @@ func generateDevCert() (*certBundle, error) {
 		BasicConstraintsValid: true,
 		IsCA:                  false,
 		DNSNames:              []string{"localhost"},
-		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		IPAddresses:           append([]net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback}, localNonLoopbackIPs()...),
 	}
 	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &priv.PublicKey, priv)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Auto-detect all non-loopback IP addresses at dev-cert generation time
  and include them in the certificate's Subject Alternative Names.
- The previous cert only listed `localhost` / `127.0.0.1` / `::1`, which
  is insufficient for split-mode where the browser connects to the
  bridge's LAN IP.  While `serverCertificateHashes` should bypass SAN
  checking per the W3C WebTransport spec, an accurate SAN list is
  correct regardless and guards against browser regressions.

## Test plan

- [ ] `go build` passes (verified locally)
- [ ] Start bridge with `--dev`, confirm log prints the cert hash
- [ ] In split-mode, verify the browser's WebTransport handshake succeeds
      after also opening the firewall (`ufw allow 4433/udp`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)