### PR TITLE
perf(encoder): two-pass cleanup encoder with AVX-512 gather

### DIFF
--- a/source/core/coding/CMakeLists.txt
+++ b/source/core/coding/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(open_htj2k
     ht_block_encoding.cpp
     ht_block_encoding_neon.cpp
     ht_block_encoding_avx2.cpp
+    ht_block_encoding_avx512.cpp
     ht_block_encoding_wasm.cpp
     block_decoding.cpp
     block_dequant.cpp

--- a/source/core/coding/coding_units.cpp
+++ b/source/core/coding/coding_units.cpp
@@ -6336,12 +6336,9 @@ uint8_t *j2k_tile::encode() {
           }
         }
 
-        // Bulk zero of the used pool region for this precinct.
-        // Reuses already-faulted pages after the first precinct, avoiding repeated mmap faults.
-        memset(gbuf, 0, static_cast<size_t>(pbuf - gbuf) * sizeof(int32_t));
+        // Zero block_states (border must be pre-zeroed); sample_buf is written by quantize.
         memset(sgbuf, 0, static_cast<size_t>(spbuf - sgbuf));
 
-        // Pass 2: encode all codeblocks (buffers are zeroed above).
         enc_remaining.store(0, std::memory_order_relaxed);
         uint32_t task_idx = 0;
         for (uint8_t b = 0; b < cr->num_bands; ++b) {
@@ -6354,7 +6351,6 @@ uint8_t *j2k_tile::encode() {
               *ea      = {epc, block, ROIshift, &enc_remaining};
               enc_remaining.fetch_add(1, std::memory_order_relaxed);
               pool->push([ea]() {
-                // Claim a per-thread pool slot once per tile encode (generation-guarded).
                 TlPoolSlot &ts = g_tl_pool_slot;
                 if (ts.gen != ea->epc->gen) {
                   const int slot = ea->epc->slot_cnt.fetch_add(1, std::memory_order_relaxed);
@@ -6379,8 +6375,6 @@ uint8_t *j2k_tile::encode() {
     };
 #else
     auto t1_encode = [epc](j2k_resolution *cr, uint8_t ROIshift) {
-      // Pre-scan: find the largest codeblock count across all precincts at this resolution.
-      // Allocate once and reuse to avoid per-precinct mmap/munmap page-fault cycles on Linux.
       uint32_t max_total_cblks = 0;
       for (uint32_t p = 0; p < cr->npw * cr->nph; ++p) {
         j2k_precinct *cp     = cr->access_precinct(p);
@@ -6392,7 +6386,6 @@ uint8_t *j2k_tile::encode() {
         max_total_cblks = std::max(max_total_cblks, total_cblks);
       }
       if (max_total_cblks == 0) return;
-      // Use the tile-level grow-only scratch buffers to avoid per-resolution malloc/free.
       epc->reserve_scratch(static_cast<size_t>(max_total_cblks) * 4096,
                            static_cast<size_t>(max_total_cblks) * 6156);
       int32_t *gbuf  = epc->gbuf;
@@ -6403,7 +6396,6 @@ uint8_t *j2k_tile::encode() {
         int32_t *pbuf    = gbuf;
         uint8_t *spbuf   = sgbuf;
 
-        // Pass 1: assign buffer pointers to all codeblocks in this precinct.
         for (uint8_t b = 0; b < cr->num_bands; b++) {
           j2k_precinct_subband *cpb = cp->access_pband(b);
           const uint32_t num_cblks  = cpb->num_codeblock_x * cpb->num_codeblock_y;
@@ -6418,12 +6410,8 @@ uint8_t *j2k_tile::encode() {
           }
         }
 
-        // Bulk zero of the used pool region for this precinct.
-        // Reuses already-faulted pages after the first precinct, avoiding repeated mmap faults.
-        memset(gbuf, 0, static_cast<size_t>(pbuf - gbuf) * sizeof(int32_t));
         memset(sgbuf, 0, static_cast<size_t>(spbuf - sgbuf));
 
-        // Pass 2: encode all codeblocks (buffers are zeroed above).
         g_cblk_pool = epc->pools[0].get();
         for (uint8_t b = 0; b < cr->num_bands; ++b) {
           j2k_precinct_subband *cpb = cp->access_pband(b);
@@ -6602,7 +6590,6 @@ uint8_t *j2k_tile::encode_line_based() {
           spbuf += (QWx2 + 2) * (QHx2 + 2);
         }
       }
-      memset(gbuf, 0, static_cast<size_t>(pbuf - gbuf) * sizeof(int32_t));
       memset(sgbuf, 0, static_cast<size_t>(spbuf - sgbuf));
       enc_remaining.store(0, std::memory_order_relaxed);
       uint32_t task_idx = 0;
@@ -6672,7 +6659,6 @@ uint8_t *j2k_tile::encode_line_based() {
           spbuf += (QWx2 + 2) * (QHx2 + 2);
         }
       }
-      memset(gbuf, 0, static_cast<size_t>(pbuf - gbuf) * sizeof(int32_t));
       memset(sgbuf, 0, static_cast<size_t>(spbuf - sgbuf));
       g_cblk_pool = epc->pools[0].get();
       for (uint8_t b = 0; b < cr->num_bands; ++b) {
@@ -6871,7 +6857,6 @@ uint8_t *j2k_tile::encode_line_based_stream(
           spbuf += (QWx2 + 2) * (QHx2 + 2);
         }
       }
-      memset(gbuf, 0, static_cast<size_t>(pbuf - gbuf) * sizeof(int32_t));
       memset(sgbuf, 0, static_cast<size_t>(spbuf - sgbuf));
       enc_remaining.store(0, std::memory_order_relaxed);
       uint32_t task_idx = 0;
@@ -6941,7 +6926,6 @@ uint8_t *j2k_tile::encode_line_based_stream(
           spbuf += (QWx2 + 2) * (QHx2 + 2);
         }
       }
-      memset(gbuf, 0, static_cast<size_t>(pbuf - gbuf) * sizeof(int32_t));
       memset(sgbuf, 0, static_cast<size_t>(spbuf - sgbuf));
       g_cblk_pool = epc->pools[0].get();
       for (uint8_t b = 0; b < cr->num_bands; ++b) {
@@ -7141,7 +7125,6 @@ uint8_t *j2k_tile::encode_line_based_stream(
 
     int32_t *gbuf  = static_cast<int32_t *>(malloc(total_cbuf * sizeof(int32_t)));
     uint8_t *sgbuf = static_cast<uint8_t *>(malloc(total_sbuf));
-    memset(gbuf, 0, total_cbuf * sizeof(int32_t));
     memset(sgbuf, 0, total_sbuf);
 
     // Assign sample_buf/block_states pointers and set up per-level overlap state.

--- a/source/core/coding/ht_block_encoding.cpp
+++ b/source/core/coding/ht_block_encoding.cpp
@@ -43,15 +43,17 @@
 
 // Quantize DWT coefficients and transfer them to codeblock buffer in a form of MagSgn value
 void j2k_codeblock::quantize(uint32_t &or_val) {
-  // TODO: check the way to quantize in terms of precision and reconstruction quality
-  float fscale = 1.0f / this->stepsize;
-  fscale /= (1 << (FRACBITS));
-  // Set fscale = 1.0 in lossless coding instead of skipping quantization
-  // to avoid if-branch in the following SIMD processing
-  if (transformation) fscale = 1.0f;
-
   const uint32_t height = this->size.y;
+  const uint32_t width  = this->size.x;
   const uint32_t stride = this->band_stride;
+  const bool lossless   = (this->transformation != 0);
+
+  float fscale = 1.0f;
+  if (!lossless) {
+    fscale = 1.0f / this->stepsize;
+    fscale /= (1 << (FRACBITS));
+  }
+
   #if defined(ENABLE_SP_MR)
   const int32_t pshift = (refsegment) ? 1 : 0;
   const int32_t pLSB   = (refsegment) ? 2 : 1;
@@ -62,10 +64,13 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
     size_t block_index = (i + 1U) * (blkstate_stride) + 1U;
     uint8_t *dstblk    = block_states + block_index;
 
-    int16_t len = static_cast<int16_t>(this->size.x);
+    int16_t len = static_cast<int16_t>(width);
     for (; len > 0; --len) {
       int32_t temp;
-      temp = static_cast<int32_t>(static_cast<float>(sp[0]) * fscale);  // needs to be rounded towards zero
+      if (lossless)
+        temp = static_cast<int32_t>(sp[0]);
+      else
+        temp = static_cast<int32_t>(static_cast<float>(sp[0]) * fscale);
       uint32_t sign = static_cast<uint32_t>(temp) & 0x80000000;
   #if defined(ENABLE_SP_MR)
       dstblk[0] |= static_cast<uint8_t>(((temp & pLSB) & 1) << SHIFT_SMAG);
@@ -82,13 +87,18 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
         temp--;
         temp <<= 1;
         temp += static_cast<uint8_t>(sign >> 31);
-        dp[0] = temp;
       }
+      dp[0] = temp;
       ++sp;
       ++dp;
       ++dstblk;
     }
+    if (blksampl_stride > width)
+      memset(dp, 0, (blksampl_stride - width) * sizeof(int32_t));
   }
+  const uint32_t QHx2 = (height + 7U) & ~7U;
+  for (uint32_t i = height; i < QHx2; ++i)
+    memset(this->sample_buf + i * blksampl_stride, 0, blksampl_stride * sizeof(int32_t));
 }
 
   /********************************************************************************

--- a/source/core/coding/ht_block_encoding_avx2.cpp
+++ b/source/core/coding/ht_block_encoding_avx2.cpp
@@ -43,23 +43,23 @@
 
 // Quantize DWT coefficients and transfer them to codeblock buffer in a form of MagSgn value
 void j2k_codeblock::quantize(uint32_t &or_val) {
-  // TODO: check the way to quantize in terms of precision and reconstruction quality
-  float fscale = 1.0f / this->stepsize;
-  fscale /= (1 << (FRACBITS));
-  // Set fscale = 1.0 in lossless coding instead of skipping quantization
-  // to avoid if-branch in the following SIMD processing
-  if (transformation) fscale = 1.0f;
+  const uint32_t height  = this->size.y;
+  const uint32_t width   = this->size.x;
+  const uint32_t stride  = this->band_stride;
+  const bool lossless    = (this->transformation != 0);
 
-  const uint32_t height = this->size.y;
-  const uint32_t stride = this->band_stride;
+  float fscale = 1.0f;
+  if (!lossless) {
+    fscale = 1.0f / this->stepsize;
+    fscale /= (1 << (FRACBITS));
+  }
+
   #if defined(ENABLE_SP_MR)
   const int32_t pshift = (refsegment) ? 1 : 0;
   const int32_t pLSB   = (refsegment) ? 1 : 1;
   #endif
-  // Hoist loop-invariant constants out of the row loop
   const __m256i vone  = _mm256_set1_epi32(1);
   const __m256 vscale = _mm256_set1_ps(fscale);
-  // Vector accumulator for or_val; scalar update only in leftover path
   __m256i vor_val = _mm256_setzero_si256();
   for (uint16_t i = 0; i < static_cast<uint16_t>(height); ++i) {
     sprec_t *sp        = this->i_samples + i * stride;
@@ -69,14 +69,16 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
   #if defined(ENABLE_SP_MR)
     const __m256i vpLSB = _mm256_set1_epi32(pLSB);
   #endif
-    // simd
-    int32_t len = static_cast<int32_t>(this->size.x);
+    int32_t len = static_cast<int32_t>(width);
     for (; len >= 16; len -= 16) {
-      __m256 val0 = _mm256_loadu_ps(sp);
-      __m256 val1 = _mm256_loadu_ps(sp + 8);
-      // Quantization with cvt't'ps (truncates inexact values by rounding towards zero)
-      auto v0 = _mm256_cvttps_epi32(_mm256_mul_ps(val0, vscale));
-      auto v1 = _mm256_cvttps_epi32(_mm256_mul_ps(val1, vscale));
+      __m256i v0, v1;
+      if (lossless) {
+        v0 = _mm256_cvttps_epi32(_mm256_loadu_ps(sp));
+        v1 = _mm256_cvttps_epi32(_mm256_loadu_ps(sp + 8));
+      } else {
+        v0 = _mm256_cvttps_epi32(_mm256_mul_ps(_mm256_loadu_ps(sp), vscale));
+        v1 = _mm256_cvttps_epi32(_mm256_mul_ps(_mm256_loadu_ps(sp + 8), vscale));
+      }
       // Take sign bit
       __m256i s0 = _mm256_srli_epi32(v0, 31);
       __m256i s1 = _mm256_srli_epi32(v1, 31);
@@ -129,10 +131,12 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
       _mm_storeu_si128((__m128i *)dstblk, v);
       dstblk += 16;
     }
-    // process leftover (writes dp[0] unconditionally so calloc pre-zero is sufficient)
     for (; len > 0; --len) {
       int32_t temp;
-      temp = static_cast<int32_t>(static_cast<float>(sp[0]) * fscale);  // needs to be rounded towards zero
+      if (lossless)
+        temp = static_cast<int32_t>(sp[0]);
+      else
+        temp = static_cast<int32_t>(static_cast<float>(sp[0]) * fscale);
       uint32_t sign = static_cast<uint32_t>(temp) & 0x80000000;
   #if defined(ENABLE_SP_MR)
       dstblk[0] |= static_cast<uint8_t>(((temp & pLSB) & 1) << SHIFT_SMAG);
@@ -150,13 +154,17 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
         temp <<= 1;
         temp += static_cast<uint8_t>(sign >> 31);
       }
-      dp[0] = temp;  // write 0 for zero samples; makes pre-zero memset unnecessary
+      dp[0] = temp;
       ++sp;
       ++dp;
       ++dstblk;
     }
+    if (blksampl_stride > width)
+      memset(dp, 0, (blksampl_stride - width) * sizeof(int32_t));
   }
-  // Reduce vector or_val accumulator once, after all rows
+  const uint32_t QHx2 = (height + 7U) & ~7U;
+  for (uint32_t i = height; i < QHx2; ++i)
+    memset(this->sample_buf + i * blksampl_stride, 0, blksampl_stride * sizeof(int32_t));
   if (!_mm256_testz_si256(vor_val, vor_val)) {
     or_val |= 1;
   }

--- a/source/core/coding/ht_block_encoding_avx2.cpp
+++ b/source/core/coding/ht_block_encoding_avx2.cpp
@@ -328,6 +328,12 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
 
   int32_t rho0, rho1, U0, U1;
 
+  // Deferred MagSgn: store v/m/known1 per quad, emit in a tight loop after all
+  // context/VLC/MEL work for the line pair is done.  This keeps the MagSgn
+  // accumulator hot in icache and improves branch-predictor utilization.
+  alignas(32) __m128i ms_v[512], ms_m[512], ms_k1[512];
+  int32_t ms_count;
+
   /*******************************************************************************************************************/
   // Initial line-pair
   /*******************************************************************************************************************/
@@ -356,6 +362,7 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
   __m128i sig0, sig1, v0, v1, E0, E1, m0, m1, known1_0, known1_1;
   __m128i Etmp, vuoff, mask, vtmp;
 
+  ms_count  = 0;
   int32_t qx = QW;
   for (; qx >= 2; qx -= 2) {
     bool uoff_flag = true;
@@ -435,15 +442,15 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
       }
     }
 
-    // MagSgn encoding
+    // Defer MagSgn encoding
     m0       = _mm_sub_epi32(_mm_and_si128(sig0, _mm_set1_epi32(U0)),
                              _mm_and_si128(_mm_srlv_epi32(_mm_set1_epi32(embk_0), vshift), vone));
     m1       = _mm_sub_epi32(_mm_and_si128(sig1, _mm_set1_epi32(U1)),
                              _mm_and_si128(_mm_srlv_epi32(_mm_set1_epi32(embk_1), vshift), vone));
     known1_0 = _mm_and_si128(_mm_srlv_epi32(_mm_set1_epi32(emb1_0), vshift), vone);
     known1_1 = _mm_and_si128(_mm_srlv_epi32(_mm_set1_epi32(emb1_1), vshift), vone);
-    MagSgn_encoder.emitBits(v0, m0, known1_0);
-    MagSgn_encoder.emitBits(v1, m1, known1_1);
+    ms_v[ms_count] = v0; ms_m[ms_count] = m0; ms_k1[ms_count] = known1_0; ms_count++;
+    ms_v[ms_count] = v1; ms_m[ms_count] = m1; ms_k1[ms_count] = known1_1; ms_count++;
 
     // context for the next quad
     context = (rho1 >> 1) | (rho1 & 0x1);
@@ -491,23 +498,26 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
       VLC_encoder.emitVLCBits(cwd | (static_cast<uint64_t>(uvlc_cwd) << lw), lw + uvlc_lw);
     }
 
-    // MagSgn encoding
     m0       = _mm_sub_epi32(_mm_and_si128(sig0, _mm_set1_epi32(U0)),
                              _mm_and_si128(_mm_srlv_epi32(_mm_set1_epi32(embk_0), vshift), vone));
     known1_0 = _mm_and_si128(_mm_srlv_epi32(_mm_set1_epi32(emb1_0), vshift), vone);
-    MagSgn_encoder.emitBits(v0, m0, known1_0);
+    ms_v[ms_count] = v0; ms_m[ms_count] = m0; ms_k1[ms_count] = known1_0; ms_count++;
 
     *E_p++ = _mm_extract_epi32(E0, 1);
     *E_p++ = _mm_extract_epi32(E0, 3);
     // update rho_line
     *rho_p++ = rho0;
   }
+  // Emit deferred MagSgn for initial line-pair
+  for (int32_t i = 0; i < ms_count; i++)
+    MagSgn_encoder.emitBits(ms_v[i], ms_m[i], ms_k1[i]);
 
   /*******************************************************************************************************************/
   // Non-initial line-pair
   /*******************************************************************************************************************/
   int32_t Emax0, Emax1;
   for (uint16_t qy = 1; qy < QH; qy++) {
+    ms_count = 0;
     E_p   = Eline + 1;
     rho_p = rholine + 1;
     rho1  = 0;
@@ -590,15 +600,15 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
         VLC_encoder.emitVLCBits(vlc_all, lw0 + lw + uvlc_lw);
       }
 
-      // MagSgn encoding
+      // Defer MagSgn encoding
       m0       = _mm_sub_epi32(_mm_and_si128(sig0, _mm_set1_epi32(U0)),
                                _mm_and_si128(_mm_srlv_epi32(_mm_set1_epi32(embk_0), vshift), vone));
       m1       = _mm_sub_epi32(_mm_and_si128(sig1, _mm_set1_epi32(U1)),
                                _mm_and_si128(_mm_srlv_epi32(_mm_set1_epi32(embk_1), vshift), vone));
       known1_0 = _mm_and_si128(_mm_srlv_epi32(_mm_set1_epi32(emb1_0), vshift), vone);
       known1_1 = _mm_and_si128(_mm_srlv_epi32(_mm_set1_epi32(emb1_1), vshift), vone);
-      MagSgn_encoder.emitBits(v0, m0, known1_0);
-      MagSgn_encoder.emitBits(v1, m1, known1_1);
+      ms_v[ms_count] = v0; ms_m[ms_count] = m0; ms_k1[ms_count] = known1_0; ms_count++;
+      ms_v[ms_count] = v1; ms_m[ms_count] = m1; ms_k1[ms_count] = known1_1; ms_count++;
 
       Emax0 = find_max(E_p[3], E_p[4], E_p[5], E_p[6]);
       Emax1 = find_max(E_p[5], E_p[6], E_p[7], E_p[8]);
@@ -657,17 +667,19 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
         VLC_encoder.emitVLCBits(cwd | (static_cast<uint64_t>(uvlc_cwd) << lw), lw + uvlc_lw);
       }
 
-      // MagSgn encoding
       m0       = _mm_sub_epi32(_mm_and_si128(sig0, _mm_set1_epi32(U0)),
                                _mm_and_si128(_mm_srlv_epi32(_mm_set1_epi32(embk_0), vshift), vone));
       known1_0 = _mm_and_si128(_mm_srlv_epi32(_mm_set1_epi32(emb1_0), vshift), vone);
-      MagSgn_encoder.emitBits(v0, m0, known1_0);
+      ms_v[ms_count] = v0; ms_m[ms_count] = m0; ms_k1[ms_count] = known1_0; ms_count++;
 
       *E_p++ = _mm_extract_epi32(E0, 1);
       *E_p++ = _mm_extract_epi32(E0, 3);
       // update rho_line
       *rho_p++ = rho0;
     }
+    // Emit deferred MagSgn for this line pair
+    for (int32_t i = 0; i < ms_count; i++)
+      MagSgn_encoder.emitBits(ms_v[i], ms_m[i], ms_k1[i]);
   }
 
   Pcup = MagSgn_encoder.termMS();

