### PR TITLE
build: wire optional NASM toolchain for AVX-512 cleanup encoder hot path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,17 @@ if (NOT EMSCRIPTEN)
 else()
   option(BUILD_SHARED_LIBS "Shared Libraries" OFF)
 endif()
+# OPENHTJ2K_ENABLE_NASM: enable the NASM-based hot-path replacements for the
+# AVX-512 cleanup encoder.  Default ON on x86-64 (where AVX-512 is meaningful
+# and NASM is the canonical assembler), OFF on aarch64 NEON / WASM where the
+# AVX-512 path isn't built anyway.  If the user sets it ON but `nasm` is not
+# in PATH, we fall back to the C++ emitFlat silently — see the
+# find_program(NASM_EXECUTABLE) block below.
+if (NOT EMSCRIPTEN AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64)$")
+  option(OPENHTJ2K_ENABLE_NASM "Build NASM-based hot paths for AVX-512 cleanup encoder" ON)
+else()
+  option(OPENHTJ2K_ENABLE_NASM "Build NASM-based hot paths for AVX-512 cleanup encoder" OFF)
+endif()
 enable_language(CXX)
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -72,6 +83,27 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 add_library(open_htj2k)
+# NASM enablement (paired with the OPENHTJ2K_ENABLE_NASM option above).
+# Probe for `nasm` first instead of relying on enable_language(ASM_NASM) to
+# fatal-error: that lets us silently fall back to the C++ emitFlat path when
+# the user has the option ON but no NASM installed (common in fresh CI
+# images and developer machines that haven't built OpenJPH).  The
+# OPENHTJ2K_NASM_FOUND cache flag is consulted by source/core/coding to
+# decide whether to add ht_block_encoding_avx512.asm to the sources list.
+if (OPENHTJ2K_ENABLE_NASM)
+  find_program(NASM_EXECUTABLE nasm)
+  if (NASM_EXECUTABLE)
+    enable_language(ASM_NASM)
+    message(STATUS "OPENHTJ2K_ENABLE_NASM: NASM found at ${NASM_EXECUTABLE}")
+    target_compile_definitions(open_htj2k PRIVATE OPENHTJ2K_HAVE_NASM_EMITFLAT)
+    set(OPENHTJ2K_NASM_FOUND TRUE CACHE INTERNAL "")
+  else()
+    message(WARNING "OPENHTJ2K_ENABLE_NASM=ON but `nasm` not in PATH; falling back to C++ emitFlat")
+    set(OPENHTJ2K_NASM_FOUND FALSE CACHE INTERNAL "")
+  endif()
+else()
+  set(OPENHTJ2K_NASM_FOUND FALSE CACHE INTERNAL "")
+endif()
 add_subdirectory(source/core/codestream)
 add_subdirectory(source/core/coding)
 add_subdirectory(source/core/transform)

--- a/source/core/coding/CMakeLists.txt
+++ b/source/core/coding/CMakeLists.txt
@@ -20,6 +20,13 @@ target_sources(open_htj2k
     subband_row_buf.cpp
 )
 
+# NASM hot-path translation units (cleanup encoder).  Added only when the
+# top-level NASM probe succeeded (see OPENHTJ2K_NASM_FOUND in the root
+# CMakeLists).  Each file should be self-contained with C-ABI exports.
+if (OPENHTJ2K_NASM_FOUND)
+  target_sources(open_htj2k PRIVATE ht_block_encoding_avx512.asm)
+endif()
+
 # clang-18 miscompiles NEON bitstream helper functions when they are inlined.
 # Disabling inlining for the affected files fixes the issue without changing
 # the source; -fno-inline still respects always_inline attributes.

--- a/source/core/coding/ht_block_encoding_avx512.asm
+++ b/source/core/coding/ht_block_encoding_avx512.asm
@@ -1,0 +1,39 @@
+; ht_block_encoding_avx512.asm
+;
+; NASM scaffolding for the AVX-512 cleanup encoder hot path.
+;
+; PR A1 of the cleanup_encode rewrite series: this file exists only to wire
+; the NASM toolchain into the build so PR A2 can drop in
+; `openhtj2k_avx512_emit_flat` without also having to land the CMake plumbing.
+; The only export here is a probe symbol the C++ side can optionally call
+; from a debug build to confirm the NASM object linked correctly.
+;
+; ABI: SysV AMD64 on Linux/macOS, Microsoft x64 on Windows.  Both calling
+; conventions return ints in RAX/EAX, so the probe symbol below is portable
+; as-is.
+
+default rel
+
+%ifdef WIN64
+  %define EXPORT(sym) global sym
+%else
+  %define EXPORT(sym) global sym:function
+%endif
+
+section .text
+
+; uint32_t openhtj2k_nasm_probe(void);
+;
+; Returns the PR scaffolding marker 0xA1.  Never called on the hot path —
+; reserved for build-system smoke tests and PR A2's bring-up.
+EXPORT(openhtj2k_nasm_probe)
+openhtj2k_nasm_probe:
+        mov     eax, 0xA1
+        ret
+
+; Non-executable stack note (Linux): silences the GNU linker's
+; "missing .note.GNU-stack section implies executable stack" warning
+; without affecting the Windows/macOS objects, which ignore the section.
+%ifidn __OUTPUT_FORMAT__, elf64
+section .note.GNU-stack noalloc noexec nowrite progbits
+%endif

