### PR TITLE
perf(wt_bridge): reduce hot-path allocations and syscalls

### DIFF
--- a/tools/wt_bridge/fanout.go
+++ b/tools/wt_bridge/fanout.go
@@ -60,10 +60,8 @@ func (f *fanout) subscriberCount() int {
 
 func (f *fanout) broadcast(pkt []byte) {
 	f.mu.Lock()
-	subs := make([]*subscriber, len(f.subscribers))
-	copy(subs, f.subscribers)
-	f.mu.Unlock()
-	for _, s := range subs {
+	defer f.mu.Unlock()
+	for _, s := range f.subscribers {
 		select {
 		case s.ch <- pkt:
 		default:

--- a/tools/wt_bridge/session.go
+++ b/tools/wt_bridge/session.go
@@ -34,7 +34,7 @@ func runSession(ctx context.Context, sess *webtransport.Session, fan *fanout) {
 	defer fan.unsubscribe(sub)
 
 	var forwarded uint64
-	hdr := make([]byte, 2)
+	buf := make([]byte, 2+65536)
 
 	for {
 		select {
@@ -51,24 +51,16 @@ func runSession(ctx context.Context, sess *webtransport.Session, fan *fanout) {
 				log.Printf("session %d: oversized packet %d, dropping", id, len(pkt))
 				continue
 			}
-			binary.BigEndian.PutUint16(hdr, uint16(len(pkt)))
-			if _, err := stream.Write(hdr); err != nil {
+			binary.BigEndian.PutUint16(buf, uint16(len(pkt)))
+			copy(buf[2:], pkt)
+			if _, err := stream.Write(buf[:2+len(pkt)]); err != nil {
 				if !isClosedErr(err) {
-					log.Printf("session %d: write hdr: %v", id, err)
+					log.Printf("session %d: write: %v", id, err)
 				}
 				return
 			}
-			if _, err := stream.Write(pkt); err != nil {
-				if !isClosedErr(err) {
-					log.Printf("session %d: write body: %v", id, err)
-				}
-				return
-			}
-			// Local-only counter — this goroutine is the sole writer and
-			// reader, so no atomic dance is needed.  (Cross-session totals
-			// live on `fanout.stats` which uses atomics.)
 			forwarded++
-			if forwarded == 1 || forwarded%100000 == 0 {
+			if forwarded == 1 || forwarded%150000 == 0 {
 				log.Printf("session %d forwarded=%d", id, forwarded)
 			}
 		}


### PR DESCRIPTION
## Summary

- **broadcast()**: hold mutex during iteration instead of allocating a
  subscriber-slice copy per packet.  All channel ops are non-blocking
  (`select` with `default`), so lock duration is bounded.  Eliminates
  ~10k slice allocs/sec at typical RTP rates.
- **runSession()**: merge the 2-byte length header and body into a
  single `stream.Write` via a reusable buffer.  Halves write-syscall
  count per subscriber per packet.
- Bump forwarded-count log interval to 150,000 packets (~15 s).

## Test plan

- [ ] `go build` passes
- [ ] Split-mode and LAN-mode streaming still works
- [ ] Verify reduced CPU usage on the bridge host under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)