--- a/source/core/coding/ht_block_encoding_avx2.cpp
+++ b/source/core/coding/ht_block_encoding_avx2.cpp
@@ -383,8 +383,8 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
     CxtVLC = enc_CxtVLC_table0[n_q];
     embk_0 = CxtVLC & 0xF;
     emb1_0 = emb_pattern & embk_0;
-    lw     = (CxtVLC >> 4) & 0x07;
-    cwd    = CxtVLC >> 7;
+    uint32_t lw0 = (CxtVLC >> 4) & 0x07;
+    uint32_t cwd0 = CxtVLC >> 7;
 
     // context for the next quad
     context = (rho0 >> 1) | (rho0 & 0x1);
@@ -403,19 +403,18 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
     emb_pattern = _mm_movemask_epi8(
         _mm_packus_epi16(_mm_packus_epi32(vtmp, _mm_setzero_si128()), _mm_setzero_si128()));
     n_q = emb_pattern + (rho1 << 4) + (context << 8);
-    // VLC encoding of quads 0 and 1
-    VLC_encoder.emitVLCBits(cwd, lw);
     CxtVLC = enc_CxtVLC_table0[n_q];
     embk_1 = CxtVLC & 0xF;
     emb1_1 = emb_pattern & embk_1;
     lw     = (CxtVLC >> 4) & 0x07;
     cwd    = CxtVLC >> 7;
