### PR TITLE
perf(wt_bridge): add --log flag and reduce log frequency

### DIFF
--- a/tools/wt_bridge/main.go
+++ b/tools/wt_bridge/main.go
@@ -33,6 +33,7 @@ func main() {
 		keyPath     = flag.String("key", "", "PEM private key matching --cert")
 		dev         = flag.Bool("dev", false, "Generate an ephemeral self-signed cert and print SHA-256 hash")
 		initialMTU  = flag.Int("initial-mtu", 1200, "Initial QUIC packet size in bytes (1200-1452); lower for VPN/tunnel paths")
+		logPath     = flag.String("log", "", "Log to file instead of stderr")
 	)
 	flag.Parse()
 
@@ -43,6 +44,14 @@ func main() {
 		log.Fatalf("--initial-mtu must be between 1200 and 1452")
 	}
 	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
+	if *logPath != "" {
+		f, err := os.OpenFile(*logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		if err != nil {
+			log.Fatalf("open log file: %v", err)
+		}
+		defer f.Close()
+		log.SetOutput(f)
+	}
 
 	udpAddr, err := net.ResolveUDPAddr("udp", *listenUDP)
 	if err != nil {

--- a/tools/wt_bridge/session.go
+++ b/tools/wt_bridge/session.go
@@ -68,7 +68,7 @@ func runSession(ctx context.Context, sess *webtransport.Session, fan *fanout) {
 			// reader, so no atomic dance is needed.  (Cross-session totals
 			// live on `fanout.stats` which uses atomics.)
 			forwarded++
-			if forwarded == 1 || forwarded%1000 == 0 {
+			if forwarded == 1 || forwarded%100000 == 0 {
 				log.Printf("session %d forwarded=%d", id, forwarded)
 			}
 		}


### PR DESCRIPTION
## Summary

- Add `--log <path>` flag to write operational logs to a file instead of
  stderr.  The dev cert SHA-256 hash still prints to stderr so it remains
  visible when starting the bridge interactively.
- Reduce per-session forwarded-count logging from every 1,000 packets
  (~3 s at 30 fps) to every 100,000 (~5 min).

## Test plan

- [ ] `go build` passes
- [ ] `--log /tmp/test.log` writes logs to file, cert hash still on terminal
- [ ] Without `--log`, behavior unchanged (logs to stderr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)