--- a/source/core/coding/ht_block_encoding_avx512.asm
+++ b/source/core/coding/ht_block_encoding_avx512.asm
@@ -10,14 +10,27 @@
 ;
 ; ABI: SysV AMD64 on Linux/macOS, Microsoft x64 on Windows.  Both calling
 ; conventions return ints in RAX/EAX, so the probe symbol below is portable
-; as-is.
+; as-is.  Symbol-export syntax differs between object formats:
+;   * ELF: `global sym:function` (the :function suffix is ELF-only)
+;   * Win64 / Mach-O: `global sym`  (no decorations)
+; Mach-O additionally prepends an underscore to C identifiers — handle that
+; via the conditional rename below so the same C declaration links on all
+; three platforms.
 
 default rel
 
-%ifdef WIN64
-  %define EXPORT(sym) global sym
+%ifidn __OUTPUT_FORMAT__, elf64
+  %define EXPORT(sym) global sym %+ :function
+%elifidn __OUTPUT_FORMAT__, macho64
+  %define EXPORT(sym) global _ %+ sym
 %else
-  %define EXPORT(sym) global sym:function
+  %define EXPORT(sym) global sym
+%endif
+
+%ifidn __OUTPUT_FORMAT__, macho64
+  %define DEFINE_FUNC(sym) _ %+ sym
+%else
+  %define DEFINE_FUNC(sym) sym
 %endif
 
 section .text
@@ -27,13 +40,13 @@ section .text
 ; Returns the PR scaffolding marker 0xA1.  Never called on the hot path —
 ; reserved for build-system smoke tests and PR A2's bring-up.
 EXPORT(openhtj2k_nasm_probe)
-openhtj2k_nasm_probe:
+DEFINE_FUNC(openhtj2k_nasm_probe):
         mov     eax, 0xA1
         ret
 
 ; Non-executable stack note (Linux): silences the GNU linker's
-; "missing .note.GNU-stack section implies executable stack" warning
-; without affecting the Windows/macOS objects, which ignore the section.
+; "missing .note.GNU-stack section implies executable stack" warning.
+; The section is only emitted for elf64 output; Win64/Mach-O ignore it.
 %ifidn __OUTPUT_FORMAT__, elf64
 section .note.GNU-stack noalloc noexec nowrite progbits
 %endif


### PR DESCRIPTION
## Summary

Scaffolding only — no behavior change.  Establishes NASM build wiring so a follow-up PR can drop in a NASM rewrite of `state_MS_enc::emitFlat` (the MagSgn drain helper) without also having to land the build-system plumbing in the same review.

`emitFlat` currently accounts for ~17% of encode wall time on 4K RGB-lossless single-thread and is the largest single sub-bucket of `htj2k_cleanup_encode` (which itself is ~35% of wall).  C++ rewrites of the cleanup encoder's outer structure have repeatedly regressed wall-time on this codebase — NASM substitution of just the inner serial-emit helper isolates the change behind a stable ABI and removes the compiler-fragility class entirely.

## How

- New `OPENHTJ2K_ENABLE_NASM` CMake option.  Default ON on x86-64 Linux/macOS/Windows, OFF on aarch64 NEON / WebAssembly (where the AVX-512 path isn't compiled).
- When ON, probes for `nasm` via `find_program` BEFORE calling `enable_language(ASM_NASM)`.  If NASM is absent, the option falls back silently to the existing C++ `emitFlat` so users without NASM installed (fresh CI images, developer machines that haven't built OpenJPH) keep building cleanly.
- When the probe succeeds, defines `OPENHTJ2K_HAVE_NASM_EMITFLAT` on the library target so the follow-up `#ifdef` in `ht_block_encoding_avx2.hpp` can route the AVX-512 translation unit's `emitFlat` call into NASM while AVX-2, scalar, NEON, and WASM paths keep the C++ definition.
- `source/core/coding/ht_block_encoding_avx512.asm` is a stub that exports only `openhtj2k_nasm_probe` (returns 0xA1) so we can confirm the NASM object is linked end-to-end.  The probe is unused on the hot path; PR A2 replaces this stub with the real implementation.  Includes a Linux `.note.GNU-stack` section to keep the GNU linker from defaulting to executable stack.

## Verification

Ryzen 9 9950X, Ubuntu 25.04, NASM 2.16.03.

- [x] 402/402 ctest pass with NASM enabled.
- [x] `-DOPENHTJ2K_ENABLE_NASM=OFF` reconfigure builds cleanly without nasm; `nm` shows the probe symbol is absent.
- [x] ED4K 4K RGB-lossless single-thread wall: 100 ms median over 10 runs.  Bit-identical to main.
- [x] `nm build/bin/libopenhtj2k.so | grep nasm_probe` confirms the symbol is exported when NASM is enabled.

## Follow-ups

- A2: replace the stub with `openhtj2k_avx512_emit_flat` (~150-250 LOC NASM, SysV + MS-x64 ABIs).  Wall gate: ship if median improvement ≥ 3.0 ms and p95 ≥ 1.5 ms; revert if median worse by >0.5 ms.
- A3 (optional): after A2 ships, re-evaluate `noinline` on the now-AVX-2-only C++ `emitFlat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)