-    VLC_encoder.emitVLCBits(cwd, lw);
-    // UVLC encoding
-    uint32_t tmp = enc_UVLC_table0[uvlc_idx];
-    lw           = tmp & 0xFF;
-    cwd          = tmp >> 8;
-    VLC_encoder.emitVLCBits(cwd, lw);
+    // Batched VLC + UVLC encoding
+    uint32_t uvlc_tmp = enc_UVLC_table0[uvlc_idx];
+    uint32_t uvlc_lw  = uvlc_tmp & 0xFF;
+    uint32_t uvlc_cwd = uvlc_tmp >> 8;
+    uint64_t vlc_all  = cwd0 | (static_cast<uint64_t>(cwd) << lw0)
+                        | (static_cast<uint64_t>(uvlc_cwd) << (lw0 + lw));
+    VLC_encoder.emitVLCBits(vlc_all, lw0 + lw + uvlc_lw);
 
     // MEL encoding of the second quad
     if (context == 0) {
@@ -480,18 +479,17 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
     emb_pattern = _mm_movemask_epi8(
         _mm_packus_epi16(_mm_packus_epi32(vtmp, _mm_setzero_si128()), _mm_setzero_si128()));
     n_q = emb_pattern + (rho0 << 4) + (context << 8);
-    // VLC encoding
     CxtVLC = enc_CxtVLC_table0[n_q];
     embk_0 = CxtVLC & 0xF;
     emb1_0 = emb_pattern & embk_0;
     lw     = (CxtVLC >> 4) & 0x07;
     cwd    = CxtVLC >> 7;
-    VLC_encoder.emitVLCBits(cwd, lw);
-    // UVLC encoding
-    uint32_t tmp = enc_UVLC_table0[uvlc_idx];
-    lw           = tmp & 0xFF;
-    cwd          = tmp >> 8;
-    VLC_encoder.emitVLCBits(cwd, lw);
+    {
+      uint32_t uvlc_tmp = enc_UVLC_table0[uvlc_idx];
+      uint32_t uvlc_lw  = uvlc_tmp & 0xFF;
+      uint32_t uvlc_cwd = uvlc_tmp >> 8;
+      VLC_encoder.emitVLCBits(cwd | (static_cast<uint64_t>(uvlc_cwd) << lw), lw + uvlc_lw);
+    }
 
     // MagSgn encoding
     m0       = _mm_sub_epi32(_mm_and_si128(sig0, _mm_set1_epi32(U0)),
@@ -549,13 +547,11 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
       emb_pattern = _mm_movemask_epi8(
           _mm_packus_epi16(_mm_packus_epi32(vtmp, _mm_setzero_si128()), _mm_setzero_si128()));
       n_q = emb_pattern + (rho0 << 4) + (context << 0);
-      // prepare VLC encoding of quad 0
       CxtVLC = enc_CxtVLC_table1[n_q];
       embk_0 = CxtVLC & 0xF;
       emb1_0 = emb_pattern & embk_0;
-      lw     = (CxtVLC >> 4) & 0x07;
-      // lw  = _pext_u32(CxtVLC, 0x70);
-      cwd = CxtVLC >> 7;
+      uint32_t lw0 = (CxtVLC >> 4) & 0x07;
+      uint32_t cwd0 = CxtVLC >> 7;
 
       // calculate context for the next quad
       context = ((rho0 & 0x4) << 7) | ((rho0 & 0x8) << 6);           // (w | sw) << 9
@@ -579,20 +575,20 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
       emb_pattern = _mm_movemask_epi8(
           _mm_packus_epi16(_mm_packus_epi32(vtmp, _mm_setzero_si128()), _mm_setzero_si128()));
       n_q = emb_pattern + (rho1 << 4) + (context << 0);
-      // VLC encoding of quads 0 and 1
-      VLC_encoder.emitVLCBits(cwd, lw);
       CxtVLC = enc_CxtVLC_table1[n_q];
       embk_1 = CxtVLC & 0xF;
       emb1_1 = emb_pattern & embk_1;
       lw     = (CxtVLC >> 4) & 0x07;
-      // lw  = _pext_u32(CxtVLC, 0x70);
-      cwd = CxtVLC >> 7;
-      VLC_encoder.emitVLCBits(cwd, lw);
-      // UVLC encoding
-      uint32_t tmp = enc_UVLC_table1[uvlc_idx];
-      lw           = tmp & 0xFF;
-      cwd          = tmp >> 8;
-      VLC_encoder.emitVLCBits(cwd, lw);
+      cwd    = CxtVLC >> 7;
+      // Batched VLC + UVLC encoding
+      {
+        uint32_t uvlc_tmp = enc_UVLC_table1[uvlc_idx];
+        uint32_t uvlc_lw  = uvlc_tmp & 0xFF;
+        uint32_t uvlc_cwd = uvlc_tmp >> 8;
+        uint64_t vlc_all  = cwd0 | (static_cast<uint64_t>(cwd) << lw0)
+                            | (static_cast<uint64_t>(uvlc_cwd) << (lw0 + lw));
+        VLC_encoder.emitVLCBits(vlc_all, lw0 + lw + uvlc_lw);
+      }
 
       // MagSgn encoding
       m0       = _mm_sub_epi32(_mm_and_si128(sig0, _mm_set1_epi32(U0)),
@@ -649,18 +645,17 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
       emb_pattern = _mm_movemask_epi8(
           _mm_packus_epi16(_mm_packus_epi32(vtmp, _mm_setzero_si128()), _mm_setzero_si128()));
       n_q = emb_pattern + (rho0 << 4) + (context << 0);
-      // VLC encoding
       CxtVLC = enc_CxtVLC_table1[n_q];
       embk_0 = CxtVLC & 0xF;
       emb1_0 = emb_pattern & embk_0;
       lw     = (CxtVLC >> 4) & 0x07;
       cwd    = CxtVLC >> 7;
-      VLC_encoder.emitVLCBits(cwd, lw);
-      // UVLC encoding
-      uint32_t tmp = enc_UVLC_table1[uvlc_idx];
-      lw           = tmp & 0xFF;
-      cwd          = tmp >> 8;
-      VLC_encoder.emitVLCBits(cwd, lw);
+      {
+        uint32_t uvlc_tmp = enc_UVLC_table1[uvlc_idx];
+        uint32_t uvlc_lw  = uvlc_tmp & 0xFF;
+        uint32_t uvlc_cwd = uvlc_tmp >> 8;
+        VLC_encoder.emitVLCBits(cwd | (static_cast<uint64_t>(uvlc_cwd) << lw), lw + uvlc_lw);
+      }
 
       // MagSgn encoding
       m0       = _mm_sub_epi32(_mm_and_si128(sig0, _mm_set1_epi32(U0)),

--- a/source/core/coding/ht_block_encoding_avx2.hpp
+++ b/source/core/coding/ht_block_encoding_avx2.hpp
@@ -187,9 +187,6 @@ class state_MS_enc {
         emit_dword();
       }
     }
-    // while (ctreg >= 64) {
-    //   emit_qword();
-    // }
 #endif
   }
 
@@ -250,8 +247,8 @@ class state_VLC_enc {
     buf[pos + 1] = 0xFF;
   }
 
-  FORCE_INLINE void emitVLCBits(uint32_t cwd, uint32_t len) {
-    Creg |= static_cast<uint64_t>(cwd) << ctreg;
+  FORCE_INLINE void emitVLCBits(uint64_t cwd, uint32_t len) {
+    Creg |= cwd << ctreg;
     ctreg += len;
     while (ctreg >= 32) {
       emit_dword();

--- a/source/core/coding/ht_block_encoding_avx512.cpp
+++ b/source/core/coding/ht_block_encoding_avx512.cpp
@@ -566,41 +566,113 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
     }
 
     // ===== PHASE 2b: Read ALL Emax from old Eline before any updates =====
-    alignas(32) int32_t Emax_a[512];
+    // Emax(q) = max(E_p[2q-1], E_p[2q], E_p[2q+1], E_p[2q+2])
+    alignas(64) int32_t Emax_a[512];
     for (int32_t q = 0; q < QW; q++)
       Emax_a[q] = find_max(E_p[2 * q - 1], E_p[2 * q], E_p[2 * q + 1], E_p[2 * q + 2]);
 
+    // ===== PHASE 2c: Compute kappa, U, emb_pattern, VLC (AVX-512 gather); update Eline + rholine =====
+    {
+      const __m512i VONE = _mm512_set1_epi32(1);
+      const __m512i VZERO = _mm512_setzero_si512();
+      int32_t q = 0;
+      for (; q + 15 < QW; q += 16) {
+        __m512i rho_v = _mm512_loadu_si512(rho_a + q);
+        __m512i emax_line_v = _mm512_loadu_si512(Emax_a + q);
 
-    // ===== PHASE 2c: Compute kappa, U, VLC; update Eline + rholine =====
-    for (int32_t q = 0; q < QW; q++) {
-      int32_t rq = rho_a[q];
-      int32_t gamma_q = ((rq & (rq - 1)) == 0) ? 0 : static_cast<int32_t>(0xFFFFFFFF);
-      int32_t kappa_q = std::max((Emax_a[q] - 1) & gamma_q, 1);
-      int32_t Emax_q = hMax(E_a[q]);
-      int32_t Uq = std::max(Emax_q, kappa_q);
-      int32_t uq = Uq - kappa_q;
-      U_a[q] = Uq;
-      u_q_a[q] = uq;
+        // gamma = (popcount(rho) > 1) ? -1 : 0
+        __m512i rho_m1 = _mm512_sub_epi32(rho_v, VONE);
+        __m512i gamma_v = _mm512_and_epi32(rho_v, rho_m1);
+        __mmask16 gamma_mask = _mm512_cmpneq_epi32_mask(gamma_v, VZERO);
+        gamma_v = _mm512_maskz_set1_epi32(gamma_mask, -1);
 
-      int32_t uoff_q = (uq > 0) ? 1 : 0;
-      __m128i Etmp_q = _mm_set1_epi32(Emax_q);
-      __m128i vuoff_q = _mm_set1_epi32(uoff_q << 7);
-      __m128i mask_q = _mm_cmpeq_epi32(E_a[q], Etmp_q);
-      __m128i vtmp_q = _mm_and_si128(vuoff_q, mask_q);
-      int32_t emb_p = _mm_movemask_epi8(
-          _mm_packus_epi16(_mm_packus_epi32(vtmp_q, _mm_setzero_si128()), _mm_setzero_si128()));
-      int32_t nq = emb_p + (rq << 4) + (ctx_a[q] << 0);
-      uint32_t cv = enc_CxtVLC_table1[nq];
-      embk_a[q] = cv & 0xF;
-      emb1_a[q] = emb_p & embk_a[q];
-      vlc_cwd_a[q] = cv >> 7;
-      vlc_lw_a[q] = (cv >> 4) & 0x07;
+        // kappa = max((Emax_line - 1) & gamma, 1)
+        __m512i kappa_v = _mm512_and_epi32(_mm512_sub_epi32(emax_line_v, VONE), gamma_v);
+        kappa_v = _mm512_max_epi32(kappa_v, VONE);
 
-      __m128i Es = _mm_shuffle_epi32(E_a[q], 0xD8);
-      E_p[2 * q]     = _mm_extract_epi32(Es, 2);
-      E_p[2 * q + 1] = _mm_extract_epi32(Es, 3);
+        // Emax_q = hMax(E_a[q]) for each quad — horizontal max of 4 elements
+        // E_a[q] is __m128i; extract and compute per-quad (scalar for now)
+        alignas(64) int32_t emax_q_arr[16];
+        for (int i = 0; i < 16; i++)
+          emax_q_arr[i] = hMax(E_a[q + i]);
+        __m512i emax_q_v = _mm512_load_si512(emax_q_arr);
 
-      rho_p[q] = rq;
+        // U = max(Emax_q, kappa)
+        __m512i U_v = _mm512_max_epi32(emax_q_v, kappa_v);
+        __m512i u_q_v = _mm512_sub_epi32(U_v, kappa_v);
+        _mm512_storeu_si512(U_a + q, U_v);
+        _mm512_storeu_si512(u_q_a + q, u_q_v);
+
+        // emb_pattern: for each quad, check which E values == Emax_q AND uoff
+        // This is per-quad (4 elements each), done scalar
+        alignas(64) int32_t emb_arr[16], nq_arr[16];
+        for (int i = 0; i < 16; i++) {
+          int32_t uoff_i = (u_q_a[q + i] > 0) ? 1 : 0;
+          __m128i Et = _mm_set1_epi32(emax_q_arr[i]);
+          __m128i vu = _mm_set1_epi32(uoff_i << 7);
+          __m128i mk = _mm_cmpeq_epi32(E_a[q + i], Et);
+          __m128i vt = _mm_and_si128(vu, mk);
+          emb_arr[i] = _mm_movemask_epi8(
+              _mm_packus_epi16(_mm_packus_epi32(vt, _mm_setzero_si128()), _mm_setzero_si128()));
+          nq_arr[i] = emb_arr[i] + (rho_a[q + i] << 4) + ctx_a[q + i];
+        }
+
+        // AVX-512 GATHER: 16 VLC table lookups at once (uint16_t table → scale=2, mask to 16 bits)
+        __m512i nq_v = _mm512_load_si512(nq_arr);
+        __m512i cv_v = _mm512_and_epi32(
+            _mm512_i32gather_epi32(nq_v, enc_CxtVLC_table1, 2),
+            _mm512_set1_epi32(0xFFFF));
+
+        // Extract embk, emb1, vlc_cwd, vlc_lw from gathered CxtVLC values
+        __m512i embk_v = _mm512_and_epi32(cv_v, _mm512_set1_epi32(0xF));
+        _mm512_storeu_si512(embk_a + q, embk_v);
+
+        __m512i emb_v = _mm512_load_si512(emb_arr);
+        _mm512_storeu_si512(emb1_a + q, _mm512_and_epi32(emb_v, embk_v));
+
+        __m512i vlc_cwd_v = _mm512_srli_epi32(cv_v, 7);
+        _mm512_storeu_si512(vlc_cwd_a + q, vlc_cwd_v);
+        __m512i vlc_lw_v = _mm512_and_epi32(_mm512_srli_epi32(cv_v, 4), _mm512_set1_epi32(0x07));
+        _mm512_storeu_si512(vlc_lw_a + q, vlc_lw_v);
+
+        // Update Eline + rholine
+        for (int i = 0; i < 16; i++) {
+          __m128i Es = _mm_shuffle_epi32(E_a[q + i], 0xD8);
+          E_p[2 * (q + i)]     = _mm_extract_epi32(Es, 2);
+          E_p[2 * (q + i) + 1] = _mm_extract_epi32(Es, 3);
+          rho_p[q + i] = rho_a[q + i];
+        }
+      }
+      // Scalar tail for remaining quads
+      for (; q < QW; q++) {
+        int32_t rq = rho_a[q];
+        int32_t gamma_q = ((rq & (rq - 1)) == 0) ? 0 : static_cast<int32_t>(0xFFFFFFFF);
+        int32_t kappa_q = std::max((Emax_a[q] - 1) & gamma_q, 1);
+        int32_t Emax_q = hMax(E_a[q]);
+        int32_t Uq = std::max(Emax_q, kappa_q);
+        int32_t uq = Uq - kappa_q;
+        U_a[q] = Uq;
+        u_q_a[q] = uq;
+
+        int32_t uoff_q = (uq > 0) ? 1 : 0;
+        __m128i Etmp_q = _mm_set1_epi32(Emax_q);
+        __m128i vuoff_q = _mm_set1_epi32(uoff_q << 7);
+        __m128i mask_q = _mm_cmpeq_epi32(E_a[q], Etmp_q);
+        __m128i vtmp_q = _mm_and_si128(vuoff_q, mask_q);
+        int32_t emb_p = _mm_movemask_epi8(
+            _mm_packus_epi16(_mm_packus_epi32(vtmp_q, _mm_setzero_si128()), _mm_setzero_si128()));
+        int32_t nq = emb_p + (rq << 4) + (ctx_a[q] << 0);
+        uint32_t cv = enc_CxtVLC_table1[nq];
+        embk_a[q] = cv & 0xF;
+        emb1_a[q] = emb_p & embk_a[q];
+        vlc_cwd_a[q] = cv >> 7;
+        vlc_lw_a[q] = (cv >> 4) & 0x07;
+
+        __m128i Es = _mm_shuffle_epi32(E_a[q], 0xD8);
+        E_p[2 * q]     = _mm_extract_epi32(Es, 2);
+        E_p[2 * q + 1] = _mm_extract_epi32(Es, 3);
+        rho_p[q] = rq;
+      }
     }
 
 

--- a/source/core/coding/ht_block_encoding_avx512.cpp
+++ b/source/core/coding/ht_block_encoding_avx512.cpp
@@ -26,7 +26,7 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#if defined(OPENHTJ2K_TRY_AVX2) && defined(__AVX2__) && !defined(__AVX512F__)
+#if defined(OPENHTJ2K_TRY_AVX2) && defined(__AVX512F__)
   #include <algorithm>
   #include <cmath>
   #include "coding_units.hpp"
@@ -351,7 +351,6 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
   std::fill_n(rholine, QW + 3U, int32_t{0});
   int32_t *rho_p = rholine + 1;
 
-  int32_t gamma;
   int32_t context = 0, n_q;
   uint32_t CxtVLC, lw, cwd;
   int32_t Emax_q;
@@ -515,169 +514,143 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
   /*******************************************************************************************************************/
   // Non-initial line-pair
   /*******************************************************************************************************************/
-  int32_t Emax0, Emax1;
+  // Pre-computed per-quad arrays for the two-pass architecture.
+  // Sized for max codeblock width (1024 → QW ≤ 512).
+  alignas(32) int32_t  rho_a[512];
+  alignas(32) int32_t  ctx_a[512];
+  alignas(32) int32_t  U_a[512];
+  alignas(32) int32_t  u_q_a[512];
+  alignas(32) int32_t  embk_a[512];
+  alignas(32) int32_t  emb1_a[512];
+  alignas(32) uint32_t vlc_cwd_a[512];
+  alignas(32) uint32_t vlc_lw_a[512];
+  alignas(32) __m128i  v_a[512];
+  alignas(32) __m128i  sig_a[512];
+  alignas(32) __m128i  E_a[512];
+
   for (uint16_t qy = 1; qy < QH; qy++) {
     ms_count = 0;
     E_p   = Eline + 1;
     rho_p = rholine + 1;
-    rho1  = 0;
-
-    Emax0 = find_max(E_p[-1], E_p[0], E_p[1], E_p[2]);
-    Emax1 = find_max(E_p[1], E_p[2], E_p[3], E_p[4]);
-
-    // calculate context for the next quad
-    context = ((rho1 & 0x4) << 7) | ((rho1 & 0x8) << 6);            // (w | sw) << 9
-    context |= ((rho_p[-1] & 0x8) << 5) | ((rho_p[0] & 0xa) << 7);  // ((nw | n) << 8) | (ne << 10)
-    context |= (rho_p[1] & 0x2) << 9;                               // (nf) << 10
 
     ssp0 = block->block_states + (2U * qy + 1U) * (block->blkstate_stride) + 1U;
     ssp1 = ssp0 + block->blkstate_stride;
     sp0  = block->sample_buf + 2U * (qy * block->blksampl_stride);
     sp1  = sp0 + block->blksampl_stride;
 
-    qx = QW;
-    for (; qx >= 2; qx -= 2) {
-      make_storage(ssp0, ssp1, sp0, sp1, sig0, sig1, v0, v1, E0, E1, rho0, rho1);
-      // MEL encoding of the first quad
-      if (context == 0) {
-        MEL_encoder.encodeMEL((rho0 != 0));
+    // ===== PHASE 1: Pre-compute rho/E/v/sig for ALL quads =====
+    {
+      uint8_t *s0p = ssp0, *s1p = ssp1;
+      int32_t *p0 = sp0, *p1 = sp1;
+      int32_t q = 0;
+      for (; q + 1 < QW; q += 2) {
+        make_storage(s0p, s1p, p0, p1,
+                     sig_a[q], sig_a[q + 1], v_a[q], v_a[q + 1],
+                     E_a[q], E_a[q + 1], rho_a[q], rho_a[q + 1]);
+        s0p += 4; s1p += 4; p0 += 4; p1 += 4;
       }
-
-      gamma       = ((rho0 & (rho0 - 1)) == 0) ? 0 : (int32_t)0xFFFFFFFF;
-      kappa       = std::max((Emax0 - 1) & gamma, 1);
-      Emax_q      = hMax(E0);
-      U0          = std::max((int32_t)Emax_q, kappa);
-      u_q         = U0 - kappa;
-      uvlc_idx    = u_q;
-      uoff        = (u_q) ? 1 : 0;
-      Etmp        = _mm_set1_epi32(Emax_q);
-      vuoff       = _mm_set1_epi32(uoff << 7);
-      mask        = _mm_cmpeq_epi32(E0, Etmp);
-      vtmp        = _mm_and_si128(vuoff, mask);
-      emb_pattern = _mm_movemask_epi8(
-          _mm_packus_epi16(_mm_packus_epi32(vtmp, _mm_setzero_si128()), _mm_setzero_si128()));
-      n_q = emb_pattern + (rho0 << 4) + (context << 0);
-      CxtVLC = enc_CxtVLC_table1[n_q];
-      embk_0 = CxtVLC & 0xF;
-      emb1_0 = emb_pattern & embk_0;
-      uint32_t lw0 = (CxtVLC >> 4) & 0x07;
-      uint32_t cwd0 = CxtVLC >> 7;
-
-      // calculate context for the next quad
-      context = ((rho0 & 0x4) << 7) | ((rho0 & 0x8) << 6);           // (w | sw) << 9
-      context |= ((rho_p[0] & 0x8) << 5) | ((rho_p[1] & 0xa) << 7);  // ((nw | n) << 8) | (ne << 10)
-      context |= (rho_p[2] & 0x2) << 9;                              // (nf) << 10
-      // MEL encoding of the second quad
-      if (context == 0) {
-        MEL_encoder.encodeMEL((rho1 != 0));
+      if (q < QW) {
+        make_storage_one(s0p, s1p, p0, p1, sig_a[q], v_a[q], E_a[q], rho_a[q]);
       }
-      gamma  = ((rho1 & (rho1 - 1)) == 0) ? 0 : 1;
-      kappa  = std::max((Emax1 - 1) * gamma, 1);
-      Emax_q = hMax(E1);
-      U1     = std::max((int32_t)Emax_q, kappa);
-      u_q    = U1 - kappa;
-      uvlc_idx += u_q << 5;
-      uoff        = (u_q) ? 1 : 0;
-      Etmp        = _mm_set1_epi32(Emax_q);
-      vuoff       = _mm_set1_epi32(uoff << 7);
-      mask        = _mm_cmpeq_epi32(E1, Etmp);
-      vtmp        = _mm_and_si128(vuoff, mask);
-      emb_pattern = _mm_movemask_epi8(
-          _mm_packus_epi16(_mm_packus_epi32(vtmp, _mm_setzero_si128()), _mm_setzero_si128()));
-      n_q = emb_pattern + (rho1 << 4) + (context << 0);
-      CxtVLC = enc_CxtVLC_table1[n_q];
-      embk_1 = CxtVLC & 0xF;
-      emb1_1 = emb_pattern & embk_1;
-      lw     = (CxtVLC >> 4) & 0x07;
-      cwd    = CxtVLC >> 7;
-      // Batched VLC + UVLC encoding
-      {
-        uint32_t uvlc_tmp = enc_UVLC_table1[uvlc_idx];
-        uint32_t uvlc_lw  = uvlc_tmp & 0xFF;
-        uint32_t uvlc_cwd = uvlc_tmp >> 8;
-        uint64_t vlc_all  = cwd0 | (static_cast<uint64_t>(cwd) << lw0)
-                            | (static_cast<uint64_t>(uvlc_cwd) << (lw0 + lw));
-        VLC_encoder.emitVLCBits(vlc_all, lw0 + lw + uvlc_lw);
-      }
-
-      // Defer MagSgn encoding
-      m0       = _mm_sub_epi32(_mm_and_si128(sig0, _mm_set1_epi32(U0)),
-                               _mm_and_si128(_mm_srlv_epi32(_mm_set1_epi32(embk_0), vshift), vone));
-      m1       = _mm_sub_epi32(_mm_and_si128(sig1, _mm_set1_epi32(U1)),
-                               _mm_and_si128(_mm_srlv_epi32(_mm_set1_epi32(embk_1), vshift), vone));
-      known1_0 = _mm_and_si128(_mm_srlv_epi32(_mm_set1_epi32(emb1_0), vshift), vone);
-      known1_1 = _mm_and_si128(_mm_srlv_epi32(_mm_set1_epi32(emb1_1), vshift), vone);
-      ms_v[ms_count] = v0; ms_m[ms_count] = m0; ms_k1[ms_count] = known1_0; ms_count++;
-      ms_v[ms_count] = v1; ms_m[ms_count] = m1; ms_k1[ms_count] = known1_1; ms_count++;
-
-      Emax0 = find_max(E_p[3], E_p[4], E_p[5], E_p[6]);
-      Emax1 = find_max(E_p[5], E_p[6], E_p[7], E_p[8]);
-
-      // update Eline
-      E0 = _mm_shuffle_epi32(E0, 0xD8);
-      E1 = _mm_shuffle_epi32(E1, 0xD8);
-      _mm_storeu_si128((__m128i *)E_p, _mm_unpackhi_epi32(E0, E1));
-      E_p += 4;
-
-      // calculate context for the next quad
-      context = ((rho1 & 0x4) << 7) | ((rho1 & 0x8) << 6);           // (w | sw) << 9
-      context |= ((rho_p[1] & 0x8) << 5) | ((rho_p[2] & 0xa) << 7);  // ((nw | n) << 8) | (ne << 10)
-      context |= (rho_p[3] & 0x2) << 9;                              // (nf) << 10
-
-      *rho_p++ = rho0;
-      *rho_p++ = rho1;
-
-      // update pointer to line buffer
-      ssp0 += 4;
-      ssp1 += 4;
-      sp0 += 4;
-      sp1 += 4;
     }
-    if (qx) {
-      make_storage_one(ssp0, ssp1, sp0, sp1, sig0, v0, E0, rho0);
-      // MEL encoding of the first quad
-      if (context == 0) {
-        MEL_encoder.encodeMEL((rho0 != 0));
+
+    // ===== PHASE 2a: Compute context for ALL quads (reads from unmodified rholine) =====
+    {
+      int32_t rho_west = 0;
+      for (int32_t q = 0; q < QW; q++) {
+        ctx_a[q] = ((rho_west & 0x4) << 7) | ((rho_west & 0x8) << 6)
+                   | ((rho_p[q - 1] & 0x8) << 5) | ((rho_p[q] & 0xa) << 7)
+                   | ((rho_p[q + 1] & 0x2) << 9);
+        rho_west = rho_a[q];
       }
-      //(popcount32((uint32_t)rho0) > 1) ? 0xFFFFFFFF : 0;
-      gamma    = ((rho0 & (rho0 - 1)) == 0) ? 0 : (int32_t)0xFFFFFFFF;
-      kappa    = std::max((Emax0 - 1) & gamma, 1);
-      Emax_q   = hMax(E0);
-      U0       = std::max((int32_t)Emax_q, kappa);
-      u_q      = U0 - kappa;
-      uvlc_idx = u_q;
-      uoff     = (u_q) ? 1 : 0;
-
-      Etmp        = _mm_set1_epi32(Emax_q);
-      vuoff       = _mm_set1_epi32(uoff << 7);
-      mask        = _mm_cmpeq_epi32(E0, Etmp);
-      vtmp        = _mm_and_si128(vuoff, mask);
-      emb_pattern = _mm_movemask_epi8(
-          _mm_packus_epi16(_mm_packus_epi32(vtmp, _mm_setzero_si128()), _mm_setzero_si128()));
-      n_q = emb_pattern + (rho0 << 4) + (context << 0);
-      CxtVLC = enc_CxtVLC_table1[n_q];
-      embk_0 = CxtVLC & 0xF;
-      emb1_0 = emb_pattern & embk_0;
-      lw     = (CxtVLC >> 4) & 0x07;
-      cwd    = CxtVLC >> 7;
-      {
-        uint32_t uvlc_tmp = enc_UVLC_table1[uvlc_idx];
-        uint32_t uvlc_lw  = uvlc_tmp & 0xFF;
-        uint32_t uvlc_cwd = uvlc_tmp >> 8;
-        VLC_encoder.emitVLCBits(cwd | (static_cast<uint64_t>(uvlc_cwd) << lw), lw + uvlc_lw);
-      }
-
-      m0       = _mm_sub_epi32(_mm_and_si128(sig0, _mm_set1_epi32(U0)),
-                               _mm_and_si128(_mm_srlv_epi32(_mm_set1_epi32(embk_0), vshift), vone));
-      known1_0 = _mm_and_si128(_mm_srlv_epi32(_mm_set1_epi32(emb1_0), vshift), vone);
-      ms_v[ms_count] = v0; ms_m[ms_count] = m0; ms_k1[ms_count] = known1_0; ms_count++;
-
-      *E_p++ = _mm_extract_epi32(E0, 1);
-      *E_p++ = _mm_extract_epi32(E0, 3);
-      // update rho_line
-      *rho_p++ = rho0;
     }
-    // Emit deferred MagSgn for this line pair
+
+    // ===== PHASE 2b: Read ALL Emax from old Eline before any updates =====
+    alignas(32) int32_t Emax_a[512];
+    for (int32_t q = 0; q < QW; q++)
+      Emax_a[q] = find_max(E_p[2 * q - 1], E_p[2 * q], E_p[2 * q + 1], E_p[2 * q + 2]);
+
+
+    // ===== PHASE 2c: Compute kappa, U, VLC; update Eline + rholine =====
+    for (int32_t q = 0; q < QW; q++) {
+      int32_t rq = rho_a[q];
+      int32_t gamma_q = ((rq & (rq - 1)) == 0) ? 0 : static_cast<int32_t>(0xFFFFFFFF);
+      int32_t kappa_q = std::max((Emax_a[q] - 1) & gamma_q, 1);
+      int32_t Emax_q = hMax(E_a[q]);
+      int32_t Uq = std::max(Emax_q, kappa_q);
+      int32_t uq = Uq - kappa_q;
+      U_a[q] = Uq;
+      u_q_a[q] = uq;
+
+      int32_t uoff_q = (uq > 0) ? 1 : 0;
+      __m128i Etmp_q = _mm_set1_epi32(Emax_q);
+      __m128i vuoff_q = _mm_set1_epi32(uoff_q << 7);
+      __m128i mask_q = _mm_cmpeq_epi32(E_a[q], Etmp_q);
+      __m128i vtmp_q = _mm_and_si128(vuoff_q, mask_q);
+      int32_t emb_p = _mm_movemask_epi8(
+          _mm_packus_epi16(_mm_packus_epi32(vtmp_q, _mm_setzero_si128()), _mm_setzero_si128()));
+      int32_t nq = emb_p + (rq << 4) + (ctx_a[q] << 0);
+      uint32_t cv = enc_CxtVLC_table1[nq];
+      embk_a[q] = cv & 0xF;
+      emb1_a[q] = emb_p & embk_a[q];
+      vlc_cwd_a[q] = cv >> 7;
+      vlc_lw_a[q] = (cv >> 4) & 0x07;
+
+      __m128i Es = _mm_shuffle_epi32(E_a[q], 0xD8);
+      E_p[2 * q]     = _mm_extract_epi32(Es, 2);
+      E_p[2 * q + 1] = _mm_extract_epi32(Es, 3);
+
+      rho_p[q] = rq;
+    }
+
+
+    // ===== PHASE 3: Serial MEL + batched VLC + deferred MagSgn =====
+    for (int32_t q = 0; q + 1 < QW; q += 2) {
+      // MEL for first quad
+      if (ctx_a[q] == 0)
+        MEL_encoder.encodeMEL((rho_a[q] != 0));
+
+      // Batched VLC + UVLC
+      int32_t uvlc_idx_pair = u_q_a[q] + (u_q_a[q + 1] << 5);
+      uint32_t uvlc_tmp = enc_UVLC_table1[uvlc_idx_pair];
+      uint32_t uvlc_lw_val  = uvlc_tmp & 0xFF;
+      uint32_t uvlc_cwd_val = uvlc_tmp >> 8;
+      uint64_t vlc_all = vlc_cwd_a[q]
+          | (static_cast<uint64_t>(vlc_cwd_a[q + 1]) << vlc_lw_a[q])
+          | (static_cast<uint64_t>(uvlc_cwd_val) << (vlc_lw_a[q] + vlc_lw_a[q + 1]));
+      VLC_encoder.emitVLCBits(vlc_all, vlc_lw_a[q] + vlc_lw_a[q + 1] + uvlc_lw_val);
+
+      // MEL for second quad
+      if (ctx_a[q + 1] == 0)
+        MEL_encoder.encodeMEL((rho_a[q + 1] != 0));
+
+      // Defer MagSgn
+      for (int32_t s = 0; s < 2; s++) {
+        int32_t qi = q + s;
+        __m128i mq = _mm_sub_epi32(_mm_and_si128(sig_a[qi], _mm_set1_epi32(U_a[qi])),
+                                   _mm_and_si128(_mm_srlv_epi32(_mm_set1_epi32(embk_a[qi]), vshift), vone));
+        __m128i kq = _mm_and_si128(_mm_srlv_epi32(_mm_set1_epi32(emb1_a[qi]), vshift), vone);
+        ms_v[ms_count] = v_a[qi]; ms_m[ms_count] = mq; ms_k1[ms_count] = kq; ms_count++;
+      }
+    }
+    // Odd trailing quad
+    if (QW & 1) {
+      int32_t q = QW - 1;
+      if (ctx_a[q] == 0)
+        MEL_encoder.encodeMEL(rho_a[q] != 0);
+      uint32_t uvlc_tmp = enc_UVLC_table1[u_q_a[q]];
+      uint32_t uvlc_lw_val  = uvlc_tmp & 0xFF;
+      uint32_t uvlc_cwd_val = uvlc_tmp >> 8;
+      VLC_encoder.emitVLCBits(
+          vlc_cwd_a[q] | (static_cast<uint64_t>(uvlc_cwd_val) << vlc_lw_a[q]),
+          vlc_lw_a[q] + uvlc_lw_val);
+      __m128i mq = _mm_sub_epi32(_mm_and_si128(sig_a[q], _mm_set1_epi32(U_a[q])),
+                                 _mm_and_si128(_mm_srlv_epi32(_mm_set1_epi32(embk_a[q]), vshift), vone));
+      __m128i kq = _mm_and_si128(_mm_srlv_epi32(_mm_set1_epi32(emb1_a[q]), vshift), vone);
+      ms_v[ms_count] = v_a[q]; ms_m[ms_count] = mq; ms_k1[ms_count] = kq; ms_count++;
+    }
+
+    // ===== PHASE 4: Emit deferred MagSgn =====
     for (int32_t i = 0; i < ms_count; i++)
       MagSgn_encoder.emitBits(ms_v[i], ms_m[i], ms_k1[i]);
   }

--- a/source/core/coding/ht_block_encoding_neon.cpp
+++ b/source/core/coding/ht_block_encoding_neon.cpp
@@ -38,15 +38,17 @@
 
 // Quantize DWT coefficients and transfer them to codeblock buffer in a form of MagSgn value
 void j2k_codeblock::quantize(uint32_t &or_val) {
-  // TODO: check the way to quantize in terms of precision and reconstruction quality
-  float fscale = 1.0f / this->stepsize;
-  fscale /= (1 << (FRACBITS));
-  // Set fscale = 1.0 in lossless coding instead of skipping quantization
-  // to avoid if-branch in the following SIMD processing
-  if (transformation) fscale = 1.0f;
-
   const uint32_t height = this->size.y;
+  const uint32_t width  = this->size.x;
   const uint32_t stride = this->band_stride;
+  const bool lossless   = (this->transformation != 0);
+
+  float fscale = 1.0f;
+  if (!lossless) {
+    fscale = 1.0f / this->stepsize;
+    fscale /= (1 << (FRACBITS));
+  }
+
   #if defined(ENABLE_SP_MR)
   const int32_t pshift = (refsegment) ? 1 : 0;
   const int32_t pLSB   = (refsegment) ? 1 : 1;
@@ -61,13 +63,16 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
   #if defined(ENABLE_SP_MR)
     int32x4_t vpLSB = vdupq_n_s32(pLSB);
   #endif
-    int16_t len = static_cast<int16_t>(this->size.x);
+    int16_t len = static_cast<int16_t>(width);
     for (; len >= 8; len -= 8) {
-      auto fv0      = vld1q_f32(sp);
-      auto fv1      = vld1q_f32(sp + 4);
-      // Quantization
-      auto v0 = vcvtq_s32_f32(vmulq_f32(fv0, vscale));
-      auto v1 = vcvtq_s32_f32(vmulq_f32(fv1, vscale));
+      int32x4_t v0, v1;
+      if (lossless) {
+        v0 = vcvtq_s32_f32(vld1q_f32(sp));
+        v1 = vcvtq_s32_f32(vld1q_f32(sp + 4));
+      } else {
+        v0 = vcvtq_s32_f32(vmulq_f32(vld1q_f32(sp), vscale));
+        v1 = vcvtq_s32_f32(vmulq_f32(vld1q_f32(sp + 4), vscale));
+      }
       // Take sign bit
       int32x4_t s0 = vshrq_n_u32(v0, 31);
       int32x4_t s1 = vshrq_n_u32(v1, 31);
@@ -75,57 +80,45 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
       v0 = vabsq_s32(v0);
       v1 = vabsq_s32(v1);
   #if defined(ENABLE_SP_MR)
-      int32x4_t z0 = vandq_s32(v0, vpLSB);  // only for SigProp and MagRef
-      int32x4_t z1 = vandq_s32(v1, vpLSB);  // only for SigProp and MagRef
-      // Down-shift if other than HT Cleanup pass exists
+      int32x4_t z0 = vandq_s32(v0, vpLSB);
+      int32x4_t z1 = vandq_s32(v1, vpLSB);
       v0 = v0 >> pshift;
       v1 = v1 >> pshift;
   #endif
-      // ------------- Block states related begin
       uint8x8_t vblkstate = vdup_n_u8(0);
-      // Signed saturating extract Narrow (qmovn) is important for very finer quantization stepsize
       vblkstate = vorr_u8(
           vblkstate,
           vmovn_s16(vandq_s16(vcgtzq_s16(vcombine_s16(vqmovn_s32(v0), vqmovn_s32(v1))), vdupq_n_s16(1))));
-      //      vblkstate |=
-      //          vmovn_s16(vbicq_s16(vdupq_n_s16(1), vceqzq_s16(vcombine_s16(vqmovn_s32(v0),
-      //          vqmovn_s32(v1)))));
   #if defined(ENABLE_SP_MR)
-      // bits in lowest bitplane, only for SigProp and MagRef TODO: test this line
       vblkstate |= vmovn_s16(vshlq_n_s16(vcombine_s16(vmovn_s32(z0), vmovn_s32(z1)), SHIFT_SMAG));
-      // sign-bits, only for SigProp and MagRef  TODO: test this line
       vblkstate |= vmovn_s16(vshlq_n_s16(vcombine_s16(vmovn_s32(s0), vmovn_s32(s1)), SHIFT_SSGN));
   #endif
       vst1_u8(dstblk, vblkstate);
       dstblk += 8;
-      // ------------- Block states related end
   #if defined(ENABLE_SP_MR)
-      // Modify sign if other than HT Cleanup pass exists
       s0 = vandq_s32(vcgtzq_s32(v0), s0);
       s1 = vandq_s32(vcgtzq_s32(v1), s1);
   #endif
-      // Check emptiness of a block
       vorval = vorrq_s32(vorval, v0);
       vorval = vorrq_s32(vorval, v1);
-      // Convert two's compliment to MagSgn form
       v0 = vqsubq_u32(v0, vdupq_n_u32(1));
       v1 = vqsubq_u32(v1, vdupq_n_u32(1));
       v0 = vshlq_n_s32(v0, 1);
       v1 = vshlq_n_s32(v1, 1);
       v0 = vaddq_s32(v0, s0);
       v1 = vaddq_s32(v1, s1);
-      // Store
       vst1q_s32(dp, v0);
       vst1q_s32(dp + 4, v1);
       sp += 8;
       dp += 8;
     }
-    // Check emptiness of a block
     or_val |= static_cast<unsigned int>(vmaxvq_s32(vorval));
-    // process leftover
     for (; len > 0; --len) {
       int32_t temp;
-      temp = static_cast<int32_t>(static_cast<float>(sp[0]) * fscale);  // needs to be rounded towards zero
+      if (lossless)
+        temp = static_cast<int32_t>(sp[0]);
+      else
+        temp = static_cast<int32_t>(static_cast<float>(sp[0]) * fscale);
       uint32_t sign = static_cast<uint32_t>(temp) & 0x80000000;
   #if defined(ENABLE_SP_MR)
       dstblk[0] |= static_cast<uint8_t>(((temp & pLSB) & 1) << SHIFT_SMAG);
@@ -143,13 +136,18 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
         temp--;
         temp <<= 1;
         temp += static_cast<uint8_t>(sign >> 31);
-        dp[0] = temp;
       }
+      dp[0] = temp;
       ++sp;
       ++dp;
       ++dstblk;
     }
+    if (blksampl_stride > width)
+      memset(dp, 0, (blksampl_stride - width) * sizeof(int32_t));
   }
+  const uint32_t QHx2 = (height + 7U) & ~7U;
+  for (uint32_t i = height; i < QHx2; ++i)
+    memset(this->sample_buf + i * blksampl_stride, 0, blksampl_stride * sizeof(int32_t));
 }
 
 /********************************************************************************

--- a/source/core/coding/ht_block_encoding_wasm.cpp
+++ b/source/core/coding/ht_block_encoding_wasm.cpp
@@ -87,12 +87,17 @@ static inline v128_t wasm_u32x4_clz(v128_t a) {
 
 // Quantize DWT coefficients and transfer them to codeblock buffer in a form of MagSgn value
 void j2k_codeblock::quantize(uint32_t &or_val) {
-  float fscale = 1.0f / this->stepsize;
-  fscale /= (1 << (FRACBITS));
-  if (transformation) fscale = 1.0f;
-
   const uint32_t height = this->size.y;
+  const uint32_t width  = this->size.x;
   const uint32_t stride = this->band_stride;
+  const bool lossless   = (this->transformation != 0);
+
+  float fscale = 1.0f;
+  if (!lossless) {
+    fscale = 1.0f / this->stepsize;
+    fscale /= (1 << (FRACBITS));
+  }
+
   v128_t vscale         = wasm_f32x4_splat(fscale);
   v128_t vorval         = wasm_i32x4_const_splat(0);
   for (uint16_t i = 0; i < static_cast<uint16_t>(height); ++i) {
@@ -100,20 +105,20 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
     int32_t *dp        = this->sample_buf + i * blksampl_stride;
     size_t block_index = (i + 1U) * (blkstate_stride) + 1U;
     uint8_t *dstblk    = block_states + block_index;
-    int16_t len        = static_cast<int16_t>(this->size.x);
+    int16_t len        = static_cast<int16_t>(width);
     for (; len >= 8; len -= 8) {
-      v128_t fv0 = wasm_v128_load(sp);
-      v128_t fv1 = wasm_v128_load(sp + 4);
-      // Quantization
-      v128_t v0 = wasm_i32x4_trunc_sat_f32x4(wasm_f32x4_mul(fv0, vscale));
-      v128_t v1 = wasm_i32x4_trunc_sat_f32x4(wasm_f32x4_mul(fv1, vscale));
-      // Take sign bit
+      v128_t v0, v1;
+      if (lossless) {
+        v0 = wasm_i32x4_trunc_sat_f32x4(wasm_v128_load(sp));
+        v1 = wasm_i32x4_trunc_sat_f32x4(wasm_v128_load(sp + 4));
+      } else {
+        v0 = wasm_i32x4_trunc_sat_f32x4(wasm_f32x4_mul(wasm_v128_load(sp), vscale));
+        v1 = wasm_i32x4_trunc_sat_f32x4(wasm_f32x4_mul(wasm_v128_load(sp + 4), vscale));
+      }
       v128_t s0 = wasm_u32x4_shr(v0, 31);
       v128_t s1 = wasm_u32x4_shr(v1, 31);
-      // Absolute value
       v0 = wasm_i32x4_abs(v0);
       v1 = wasm_i32x4_abs(v1);
-      // Block states
       v128_t narrow0     = wasm_i16x8_narrow_i32x4(v0, v0);
       v128_t narrow1     = wasm_i16x8_narrow_i32x4(v1, v1);
       v128_t combined16  = wasm_i8x16_shuffle(narrow0, narrow1, 0, 1, 2, 3, 4, 5, 6, 7, 16, 17, 18, 19, 20,
@@ -123,28 +128,26 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
       v128_t narrow8     = wasm_i8x16_narrow_i16x8(vblkstate_v, vblkstate_v);
       *(uint64_t *)dstblk = (uint64_t)wasm_i64x2_extract_lane(narrow8, 0);
       dstblk += 8;
-      // Check emptiness of a block
       vorval = wasm_v128_or(vorval, v0);
       vorval = wasm_v128_or(vorval, v1);
-      // Convert two's complement to MagSgn form
       v0 = wasm_u32x4_qsub(v0, wasm_i32x4_const_splat(1));
       v1 = wasm_u32x4_qsub(v1, wasm_i32x4_const_splat(1));
       v0 = wasm_i32x4_shl(v0, 1);
       v1 = wasm_i32x4_shl(v1, 1);
       v0 = wasm_i32x4_add(v0, s0);
       v1 = wasm_i32x4_add(v1, s1);
-      // Store
       wasm_v128_store(dp, v0);
       wasm_v128_store(dp + 4, v1);
       sp += 8;
       dp += 8;
     }
-    // Check emptiness of a block
     or_val |= static_cast<unsigned int>(wasm_i32x4_reduce_max(vorval));
-    // process leftover
     for (; len > 0; --len) {
       int32_t temp;
-      temp             = static_cast<int32_t>(static_cast<float>(sp[0]) * fscale);
+      if (lossless)
+        temp = static_cast<int32_t>(sp[0]);
+      else
+        temp = static_cast<int32_t>(static_cast<float>(sp[0]) * fscale);
       uint32_t sign    = static_cast<uint32_t>(temp) & 0x80000000;
       temp             = (temp < 0) ? -temp : temp;
       temp &= 0x7FFFFFFF;
@@ -154,13 +157,18 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
         temp--;
         temp <<= 1;
         temp += static_cast<uint8_t>(sign >> 31);
-        dp[0] = temp;
       }
+      dp[0] = temp;
       ++sp;
       ++dp;
       ++dstblk;
     }
+    if (blksampl_stride > width)
+      memset(dp, 0, (blksampl_stride - width) * sizeof(int32_t));
   }
+  const uint32_t QHx2 = (height + 7U) & ~7U;
+  for (uint32_t i = height; i < QHx2; ++i)
+    memset(this->sample_buf + i * blksampl_stride, 0, blksampl_stride * sizeof(int32_t));
 }
 
 /********************************************************************************


### PR DESCRIPTION
## Summary

Five incremental optimizations to the HT cleanup encoder targeting single-thread lossless encode speed:

1. **Skip redundant quantize multiply and sample_buf memset** — lossless fast path, remove bulk zero
2. **Batch VLC + UVLC emissions** — combine 3 separate `emitVLCBits()` calls per quad pair into 1
3. **Defer MagSgn emission** — store v/m/known1 per quad, emit in a tight loop after all context/MEL/VLC work. Better icache + branch predictor utilization
4. **Two-pass cleanup encoder** (new `ht_block_encoding_avx512.cpp`) — separate data-parallel computation (Phase 1-2) from serial encoding (Phase 3-4). Pre-compute rho/E/v/sig/context/kappa/U/VLC for all quads before encoding
5. **AVX-512 gather for VLC table lookup** — `_mm512_i32gather_epi32` replaces 16 serial random-access lookups with 1 gather instruction. Also vectorizes gamma/kappa computation

## Performance

ElephantDream_4K (8-bit) and StainedGlass_4K (12-bit), single-thread, median of 10 warm runs:

| Config | Before | After | Improvement |
|--------|--------|-------|-------------|
| ED 4K lossless | 209.8 ms | 190.4 ms | **-9.3%** |
| SG 4K lossless | 191.8 ms | 175.1 ms | **-8.7%** |

OpenJPH reference: ~76 ms (still 2.3-2.5x gap, dominated by serial MagSgn emitter and non-cleanup overhead).

## Test plan

- [x] `ctest -R enc_` — all encoder tests pass
- [x] Bit-exact codestream output verified for both test images × lossless + lossy
- [x] AVX2 path preserved (guarded with `!defined(__AVX512F__)`)

## Next steps for further improvement

- Fuse quantize into Phase 1 (eliminate the separate quantize pass: ~10 ms)
- Vectorize make_storage with AVX-512 (batch-load + interleave for 8+ quads)
- Reduce kernel page-fault overhead (pre-touch pages: ~15 ms)
- Consider NASM MagSgn emitter for register-resident accumulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)