### PR TITLE
fix(wt_bridge): default QUIC initial packet size to 1200 for VPN paths

### DIFF
--- a/tools/wt_bridge/main.go
+++ b/tools/wt_bridge/main.go
@@ -32,11 +32,15 @@ func main() {
 		certPath    = flag.String("cert", "", "PEM cert chain (use instead of --dev for a CA-issued cert)")
 		keyPath     = flag.String("key", "", "PEM private key matching --cert")
 		dev         = flag.Bool("dev", false, "Generate an ephemeral self-signed cert and print SHA-256 hash")
+		initialMTU  = flag.Int("initial-mtu", 1200, "Initial QUIC packet size in bytes (1200-1452); lower for VPN/tunnel paths")
 	)
 	flag.Parse()
 
 	if !*dev && (*certPath == "" || *keyPath == "") {
 		log.Fatalf("either --dev or both --cert and --key are required")
+	}
+	if *initialMTU < 1200 || *initialMTU > 1452 {
+		log.Fatalf("--initial-mtu must be between 1200 and 1452")
 	}
 	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
 
@@ -83,11 +87,10 @@ func main() {
 		NextProtos:   []string{http3.NextProtoH3},
 	}
 	quicConf := &quic.Config{
-		// Generous datagram allowance — even though we use streams for the
-		// data path, control-plane flow benefits from a steady idle timeout.
 		MaxIdleTimeout:    30 * time.Second,
 		KeepAlivePeriod:   10 * time.Second,
 		EnableDatagrams:   true,
+		InitialPacketSize: uint16(*initialMTU),
 	}
 
 	wtServer := &webtransport.Server{


### PR DESCRIPTION
## Summary

- Default `InitialPacketSize` to 1200 bytes (QUIC minimum per RFC 9000
  §14) instead of quic-go's default of 1252.  On paths with reduced MTU
  (e.g. VPN tunnels between subnets with path MTU ≤ 1280), the server's
  coalesced Initial+Handshake datagram at 1252+28 = 1280 bytes rides the
  exact MTU edge.  When it exceeds the path MTU the Initial response is
  silently dropped, the browser never receives the ServerHello, and Chrome
  reports `QUIC_HANDSHAKE_TIMEOUT` with `num_undecryptable_packets: 7`
  (Handshake packets arrive but can't be decrypted without the missing
  Initial).
- Add `--initial-mtu` flag (1200–1452) so operators with known higher
  path MTU can opt in to larger packets.

## Test plan

- [ ] `go build` passes (verified locally)
- [ ] Split-mode: bridge on 133.36.41.0/25, browser on 192.168.0.0/24
      (path MTU 1280) — verify WebTransport handshake succeeds
- [ ] LAN mode (path MTU 1500) — verify no regression
- [ ] `--initial-mtu 1452` on a same-subnet setup — verify it still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)