### PR TITLE
perf(encoder): eliminate block_states sigma array via bit-31 sentinel

### DIFF
--- a/source/core/coding/coding_units.cpp
+++ b/source/core/coding/coding_units.cpp
@@ -548,10 +548,8 @@ inline void dec_strip_barrier_wait(std::atomic<int> &cnt);
 }
 #endif
 
-// Re-stamp block->sample_buf / block->block_states for every codeblock in
-// cblk-row strip `br` into this level's per-strip scratch ring slot, then
-// zero the sgbuf portion (sink_quantize_row OR-aggregates sigma bits, so the
-// slot must start zeroed each time it is reused).  Called by
+// Re-stamp block->sample_buf for every codeblock in cblk-row strip `br`
+// into this level's per-strip scratch ring slot.  Called by
 // fdwt_level_sink_fn on the first emitted row of each new strip — both legs
 // (HL and LH+HH) of the same strip share the slot, so the first leg to fire
 // does the stamp and the second short-circuits via cx->last_stamped_br == br.
@@ -609,7 +607,7 @@ static inline void stamp_strip_pointers(fdwt_level_sink_ctx *c, int32_t br) {
   }
 }
 
-// Quantize one DWT row and scatter into codeblock sample_buf + block_states.
+// Quantize one DWT row and scatter into codeblock sample_buf.
 static inline void sink_quantize_row(const sprec_t *src, int32_t sub_row, int32_t band_idx,
                                      fdwt_level_sink_ctx *c) {
   const int32_t ncx         = c->sink_num_cblk_x[band_idx];
@@ -633,7 +631,7 @@ static inline void sink_quantize_row(const sprec_t *src, int32_t sub_row, int32_
 #if defined(__AVX2__)
       const __m256i vone      = _mm256_set1_epi32(1);
       const __m256 vscale     = _mm256_set1_ps(fs);
-      const __m256i vsentinel = _mm256_set1_epi32(static_cast<int32_t>(0x80000000u));
+      const __m256i vsentinel = _mm256_set1_epi32(INT32_MIN);
       __m256i vor             = _mm256_setzero_si256();
       int32_t col             = 0;
       for (; col + 15 < w; col += 16) {
@@ -682,7 +680,7 @@ static inline void sink_quantize_row(const sprec_t *src, int32_t sub_row, int32_
           temp--;
           temp <<= 1;
           temp += static_cast<uint8_t>(sign >> 31);
-          temp |= static_cast<int32_t>(0x80000000u);
+          temp |= INT32_MIN;
         }
         dp[col] = temp;
       }
@@ -726,7 +724,7 @@ static inline void sink_quantize_row_i32(const int32_t *src, int32_t sub_row, in
     {
 #if defined(__AVX2__)
       const __m256i vone      = _mm256_set1_epi32(1);
-      const __m256i vsentinel = _mm256_set1_epi32(static_cast<int32_t>(0x80000000u));
+      const __m256i vsentinel = _mm256_set1_epi32(INT32_MIN);
       __m256i vor             = _mm256_setzero_si256();
       int32_t col             = 0;
       for (; col + 15 < w; col += 16) {
@@ -764,7 +762,7 @@ static inline void sink_quantize_row_i32(const int32_t *src, int32_t sub_row, in
           temp--;
           temp <<= 1;
           temp += static_cast<uint8_t>(sign >> 31);
-          temp |= static_cast<int32_t>(0x80000000u);
+          temp |= INT32_MIN;
         }
         dp[col] = temp;
       }
@@ -6634,8 +6632,7 @@ uint8_t *j2k_tile::encode_line_based() {
       max_total_cblks = std::max(max_total_cblks, total_cblks);
     }
     if (max_total_cblks == 0) return;
-    epc->reserve_scratch(static_cast<size_t>(max_total_cblks) * 4096,
-                         static_cast<size_t>(max_total_cblks) * 6156);
+    epc->reserve_scratch(static_cast<size_t>(max_total_cblks) * 4096, 0);
     int32_t *gbuf      = epc->gbuf;
     auto enc_task_args = std::make_unique<EncTaskArgs[]>(max_total_cblks);
     std::atomic<int> enc_remaining{0};
@@ -6699,8 +6696,7 @@ uint8_t *j2k_tile::encode_line_based() {
       max_total_cblks = std::max(max_total_cblks, total_cblks);
     }
     if (max_total_cblks == 0) return;
-    epc->reserve_scratch(static_cast<size_t>(max_total_cblks) * 4096,
-                         static_cast<size_t>(max_total_cblks) * 6156);
+    epc->reserve_scratch(static_cast<size_t>(max_total_cblks) * 4096, 0);
     int32_t *gbuf = epc->gbuf;
     for (uint32_t p = 0; p < cr->npw * cr->nph; ++p) {
       j2k_precinct *cp = cr->access_precinct(p);
@@ -6889,8 +6885,7 @@ uint8_t *j2k_tile::encode_line_based_stream(
       max_total_cblks = std::max(max_total_cblks, total_cblks);
     }
     if (max_total_cblks == 0) return;
-    epc->reserve_scratch(static_cast<size_t>(max_total_cblks) * 4096,
-                         static_cast<size_t>(max_total_cblks) * 6156);
+    epc->reserve_scratch(static_cast<size_t>(max_total_cblks) * 4096, 0);
     int32_t *gbuf      = epc->gbuf;
     auto enc_task_args = std::make_unique<EncTaskArgs[]>(max_total_cblks);
     std::atomic<int> enc_remaining{0};
@@ -6954,8 +6949,7 @@ uint8_t *j2k_tile::encode_line_based_stream(
       max_total_cblks = std::max(max_total_cblks, total_cblks);
     }
     if (max_total_cblks == 0) return;
-    epc->reserve_scratch(static_cast<size_t>(max_total_cblks) * 4096,
-                         static_cast<size_t>(max_total_cblks) * 6156);
+    epc->reserve_scratch(static_cast<size_t>(max_total_cblks) * 4096, 0);
     int32_t *gbuf = epc->gbuf;
     for (uint32_t p = 0; p < cr->npw * cr->nph; ++p) {
       j2k_precinct *cp = cr->access_precinct(p);

--- a/source/core/coding/coding_units.cpp
+++ b/source/core/coding/coding_units.cpp
@@ -581,10 +581,8 @@ static inline void stamp_strip_pointers(fdwt_level_sink_ctx *c, int32_t br) {
   }
 #endif
 
-  int32_t *pbuf             = c->strip_gbufs[slot_idx];
-  uint8_t *spbuf            = c->strip_sgbufs[slot_idx];
-  uint8_t *const sgbuf_base = spbuf;
-  int32_t cblk_count        = 0;
+  int32_t *pbuf      = c->strip_gbufs[slot_idx];
+  int32_t cblk_count = 0;
   for (uint8_t b = 0; b < 3; ++b) {
     const int32_t ncx = c->sink_num_cblk_x[b];
     if (ncx == 0) continue;
@@ -595,15 +593,11 @@ static inline void stamp_strip_pointers(fdwt_level_sink_ctx *c, int32_t br) {
       const uint32_t QWx2  = round_up(block->size.x, 8U);
       const uint32_t QHx2  = round_up(block->size.y, 8U);
       block->sample_buf    = pbuf;
-      block->block_states  = spbuf;
       block->pre_quantized = true;
       pbuf += QWx2 * QHx2;
-      spbuf += (QWx2 + 2) * (QHx2 + 2);
       ++cblk_count;
     }
   }
-  const size_t sg_used = static_cast<size_t>(spbuf - sgbuf_base);
-  if (sg_used) std::memset(sgbuf_base, 0, sg_used);
 
   // Publish the dispatch count BEFORE enc_overlap_dispatch fires (which
   // happens later, on the strip's last row).  Workers will fetch_sub(1)
@@ -632,17 +626,16 @@ static inline void sink_quantize_row(const sprec_t *src, int32_t sub_row, int32_
     float fs = 1.0f / block->stepsize;
     fs /= (1 << FRACBITS);
     if (block->transformation) fs = 1.0f;
-    int32_t *dp = block->sample_buf + row_in_cblk * static_cast<int32_t>(block->blksampl_stride);
-    uint8_t *stp =
-        block->block_states + (row_in_cblk + 1) * static_cast<int32_t>(block->blkstate_stride) + 1;
+    int32_t *dp      = block->sample_buf + row_in_cblk * static_cast<int32_t>(block->blksampl_stride);
     const sprec_t *s = src + xstarts[static_cast<size_t>(xi)];
     const int32_t w  = static_cast<int32_t>(block->size.x);
     {
 #if defined(__AVX2__)
-      const __m256i vone  = _mm256_set1_epi32(1);
-      const __m256 vscale = _mm256_set1_ps(fs);
-      __m256i vor         = _mm256_setzero_si256();
-      int32_t col         = 0;
+      const __m256i vone      = _mm256_set1_epi32(1);
+      const __m256 vscale     = _mm256_set1_ps(fs);
+      const __m256i vsentinel = _mm256_set1_epi32(static_cast<int32_t>(0x80000000u));
+      __m256i vor             = _mm256_setzero_si256();
+      int32_t col             = 0;
       for (; col + 15 < w; col += 16) {
         __m256i v0, v1;
         if (block->transformation) {
@@ -665,16 +658,11 @@ static inline void sink_quantize_row(const sprec_t *src, int32_t sub_row, int32_
                                          _mm256_and_si256(s0, mask0));
         v1            = _mm256_add_epi32(_mm256_slli_epi32(_mm256_sub_epi32(v1, vone1), 1),
                                          _mm256_and_si256(s1, mask1));
+        // Set sentinel bit 31 for significant samples
+        v0 = _mm256_or_si256(v0, _mm256_and_si256(mask0, vsentinel));
+        v1 = _mm256_or_si256(v1, _mm256_and_si256(mask1, vsentinel));
         _mm256_storeu_si256((__m256i *)(dp + col), v0);
         _mm256_storeu_si256((__m256i *)(dp + col + 8), v1);
-        // block_states: pack sigma to bytes
-        v0                 = _mm256_packs_epi32(vone0, vone1);
-        v0                 = _mm256_permute4x64_epi64(v0, 0xD8);
-        v0                 = _mm256_packs_epi16(v0, v0);
-        v0                 = _mm256_permute4x64_epi64(v0, 0xD8);
-        __m128i vsig       = _mm256_extracti128_si256(v0, 0);
-        __m128i old_states = _mm_loadu_si128((__m128i *)(stp + col));
-        _mm_storeu_si128((__m128i *)(stp + col), _mm_or_si128(old_states, vsig));
       }
       if (!_mm256_testz_si256(vor, vor)) block->pre_or_val |= 1;
       for (; col < w; ++col) {
@@ -691,10 +679,10 @@ static inline void sink_quantize_row(const sprec_t *src, int32_t sub_row, int32_
         temp          = (temp < 0) ? -temp : temp;
         if (temp) {
           block->pre_or_val |= 1;
-          stp[col] |= 1;
           temp--;
           temp <<= 1;
           temp += static_cast<uint8_t>(sign >> 31);
+          temp |= static_cast<int32_t>(0x80000000u);
         }
         dp[col] = temp;
       }
@@ -702,14 +690,17 @@ static inline void sink_quantize_row(const sprec_t *src, int32_t sub_row, int32_
     if (static_cast<int32_t>(block->blksampl_stride) > w)
       memset(dp + w, 0,
              static_cast<size_t>(block->blksampl_stride - static_cast<size_t>(w)) * sizeof(int32_t));
-    // Odd-height: zero the trailing sample row that make_storage will read at
-    // qy = QH-1.  Sigma bits at that row are already 0 (sgbuf is memset per
-    // encode), but gbuf is grow-only and may contain stale samples; without
-    // this, emitFlat ORs garbage v lanes into the bitstream accumulator.
-    if ((static_cast<uint32_t>(block->size.y) & 1u)
-        && row_in_cblk == static_cast<int32_t>(block->size.y) - 1) {
-      memset(dp + static_cast<ptrdiff_t>(block->blksampl_stride), 0,
-             static_cast<size_t>(block->blksampl_stride) * sizeof(int32_t));
+    // Zero ALL trailing rows from size.y to QHx2 when this is the last row.
+    // With sentinel-in-sample, there is no separate sigma buffer; make_storage
+    // derives sigma from bit 31, so trailing rows must be zero to avoid
+    // garbage significance.
+    if (row_in_cblk == static_cast<int32_t>(block->size.y) - 1) {
+      const uint32_t QHx2 = (block->size.y + 7U) & ~7U;
+      const int32_t trail_rows = static_cast<int32_t>(QHx2) - static_cast<int32_t>(block->size.y);
+      if (trail_rows > 0) {
+        memset(dp + static_cast<ptrdiff_t>(block->blksampl_stride), 0,
+               static_cast<size_t>(trail_rows) * static_cast<size_t>(block->blksampl_stride) * sizeof(int32_t));
+      }
     }
   }
 }
@@ -729,16 +720,15 @@ static inline void sink_quantize_row_i32(const int32_t *src, int32_t sub_row, in
   for (int32_t xi = 0; xi < ncx; ++xi) {
     j2k_codeblock *block = cblks[static_cast<size_t>(cy * ncx + xi)];
     if (row_in_cblk >= static_cast<int32_t>(block->size.y)) continue;
-    int32_t *dp = block->sample_buf + row_in_cblk * static_cast<int32_t>(block->blksampl_stride);
-    uint8_t *stp =
-        block->block_states + (row_in_cblk + 1) * static_cast<int32_t>(block->blkstate_stride) + 1;
+    int32_t *dp      = block->sample_buf + row_in_cblk * static_cast<int32_t>(block->blksampl_stride);
     const int32_t *s = src + xstarts[static_cast<size_t>(xi)];
     const int32_t w  = static_cast<int32_t>(block->size.x);
     {
 #if defined(__AVX2__)
-      const __m256i vone = _mm256_set1_epi32(1);
-      __m256i vor        = _mm256_setzero_si256();
-      int32_t col        = 0;
+      const __m256i vone      = _mm256_set1_epi32(1);
+      const __m256i vsentinel = _mm256_set1_epi32(static_cast<int32_t>(0x80000000u));
+      __m256i vor             = _mm256_setzero_si256();
+      int32_t col             = 0;
       for (; col + 15 < w; col += 16) {
         __m256i v0    = _mm256_loadu_si256((const __m256i *)(s + col));
         __m256i v1    = _mm256_loadu_si256((const __m256i *)(s + col + 8));
@@ -755,15 +745,10 @@ static inline void sink_quantize_row_i32(const int32_t *src, int32_t sub_row, in
                                          _mm256_and_si256(s0, mask0));
         v1            = _mm256_add_epi32(_mm256_slli_epi32(_mm256_sub_epi32(v1, vone1), 1),
                                          _mm256_and_si256(s1, mask1));
+        v0 = _mm256_or_si256(v0, _mm256_and_si256(mask0, vsentinel));
+        v1 = _mm256_or_si256(v1, _mm256_and_si256(mask1, vsentinel));
         _mm256_storeu_si256((__m256i *)(dp + col), v0);
         _mm256_storeu_si256((__m256i *)(dp + col + 8), v1);
-        v0                 = _mm256_packs_epi32(vone0, vone1);
-        v0                 = _mm256_permute4x64_epi64(v0, 0xD8);
-        v0                 = _mm256_packs_epi16(v0, v0);
-        v0                 = _mm256_permute4x64_epi64(v0, 0xD8);
-        __m128i vsig       = _mm256_extracti128_si256(v0, 0);
-        __m128i old_states = _mm_loadu_si128((__m128i *)(stp + col));
-        _mm_storeu_si128((__m128i *)(stp + col), _mm_or_si128(old_states, vsig));
       }
       if (!_mm256_testz_si256(vor, vor)) block->pre_or_val |= 1;
       for (; col < w; ++col) {
@@ -776,10 +761,10 @@ static inline void sink_quantize_row_i32(const int32_t *src, int32_t sub_row, in
         temp          = (temp < 0) ? -temp : temp;
         if (temp) {
           block->pre_or_val |= 1;
-          stp[col] |= 1;
           temp--;
           temp <<= 1;
           temp += static_cast<uint8_t>(sign >> 31);
+          temp |= static_cast<int32_t>(0x80000000u);
         }
         dp[col] = temp;
       }
@@ -787,10 +772,13 @@ static inline void sink_quantize_row_i32(const int32_t *src, int32_t sub_row, in
     if (static_cast<int32_t>(block->blksampl_stride) > w)
       memset(dp + w, 0,
              static_cast<size_t>(block->blksampl_stride - static_cast<size_t>(w)) * sizeof(int32_t));
-    if ((static_cast<uint32_t>(block->size.y) & 1u)
-        && row_in_cblk == static_cast<int32_t>(block->size.y) - 1) {
-      memset(dp + static_cast<ptrdiff_t>(block->blksampl_stride), 0,
-             static_cast<size_t>(block->blksampl_stride) * sizeof(int32_t));
+    if (row_in_cblk == static_cast<int32_t>(block->size.y) - 1) {
+      const uint32_t QHx2 = (block->size.y + 7U) & ~7U;
+      const int32_t trail_rows = static_cast<int32_t>(QHx2) - static_cast<int32_t>(block->size.y);
+      if (trail_rows > 0) {
+        memset(dp + static_cast<ptrdiff_t>(block->blksampl_stride), 0,
+               static_cast<size_t>(trail_rows) * static_cast<size_t>(block->blksampl_stride) * sizeof(int32_t));
+      }
     }
   }
 }
@@ -807,7 +795,7 @@ static void fdwt_level_sink_fn(void *ctx, bool is_hp, int32_t abs_row, const spr
 
   const int32_t u_off = c->u0 & 1;
 
-  // Strip-ring stamp: re-stamp block->sample_buf / block->block_states at the
+  // Strip-ring stamp: re-stamp block->sample_buf at the
   // first emitted row of each new cblk-row strip.  In the overlap path,
   // hl_y0 == lh_y0 (asserted at setup), so both legs compute the same strip
   // index for the same vertical position.  Whichever leg fires first for
@@ -3795,9 +3783,6 @@ void j2k_tile_component::create_resolutions(uint16_t numlayers, bool line_based,
 
 void j2k_tile_component::perform_dc_offset(const uint8_t transformation, const bool is_signed) {
   const int32_t shiftup = (transformation == 1) ? 0 : FRACBITS - this->bitdepth;
-  if (shiftup < 0) {
-    printf("WARNING: Over 13 bpp precision will be down-shifted to 12 bpp.\n");
-  }
   // DC offset for signed input shall be 0
   const int32_t DC_OFFSET = (is_signed) ? 0 : 1 << (this->bitdepth - 1 + shiftup);
 
@@ -6652,13 +6637,11 @@ uint8_t *j2k_tile::encode_line_based() {
     epc->reserve_scratch(static_cast<size_t>(max_total_cblks) * 4096,
                          static_cast<size_t>(max_total_cblks) * 6156);
     int32_t *gbuf      = epc->gbuf;
-    uint8_t *sgbuf     = epc->sgbuf;
     auto enc_task_args = std::make_unique<EncTaskArgs[]>(max_total_cblks);
     std::atomic<int> enc_remaining{0};
     for (uint32_t p = 0; p < cr->npw * cr->nph; ++p) {
       j2k_precinct *cp = cr->access_precinct(p);
       int32_t *pbuf    = gbuf;
-      uint8_t *spbuf   = sgbuf;
       for (uint8_t b = 0; b < cr->num_bands; b++) {
         j2k_precinct_subband *cpb = cp->access_pband(b);
         const uint32_t num_cblks  = cpb->num_codeblock_x * cpb->num_codeblock_y;
@@ -6668,11 +6651,8 @@ uint8_t *j2k_tile::encode_line_based() {
           const uint32_t QHx2 = round_up(block->size.y, 8U);
           block->sample_buf   = pbuf;
           pbuf += QWx2 * QHx2;
-          block->block_states = spbuf;
-          spbuf += (QWx2 + 2) * (QHx2 + 2);
         }
       }
-      memset(sgbuf, 0, static_cast<size_t>(spbuf - sgbuf));
       enc_remaining.store(0, std::memory_order_relaxed);
       uint32_t task_idx = 0;
       for (uint8_t b = 0; b < cr->num_bands; ++b) {
@@ -6721,12 +6701,10 @@ uint8_t *j2k_tile::encode_line_based() {
     if (max_total_cblks == 0) return;
     epc->reserve_scratch(static_cast<size_t>(max_total_cblks) * 4096,
                          static_cast<size_t>(max_total_cblks) * 6156);
-    int32_t *gbuf  = epc->gbuf;
-    uint8_t *sgbuf = epc->sgbuf;
+    int32_t *gbuf = epc->gbuf;
     for (uint32_t p = 0; p < cr->npw * cr->nph; ++p) {
       j2k_precinct *cp = cr->access_precinct(p);
       int32_t *pbuf    = gbuf;
-      uint8_t *spbuf   = sgbuf;
       for (uint8_t b = 0; b < cr->num_bands; b++) {
         j2k_precinct_subband *cpb = cp->access_pband(b);
         const uint32_t num_cblks  = cpb->num_codeblock_x * cpb->num_codeblock_y;
@@ -6736,11 +6714,8 @@ uint8_t *j2k_tile::encode_line_based() {
           const uint32_t QHx2 = round_up(block->size.y, 8U);
           block->sample_buf   = pbuf;
           pbuf += QWx2 * QHx2;
-          block->block_states = spbuf;
-          spbuf += (QWx2 + 2) * (QHx2 + 2);
         }
       }
-      memset(sgbuf, 0, static_cast<size_t>(spbuf - sgbuf));
       g_cblk_pool = epc->pools[0].get();
       for (uint8_t b = 0; b < cr->num_bands; ++b) {
         j2k_precinct_subband *cpb = cp->access_pband(b);
@@ -6917,13 +6892,11 @@ uint8_t *j2k_tile::encode_line_based_stream(
     epc->reserve_scratch(static_cast<size_t>(max_total_cblks) * 4096,
                          static_cast<size_t>(max_total_cblks) * 6156);
     int32_t *gbuf      = epc->gbuf;
-    uint8_t *sgbuf     = epc->sgbuf;
     auto enc_task_args = std::make_unique<EncTaskArgs[]>(max_total_cblks);
     std::atomic<int> enc_remaining{0};
     for (uint32_t p = 0; p < cr->npw * cr->nph; ++p) {
       j2k_precinct *cp = cr->access_precinct(p);
       int32_t *pbuf    = gbuf;
-      uint8_t *spbuf   = sgbuf;
       for (uint8_t b = 0; b < cr->num_bands; b++) {
         j2k_precinct_subband *cpb = cp->access_pband(b);
         const uint32_t num_cblks  = cpb->num_codeblock_x * cpb->num_codeblock_y;
@@ -6933,11 +6906,8 @@ uint8_t *j2k_tile::encode_line_based_stream(
           const uint32_t QHx2 = round_up(block->size.y, 8U);
           block->sample_buf   = pbuf;
           pbuf += QWx2 * QHx2;
-          block->block_states = spbuf;
-          spbuf += (QWx2 + 2) * (QHx2 + 2);
         }
       }
-      memset(sgbuf, 0, static_cast<size_t>(spbuf - sgbuf));
       enc_remaining.store(0, std::memory_order_relaxed);
       uint32_t task_idx = 0;
       for (uint8_t b = 0; b < cr->num_bands; ++b) {
@@ -6986,12 +6956,10 @@ uint8_t *j2k_tile::encode_line_based_stream(
     if (max_total_cblks == 0) return;
     epc->reserve_scratch(static_cast<size_t>(max_total_cblks) * 4096,
                          static_cast<size_t>(max_total_cblks) * 6156);
-    int32_t *gbuf  = epc->gbuf;
-    uint8_t *sgbuf = epc->sgbuf;
+    int32_t *gbuf = epc->gbuf;
     for (uint32_t p = 0; p < cr->npw * cr->nph; ++p) {
       j2k_precinct *cp = cr->access_precinct(p);
       int32_t *pbuf    = gbuf;
-      uint8_t *spbuf   = sgbuf;
       for (uint8_t b = 0; b < cr->num_bands; b++) {
         j2k_precinct_subband *cpb = cp->access_pband(b);
         const uint32_t num_cblks  = cpb->num_codeblock_x * cpb->num_codeblock_y;
@@ -7001,11 +6969,8 @@ uint8_t *j2k_tile::encode_line_based_stream(
           const uint32_t QHx2 = round_up(block->size.y, 8U);
           block->sample_buf   = pbuf;
           pbuf += QWx2 * QHx2;
-          block->block_states = spbuf;
-          spbuf += (QWx2 + 2) * (QHx2 + 2);
         }
       }
-      memset(sgbuf, 0, static_cast<size_t>(spbuf - sgbuf));
       g_cblk_pool = epc->pools[0].get();
       for (uint8_t b = 0; b < cr->num_bands; ++b) {
         j2k_precinct_subband *cpb = cp->access_pband(b);

--- a/source/core/coding/ht_block_encoding.cpp
+++ b/source/core/coding/ht_block_encoding.cpp
@@ -59,10 +59,8 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
   const int32_t pLSB   = (refsegment) ? 2 : 1;
   #endif
   for (uint16_t i = 0; i < static_cast<uint16_t>(height); ++i) {
-    sprec_t *sp        = this->band_buf + i * stride;
-    int32_t *dp        = this->sample_buf + i * blksampl_stride;
-    size_t block_index = (i + 1U) * (blkstate_stride) + 1U;
-    uint8_t *dstblk    = block_states + block_index;
+    sprec_t *sp = this->band_buf + i * stride;
+    int32_t *dp = this->sample_buf + i * blksampl_stride;
 
     int16_t len = static_cast<int16_t>(width);
     for (; len > 0; --len) {
@@ -72,26 +70,18 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
       else
         temp = static_cast<int32_t>(static_cast<float>(sp[0]) * fscale);
       uint32_t sign = static_cast<uint32_t>(temp) & 0x80000000;
-  #if defined(ENABLE_SP_MR)
-      dstblk[0] |= static_cast<uint8_t>(((temp & pLSB) & 1) << SHIFT_SMAG);
-      dstblk[0] |= static_cast<uint8_t>((sign >> 31) << SHIFT_SSGN);
-  #endif
       temp = (temp < 0) ? -temp : temp;
       temp &= 0x7FFFFFFF;
-  #if defined(ENABLE_SP_MR)
-      temp >>= pshift;
-  #endif
       if (temp) {
         or_val |= 1;
-        dstblk[0] |= 1;
         temp--;
         temp <<= 1;
         temp += static_cast<uint8_t>(sign >> 31);
+        temp |= static_cast<int32_t>(0x80000000u);
       }
       dp[0] = temp;
       ++sp;
       ++dp;
-      ++dstblk;
     }
     if (blksampl_stride > width)
       memset(dp, 0, (blksampl_stride - width) * sizeof(int32_t));
@@ -328,61 +318,71 @@ auto make_storage = [](const j2k_codeblock *const block, const uint16_t qy, cons
                        uint8_t *const sigma_n, uint32_t *const v_n, int32_t *const E_n,
                        uint8_t *const rho_q) {
   // This function shall be called on the assumption that there are two quads
-  uint8_t *const ssp0 = block->block_states + (2U * qy + 1U) * (block->blkstate_stride) + 2U * qx + 1U;
-  uint8_t *const ssp1 = ssp0 + block->blkstate_stride;
-  int32_t *sp0        = block->sample_buf + 2U * (qx + qy * block->blksampl_stride);
-  int32_t *sp1        = sp0 + block->blksampl_stride;
+  int32_t *sp0 = block->sample_buf + 2U * (qx + qy * block->blksampl_stride);
+  int32_t *sp1 = sp0 + block->blksampl_stride;
 
-  sigma_n[0] = ssp0[0] & 1;
-  sigma_n[1] = ssp1[0] & 1;
-  sigma_n[2] = ssp0[1] & 1;
-  sigma_n[3] = ssp1[1] & 1;
-  sigma_n[4] = ssp0[2] & 1;
-  sigma_n[5] = ssp1[2] & 1;
-  sigma_n[6] = ssp0[3] & 1;
-  sigma_n[7] = ssp1[3] & 1;
+  uint32_t s0 = static_cast<uint32_t>(sp0[0]);
+  uint32_t s1 = static_cast<uint32_t>(sp1[0]);
+  uint32_t s2 = static_cast<uint32_t>(sp0[1]);
+  uint32_t s3 = static_cast<uint32_t>(sp1[1]);
+  uint32_t s4 = static_cast<uint32_t>(sp0[2]);
+  uint32_t s5 = static_cast<uint32_t>(sp1[2]);
+  uint32_t s6 = static_cast<uint32_t>(sp0[3]);
+  uint32_t s7 = static_cast<uint32_t>(sp1[3]);
+
+  sigma_n[0] = static_cast<uint8_t>(s0 >> 31);
+  sigma_n[1] = static_cast<uint8_t>(s1 >> 31);
+  sigma_n[2] = static_cast<uint8_t>(s2 >> 31);
+  sigma_n[3] = static_cast<uint8_t>(s3 >> 31);
+  sigma_n[4] = static_cast<uint8_t>(s4 >> 31);
+  sigma_n[5] = static_cast<uint8_t>(s5 >> 31);
+  sigma_n[6] = static_cast<uint8_t>(s6 >> 31);
+  sigma_n[7] = static_cast<uint8_t>(s7 >> 31);
 
   rho_q[0] = static_cast<uint8_t>(sigma_n[0] + (sigma_n[1] << 1) + (sigma_n[2] << 2) + (sigma_n[3] << 3));
   rho_q[1] = static_cast<uint8_t>(sigma_n[4] + (sigma_n[5] << 1) + (sigma_n[6] << 2) + (sigma_n[7] << 3));
 
-  v_n[0] = static_cast<uint32_t>(sp0[0]);
-  v_n[1] = static_cast<uint32_t>(sp1[0]);
-  v_n[2] = static_cast<uint32_t>(sp0[1]);
-  v_n[3] = static_cast<uint32_t>(sp1[1]);
-  v_n[4] = static_cast<uint32_t>(sp0[2]);
-  v_n[5] = static_cast<uint32_t>(sp1[2]);
-  v_n[6] = static_cast<uint32_t>(sp0[3]);
-  v_n[7] = static_cast<uint32_t>(sp1[3]);
+  v_n[0] = s0 & 0x7FFFFFFFu;
+  v_n[1] = s1 & 0x7FFFFFFFu;
+  v_n[2] = s2 & 0x7FFFFFFFu;
+  v_n[3] = s3 & 0x7FFFFFFFu;
+  v_n[4] = s4 & 0x7FFFFFFFu;
+  v_n[5] = s5 & 0x7FFFFFFFu;
+  v_n[6] = s6 & 0x7FFFFFFFu;
+  v_n[7] = s7 & 0x7FFFFFFFu;
 
   for (int i = 0; i < 8; ++i) {
-    E_n[i] = static_cast<int32_t>((32 - count_leading_zeros(v_n[i])) * sigma_n[i]);
+    E_n[i] = static_cast<int32_t>(32 - count_leading_zeros(v_n[i])) * sigma_n[i];
   }
 };
 
 static inline void make_storage_one(const j2k_codeblock *const block, const uint16_t qy, const uint16_t qx,
                                     uint8_t *const sigma_n, uint32_t *const v_n, int32_t *const E_n,
                                     uint8_t *const rho_q) {
-  uint8_t *const ssp0 = block->block_states + (2U * qy + 1U) * (block->blkstate_stride) + 2U * qx + 1U;
-  uint8_t *const ssp1 = ssp0 + block->blkstate_stride;
-  int32_t *sp0        = block->sample_buf + 2U * (qx + qy * block->blksampl_stride);
-  int32_t *sp1        = sp0 + block->blksampl_stride;
+  int32_t *sp0 = block->sample_buf + 2U * (qx + qy * block->blksampl_stride);
+  int32_t *sp1 = sp0 + block->blksampl_stride;
 
-  sigma_n[0] = ssp0[0] & 1;
-  sigma_n[1] = ssp1[0] & 1;
-  sigma_n[2] = ssp0[1] & 1;
-  sigma_n[3] = ssp1[1] & 1;
+  uint32_t s0 = static_cast<uint32_t>(sp0[0]);
+  uint32_t s1 = static_cast<uint32_t>(sp1[0]);
+  uint32_t s2 = static_cast<uint32_t>(sp0[1]);
+  uint32_t s3 = static_cast<uint32_t>(sp1[1]);
+
+  sigma_n[0] = static_cast<uint8_t>(s0 >> 31);
+  sigma_n[1] = static_cast<uint8_t>(s1 >> 31);
+  sigma_n[2] = static_cast<uint8_t>(s2 >> 31);
+  sigma_n[3] = static_cast<uint8_t>(s3 >> 31);
 
   rho_q[0] = static_cast<uint8_t>(sigma_n[0] + (sigma_n[1] << 1) + (sigma_n[2] << 2) + (sigma_n[3] << 3));
 
-  v_n[0] = static_cast<uint32_t>(sp0[0]);
-  v_n[1] = static_cast<uint32_t>(sp1[0]);
-  v_n[2] = static_cast<uint32_t>(sp0[1]);
-  v_n[3] = static_cast<uint32_t>(sp1[1]);
+  v_n[0] = s0 & 0x7FFFFFFFu;
+  v_n[1] = s1 & 0x7FFFFFFFu;
+  v_n[2] = s2 & 0x7FFFFFFFu;
+  v_n[3] = s3 & 0x7FFFFFFFu;
 
-  E_n[0] = static_cast<int32_t>((32 - count_leading_zeros(v_n[0])) * sigma_n[0]);
-  E_n[1] = static_cast<int32_t>((32 - count_leading_zeros(v_n[1])) * sigma_n[1]);
-  E_n[2] = static_cast<int32_t>((32 - count_leading_zeros(v_n[2])) * sigma_n[2]);
-  E_n[3] = static_cast<int32_t>((32 - count_leading_zeros(v_n[3])) * sigma_n[3]);
+  E_n[0] = static_cast<int32_t>(32 - count_leading_zeros(v_n[0])) * sigma_n[0];
+  E_n[1] = static_cast<int32_t>(32 - count_leading_zeros(v_n[1])) * sigma_n[1];
+  E_n[2] = static_cast<int32_t>(32 - count_leading_zeros(v_n[2])) * sigma_n[2];
+  E_n[3] = static_cast<int32_t>(32 - count_leading_zeros(v_n[3])) * sigma_n[3];
 }
 
 // joint termination of MEL and VLC

--- a/source/core/coding/ht_block_encoding.cpp
+++ b/source/core/coding/ht_block_encoding.cpp
@@ -77,7 +77,7 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
         temp--;
         temp <<= 1;
         temp += static_cast<uint8_t>(sign >> 31);
-        temp |= static_cast<int32_t>(0x80000000u);
+        temp |= INT32_MIN;
       }
       dp[0] = temp;
       ++sp;

--- a/source/core/coding/ht_block_encoding_avx2.cpp
+++ b/source/core/coding/ht_block_encoding_avx2.cpp
@@ -58,17 +58,13 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
   const int32_t pshift = (refsegment) ? 1 : 0;
   const int32_t pLSB   = (refsegment) ? 1 : 1;
   #endif
-  const __m256i vone  = _mm256_set1_epi32(1);
-  const __m256 vscale = _mm256_set1_ps(fscale);
+  const __m256i vone      = _mm256_set1_epi32(1);
+  const __m256 vscale     = _mm256_set1_ps(fscale);
+  const __m256i vsentinel = _mm256_set1_epi32(static_cast<int32_t>(0x80000000u));
   __m256i vor_val = _mm256_setzero_si256();
   for (uint16_t i = 0; i < static_cast<uint16_t>(height); ++i) {
-    sprec_t *sp        = this->band_buf + i * stride;
-    int32_t *dp        = this->sample_buf + i * blksampl_stride;
-    size_t block_index = (i + 1U) * (blkstate_stride) + 1U;
-    uint8_t *dstblk    = block_states + block_index;
-  #if defined(ENABLE_SP_MR)
-    const __m256i vpLSB = _mm256_set1_epi32(pLSB);
-  #endif
+    sprec_t *sp = this->band_buf + i * stride;
+    int32_t *dp = this->sample_buf + i * blksampl_stride;
     int32_t len = static_cast<int32_t>(width);
     for (; len >= 16; len -= 16) {
       __m256i v0, v1;
@@ -84,14 +80,6 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
       __m256i s1 = _mm256_srli_epi32(v1, 31);
       v0         = _mm256_abs_epi32(v0);
       v1         = _mm256_abs_epi32(v1);
-  #if defined(ENABLE_SP_MR)
-      __m256i z0 = _mm256_and_si256(v0, vpLSB);  // only for SigProp and MagRef
-      __m256i z1 = _mm256_and_si256(v1, vpLSB);  // only for SigProp and MagRef
-
-      // Down-shift if other than HT Cleanup pass exists
-      v0 = _mm256_srai_epi32(v0, pshift);
-      v1 = _mm256_srai_epi32(v1, pshift);
-  #endif
       // Generate masks for sigma
       __m256i mask0 = _mm256_cmpgt_epi32(v0, _mm256_setzero_si256());
       __m256i mask1 = _mm256_cmpgt_epi32(v1, _mm256_setzero_si256());
@@ -108,28 +96,14 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
       v1            = _mm256_slli_epi32(v1, 1);
       v0            = _mm256_add_epi32(v0, _mm256_and_si256(s0, mask0));
       v1            = _mm256_add_epi32(v1, _mm256_and_si256(s1, mask1));
+      // Set sentinel bit 31 for significant samples
+      v0 = _mm256_or_si256(v0, _mm256_and_si256(mask0, vsentinel));
+      v1 = _mm256_or_si256(v1, _mm256_and_si256(mask1, vsentinel));
       // Store
       _mm256_storeu_si256((__m256i *)dp, v0);
       _mm256_storeu_si256((__m256i *)(dp + 8), v1);
       sp += 16;
       dp += 16;
-      // for Block states
-      v0 = _mm256_packs_epi32(vone0, vone1);  // re-use v0 as sigma
-      v0 = _mm256_permute4x64_epi64(v0, 0xD8);
-  #if defined(ENABLE_SP_MR)
-      vone0 = _mm256_packs_epi32(z0, z1);  // re-use vone0 as z
-      vone0 = _mm256_permute4x64_epi64(vone0, 0xD8);
-      vone1 = _mm256_packs_epi32(s0, s1);  // re-use vone1 as sign
-      vone1 = _mm256_permute4x64_epi64(vone1, 0xD8);
-      v0    = _mm256_or_si256(v0, _mm256_slli_epi16(vone0, SHIFT_SMAG));
-      v0    = _mm256_or_si256(v0, _mm256_slli_epi16(vone1, SHIFT_SSGN));
-  #endif
-      v0        = _mm256_packs_epi16(v0, v0);  // re-use vone0
-      v0        = _mm256_permute4x64_epi64(v0, 0xD8);
-      __m128i v = _mm256_extracti128_si256(v0, 0);
-      // _mm256_zeroupper(); // does not work on GCC, TODO: find a solution with __m128i v
-      _mm_storeu_si128((__m128i *)dstblk, v);
-      dstblk += 16;
     }
     for (; len > 0; --len) {
       int32_t temp;
@@ -138,26 +112,18 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
       else
         temp = static_cast<int32_t>(static_cast<float>(sp[0]) * fscale);
       uint32_t sign = static_cast<uint32_t>(temp) & 0x80000000;
-  #if defined(ENABLE_SP_MR)
-      dstblk[0] |= static_cast<uint8_t>(((temp & pLSB) & 1) << SHIFT_SMAG);
-      dstblk[0] |= static_cast<uint8_t>((sign >> 31) << SHIFT_SSGN);
-  #endif
       temp = (temp < 0) ? -temp : temp;
       temp &= 0x7FFFFFFF;
-  #if defined(ENABLE_SP_MR)
-      temp >>= pshift;
-  #endif
       if (temp) {
         or_val |= 1;
-        dstblk[0] |= 1;
         temp--;
         temp <<= 1;
         temp += static_cast<uint8_t>(sign >> 31);
+        temp |= static_cast<int32_t>(0x80000000u);
       }
       dp[0] = temp;
       ++sp;
       ++dp;
-      ++dstblk;
     }
     if (blksampl_stride > width)
       memset(dp, 0, (blksampl_stride - width) * sizeof(int32_t));
@@ -187,48 +153,45 @@ inline __m128i sse_lzcnt_epi32(__m128i v) {
   return v;
 }
 
-auto make_storage = [](const uint8_t *ssp0, const uint8_t *ssp1, const int32_t *sp0, const int32_t *sp1,
+auto make_storage = [](const int32_t *sp0, const int32_t *sp1,
                        __m128i &sig0, __m128i &sig1, __m128i &v0, __m128i &v1, __m128i &E0, __m128i &E1,
                        int32_t &rho0, int32_t &rho1) {
   // This function shall be called on the assumption that there are two quads
   const __m128i zero = _mm_setzero_si128();
-  __m128i t0         = _mm_set1_epi64x(*((int64_t *)ssp0));
-  __m128i t1         = _mm_set1_epi64x(*((int64_t *)ssp1));
-  __m128i t          = _mm_unpacklo_epi8(t0, t1);
-  __m128i v_u8_out   = _mm_and_si128(t, _mm_set1_epi8(1));
-  v_u8_out           = _mm_cmpgt_epi8(v_u8_out, zero);
-  sig0               = _mm_cvtepu8_epi32(v_u8_out);
-  sig1               = _mm_cvtepu8_epi32(_mm_srli_si128(v_u8_out, 4));
-  rho0               = _mm_movemask_epi8(_mm_packus_epi16(_mm_packus_epi32(sig0, zero), zero));
-  rho1               = _mm_movemask_epi8(_mm_packus_epi16(_mm_packus_epi32(sig1, zero), zero));
-
-  sig0 = _mm_cmpgt_epi32(sig0, zero);
-  sig1 = _mm_cmpgt_epi32(sig1, zero);
-
-  t0 = _mm_loadu_si128((__m128i *)sp0);
-  t1 = _mm_loadu_si128((__m128i *)sp1);
-  v0 = _mm_unpacklo_epi32(t0, t1);
-  v1 = _mm_unpackhi_epi32(t0, t1);
-
+  const __m128i mask = _mm_set1_epi32(0x7FFFFFFF);
+  __m128i t0   = _mm_loadu_si128((__m128i *)sp0);
+  __m128i t1   = _mm_loadu_si128((__m128i *)sp1);
+  __m128i raw0 = _mm_unpacklo_epi32(t0, t1);
+  __m128i raw1 = _mm_unpackhi_epi32(t0, t1);
+  // Derive sigma (0 or 1) from bit 31
+  __m128i sig0_01 = _mm_srli_epi32(raw0, 31);
+  __m128i sig1_01 = _mm_srli_epi32(raw1, 31);
+  // Compute rho: shift value 0/1 left by 7 to get 0x00 or 0x80 in each lane's low byte
+  __m128i shift7 = _mm_set1_epi32(7);
+  rho0 = _mm_movemask_epi8(_mm_packus_epi16(_mm_packus_epi32(_mm_sllv_epi32(sig0_01, shift7), zero), zero));
+  rho1 = _mm_movemask_epi8(_mm_packus_epi16(_mm_packus_epi32(_mm_sllv_epi32(sig1_01, shift7), zero), zero));
+  // Full mask for downstream use (-1 or 0)
+  sig0 = _mm_srai_epi32(raw0, 31);
+  sig1 = _mm_srai_epi32(raw1, 31);
+  v0 = _mm_and_si128(raw0, mask);
+  v1 = _mm_and_si128(raw1, mask);
   t0 = _mm_sub_epi32(_mm_set1_epi32(32), sse_lzcnt_epi32(v0));
   E0 = _mm_and_si128(t0, sig0);
   t1 = _mm_sub_epi32(_mm_set1_epi32(32), sse_lzcnt_epi32(v1));
   E1 = _mm_and_si128(t1, sig1);
 };
 
-auto make_storage_one = [](const uint8_t *ssp0, const uint8_t *ssp1, const int32_t *sp0, const int32_t *sp1,
+auto make_storage_one = [](const int32_t *sp0, const int32_t *sp1,
                            __m128i &sig0, __m128i &v0, __m128i &E0, int32_t &rho0) {
-  sig0 = _mm_setr_epi32(ssp0[0] & 1, ssp1[0] & 1, ssp0[1] & 1, ssp1[1] & 1);
-
-  __m128i shift = _mm_setr_epi32(7, 7, 7, 7);
-  __m128i t0    = _mm_sllv_epi32(sig0, shift);
-  __m128i zero  = _mm_setzero_si128();
-  rho0          = _mm_movemask_epi8(_mm_packus_epi16(_mm_packus_epi32(t0, zero), zero));
-
-  v0 = _mm_setr_epi32(sp0[0], sp1[0], sp0[1], sp1[1]);
-
-  sig0 = _mm_cmpgt_epi32(sig0, zero);
-  t0   = _mm_sub_epi32(_mm_set1_epi32(32), sse_lzcnt_epi32(v0));
+  const __m128i zero = _mm_setzero_si128();
+  const __m128i mask = _mm_set1_epi32(0x7FFFFFFF);
+  __m128i raw0 = _mm_setr_epi32(sp0[0], sp1[0], sp0[1], sp1[1]);
+  __m128i sig0_01 = _mm_srli_epi32(raw0, 31);
+  __m128i shift7 = _mm_set1_epi32(7);
+  rho0 = _mm_movemask_epi8(_mm_packus_epi16(_mm_packus_epi32(_mm_sllv_epi32(sig0_01, shift7), zero), zero));
+  sig0 = _mm_srai_epi32(raw0, 31);
+  v0   = _mm_and_si128(raw0, mask);
+  __m128i t0 = _mm_sub_epi32(_mm_set1_epi32(32), sse_lzcnt_epi32(v0));
   E0   = _mm_and_si128(t0, sig0);
 };
 
@@ -352,10 +315,8 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
   /*******************************************************************************************************************/
   // Initial line-pair
   /*******************************************************************************************************************/
-  uint8_t *ssp0 = block->block_states + 1U * (block->blkstate_stride) + 1U;
-  uint8_t *ssp1 = ssp0 + block->blkstate_stride;
-  int32_t *sp0  = block->sample_buf;
-  int32_t *sp1  = sp0 + block->blksampl_stride;
+  int32_t *sp0 = block->sample_buf;
+  int32_t *sp1 = sp0 + block->blksampl_stride;
 
   // Stack-allocate Eline/rholine: bounded by max codeblock width (1024 → QW ≤ 512).
   // Zero exactly the used range (matches make_unique<int32_t[]> zero-initialization).
@@ -381,7 +342,7 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
   int32_t qx = QW;
   for (; qx >= 2; qx -= 2) {
     bool uoff_flag = true;
-    make_storage(ssp0, ssp1, sp0, sp1, sig0, sig1, v0, v1, E0, E1, rho0, rho1);
+    make_storage(sp0, sp1, sig0, sig1, v0, v1, E0, E1, rho0, rho1);
     // MEL encoding for the first quad
     if (context == 0) {
       MEL_encoder.encodeMEL((rho0 != 0));
@@ -478,13 +439,11 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
     _mm_storeu_si128((__m128i *)E_p, _mm_unpackhi_epi32(E0, E1));
     E_p += 4;
     // update pointer to line buffer
-    ssp0 += 4;
-    ssp1 += 4;
     sp0 += 4;
     sp1 += 4;
   }
   if (qx) {
-    make_storage_one(ssp0, ssp1, sp0, sp1, sig0, v0, E0, rho0);
+    make_storage_one(sp0, sp1, sig0, v0, E0, rho0);
     // MEL encoding for the first quad
     if (context == 0) {
       MEL_encoder.encodeMEL((rho0 != 0));
@@ -551,24 +510,21 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
     E_p   = Eline + 1;
     rho_p = rholine + 1;
 
-    ssp0 = block->block_states + (2U * qy + 1U) * (block->blkstate_stride) + 1U;
-    ssp1 = ssp0 + block->blkstate_stride;
-    sp0  = block->sample_buf + 2U * (qy * block->blksampl_stride);
-    sp1  = sp0 + block->blksampl_stride;
+    sp0 = block->sample_buf + 2U * (qy * block->blksampl_stride);
+    sp1 = sp0 + block->blksampl_stride;
 
     // ===== PHASE 1: Pre-compute rho/E/v/sig for ALL quads =====
     {
-      uint8_t *s0p = ssp0, *s1p = ssp1;
       int32_t *p0 = sp0, *p1 = sp1;
       int32_t q = 0;
       for (; q + 1 < QW; q += 2) {
-        make_storage(s0p, s1p, p0, p1,
+        make_storage(p0, p1,
                      sig_a[q], sig_a[q + 1], v_a[q], v_a[q + 1],
                      E_a[q], E_a[q + 1], rho_a[q], rho_a[q + 1]);
-        s0p += 4; s1p += 4; p0 += 4; p1 += 4;
+        p0 += 4; p1 += 4;
       }
       if (q < QW) {
-        make_storage_one(s0p, s1p, p0, p1, sig_a[q], v_a[q], E_a[q], rho_a[q]);
+        make_storage_one(p0, p1, sig_a[q], v_a[q], E_a[q], rho_a[q]);
       }
     }
 

--- a/source/core/coding/ht_block_encoding_avx2.cpp
+++ b/source/core/coding/ht_block_encoding_avx2.cpp
@@ -60,7 +60,7 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
   #endif
   const __m256i vone      = _mm256_set1_epi32(1);
   const __m256 vscale     = _mm256_set1_ps(fscale);
-  const __m256i vsentinel = _mm256_set1_epi32(static_cast<int32_t>(0x80000000u));
+  const __m256i vsentinel = _mm256_set1_epi32(INT32_MIN);
   __m256i vor_val = _mm256_setzero_si256();
   for (uint16_t i = 0; i < static_cast<uint16_t>(height); ++i) {
     sprec_t *sp = this->band_buf + i * stride;
@@ -119,7 +119,7 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
         temp--;
         temp <<= 1;
         temp += static_cast<uint8_t>(sign >> 31);
-        temp |= static_cast<int32_t>(0x80000000u);
+        temp |= INT32_MIN;
       }
       dp[0] = temp;
       ++sp;

--- a/source/core/coding/ht_block_encoding_avx512.cpp
+++ b/source/core/coding/ht_block_encoding_avx512.cpp
@@ -58,17 +58,13 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
   const int32_t pshift = (refsegment) ? 1 : 0;
   const int32_t pLSB   = (refsegment) ? 1 : 1;
   #endif
-  const __m256i vone  = _mm256_set1_epi32(1);
-  const __m256 vscale = _mm256_set1_ps(fscale);
+  const __m256i vone      = _mm256_set1_epi32(1);
+  const __m256 vscale     = _mm256_set1_ps(fscale);
+  const __m256i vsentinel = _mm256_set1_epi32(static_cast<int32_t>(0x80000000u));
   __m256i vor_val = _mm256_setzero_si256();
   for (uint16_t i = 0; i < static_cast<uint16_t>(height); ++i) {
-    sprec_t *sp        = this->band_buf + i * stride;
-    int32_t *dp        = this->sample_buf + i * blksampl_stride;
-    size_t block_index = (i + 1U) * (blkstate_stride) + 1U;
-    uint8_t *dstblk    = block_states + block_index;
-  #if defined(ENABLE_SP_MR)
-    const __m256i vpLSB = _mm256_set1_epi32(pLSB);
-  #endif
+    sprec_t *sp = this->band_buf + i * stride;
+    int32_t *dp = this->sample_buf + i * blksampl_stride;
     int32_t len = static_cast<int32_t>(width);
     for (; len >= 16; len -= 16) {
       __m256i v0, v1;
@@ -84,14 +80,6 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
       __m256i s1 = _mm256_srli_epi32(v1, 31);
       v0         = _mm256_abs_epi32(v0);
       v1         = _mm256_abs_epi32(v1);
-  #if defined(ENABLE_SP_MR)
-      __m256i z0 = _mm256_and_si256(v0, vpLSB);  // only for SigProp and MagRef
-      __m256i z1 = _mm256_and_si256(v1, vpLSB);  // only for SigProp and MagRef
-
-      // Down-shift if other than HT Cleanup pass exists
-      v0 = _mm256_srai_epi32(v0, pshift);
-      v1 = _mm256_srai_epi32(v1, pshift);
-  #endif
       // Generate masks for sigma
       __m256i mask0 = _mm256_cmpgt_epi32(v0, _mm256_setzero_si256());
       __m256i mask1 = _mm256_cmpgt_epi32(v1, _mm256_setzero_si256());
@@ -108,28 +96,14 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
       v1            = _mm256_slli_epi32(v1, 1);
       v0            = _mm256_add_epi32(v0, _mm256_and_si256(s0, mask0));
       v1            = _mm256_add_epi32(v1, _mm256_and_si256(s1, mask1));
+      // Set sentinel bit 31 for significant samples
+      v0 = _mm256_or_si256(v0, _mm256_and_si256(mask0, vsentinel));
+      v1 = _mm256_or_si256(v1, _mm256_and_si256(mask1, vsentinel));
       // Store
       _mm256_storeu_si256((__m256i *)dp, v0);
       _mm256_storeu_si256((__m256i *)(dp + 8), v1);
       sp += 16;
       dp += 16;
-      // for Block states
-      v0 = _mm256_packs_epi32(vone0, vone1);  // re-use v0 as sigma
-      v0 = _mm256_permute4x64_epi64(v0, 0xD8);
-  #if defined(ENABLE_SP_MR)
-      vone0 = _mm256_packs_epi32(z0, z1);  // re-use vone0 as z
-      vone0 = _mm256_permute4x64_epi64(vone0, 0xD8);
-      vone1 = _mm256_packs_epi32(s0, s1);  // re-use vone1 as sign
-      vone1 = _mm256_permute4x64_epi64(vone1, 0xD8);
-      v0    = _mm256_or_si256(v0, _mm256_slli_epi16(vone0, SHIFT_SMAG));
-      v0    = _mm256_or_si256(v0, _mm256_slli_epi16(vone1, SHIFT_SSGN));
-  #endif
-      v0        = _mm256_packs_epi16(v0, v0);  // re-use vone0
-      v0        = _mm256_permute4x64_epi64(v0, 0xD8);
-      __m128i v = _mm256_extracti128_si256(v0, 0);
-      // _mm256_zeroupper(); // does not work on GCC, TODO: find a solution with __m128i v
-      _mm_storeu_si128((__m128i *)dstblk, v);
-      dstblk += 16;
     }
     for (; len > 0; --len) {
       int32_t temp;
@@ -138,26 +112,18 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
       else
         temp = static_cast<int32_t>(static_cast<float>(sp[0]) * fscale);
       uint32_t sign = static_cast<uint32_t>(temp) & 0x80000000;
-  #if defined(ENABLE_SP_MR)
-      dstblk[0] |= static_cast<uint8_t>(((temp & pLSB) & 1) << SHIFT_SMAG);
-      dstblk[0] |= static_cast<uint8_t>((sign >> 31) << SHIFT_SSGN);
-  #endif
       temp = (temp < 0) ? -temp : temp;
       temp &= 0x7FFFFFFF;
-  #if defined(ENABLE_SP_MR)
-      temp >>= pshift;
-  #endif
       if (temp) {
         or_val |= 1;
-        dstblk[0] |= 1;
         temp--;
         temp <<= 1;
         temp += static_cast<uint8_t>(sign >> 31);
+        temp |= static_cast<int32_t>(0x80000000u);
       }
       dp[0] = temp;
       ++sp;
       ++dp;
-      ++dstblk;
     }
     if (blksampl_stride > width)
       memset(dp, 0, (blksampl_stride - width) * sizeof(int32_t));
@@ -187,48 +153,45 @@ inline __m128i sse_lzcnt_epi32(__m128i v) {
   return v;
 }
 
-auto make_storage = [](const uint8_t *ssp0, const uint8_t *ssp1, const int32_t *sp0, const int32_t *sp1,
+auto make_storage = [](const int32_t *sp0, const int32_t *sp1,
                        __m128i &sig0, __m128i &sig1, __m128i &v0, __m128i &v1, __m128i &E0, __m128i &E1,
                        int32_t &rho0, int32_t &rho1) {
   // This function shall be called on the assumption that there are two quads
   const __m128i zero = _mm_setzero_si128();
-  __m128i t0         = _mm_set1_epi64x(*((int64_t *)ssp0));
-  __m128i t1         = _mm_set1_epi64x(*((int64_t *)ssp1));
-  __m128i t          = _mm_unpacklo_epi8(t0, t1);
-  __m128i v_u8_out   = _mm_and_si128(t, _mm_set1_epi8(1));
-  v_u8_out           = _mm_cmpgt_epi8(v_u8_out, zero);
-  sig0               = _mm_cvtepu8_epi32(v_u8_out);
-  sig1               = _mm_cvtepu8_epi32(_mm_srli_si128(v_u8_out, 4));
-  rho0               = _mm_movemask_epi8(_mm_packus_epi16(_mm_packus_epi32(sig0, zero), zero));
-  rho1               = _mm_movemask_epi8(_mm_packus_epi16(_mm_packus_epi32(sig1, zero), zero));
-
-  sig0 = _mm_cmpgt_epi32(sig0, zero);
-  sig1 = _mm_cmpgt_epi32(sig1, zero);
-
-  t0 = _mm_loadu_si128((__m128i *)sp0);
-  t1 = _mm_loadu_si128((__m128i *)sp1);
-  v0 = _mm_unpacklo_epi32(t0, t1);
-  v1 = _mm_unpackhi_epi32(t0, t1);
-
+  const __m128i mask = _mm_set1_epi32(0x7FFFFFFF);
+  __m128i t0   = _mm_loadu_si128((__m128i *)sp0);
+  __m128i t1   = _mm_loadu_si128((__m128i *)sp1);
+  __m128i raw0 = _mm_unpacklo_epi32(t0, t1);
+  __m128i raw1 = _mm_unpackhi_epi32(t0, t1);
+  // Derive sigma (0 or 1) from bit 31
+  __m128i sig0_01 = _mm_srli_epi32(raw0, 31);
+  __m128i sig1_01 = _mm_srli_epi32(raw1, 31);
+  // Compute rho from 0-or-1 sigma values: shift left by 7, pack to bytes, movemask
+  __m128i shift7 = _mm_set1_epi32(7);
+  rho0 = _mm_movemask_epi8(_mm_packus_epi16(_mm_packus_epi32(_mm_sllv_epi32(sig0_01, shift7), zero), zero));
+  rho1 = _mm_movemask_epi8(_mm_packus_epi16(_mm_packus_epi32(_mm_sllv_epi32(sig1_01, shift7), zero), zero));
+  // Full mask for downstream use (-1 or 0)
+  sig0 = _mm_srai_epi32(raw0, 31);
+  sig1 = _mm_srai_epi32(raw1, 31);
+  v0 = _mm_and_si128(raw0, mask);
+  v1 = _mm_and_si128(raw1, mask);
   t0 = _mm_sub_epi32(_mm_set1_epi32(32), sse_lzcnt_epi32(v0));
   E0 = _mm_and_si128(t0, sig0);
   t1 = _mm_sub_epi32(_mm_set1_epi32(32), sse_lzcnt_epi32(v1));
   E1 = _mm_and_si128(t1, sig1);
 };
 
-auto make_storage_one = [](const uint8_t *ssp0, const uint8_t *ssp1, const int32_t *sp0, const int32_t *sp1,
+auto make_storage_one = [](const int32_t *sp0, const int32_t *sp1,
                            __m128i &sig0, __m128i &v0, __m128i &E0, int32_t &rho0) {
-  sig0 = _mm_setr_epi32(ssp0[0] & 1, ssp1[0] & 1, ssp0[1] & 1, ssp1[1] & 1);
-
-  __m128i shift = _mm_setr_epi32(7, 7, 7, 7);
-  __m128i t0    = _mm_sllv_epi32(sig0, shift);
-  __m128i zero  = _mm_setzero_si128();
-  rho0          = _mm_movemask_epi8(_mm_packus_epi16(_mm_packus_epi32(t0, zero), zero));
-
-  v0 = _mm_setr_epi32(sp0[0], sp1[0], sp0[1], sp1[1]);
-
-  sig0 = _mm_cmpgt_epi32(sig0, zero);
-  t0   = _mm_sub_epi32(_mm_set1_epi32(32), sse_lzcnt_epi32(v0));
+  const __m128i zero = _mm_setzero_si128();
+  const __m128i mask = _mm_set1_epi32(0x7FFFFFFF);
+  __m128i raw0 = _mm_setr_epi32(sp0[0], sp1[0], sp0[1], sp1[1]);
+  __m128i sig0_01 = _mm_srli_epi32(raw0, 31);
+  __m128i shift7 = _mm_set1_epi32(7);
+  rho0 = _mm_movemask_epi8(_mm_packus_epi16(_mm_packus_epi32(_mm_sllv_epi32(sig0_01, shift7), zero), zero));
+  sig0 = _mm_srai_epi32(raw0, 31);
+  v0   = _mm_and_si128(raw0, mask);
+  __m128i t0 = _mm_sub_epi32(_mm_set1_epi32(32), sse_lzcnt_epi32(v0));
   E0   = _mm_and_si128(t0, sig0);
 };
 
@@ -352,10 +315,8 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
   /*******************************************************************************************************************/
   // Initial line-pair
   /*******************************************************************************************************************/
-  uint8_t *ssp0 = block->block_states + 1U * (block->blkstate_stride) + 1U;
-  uint8_t *ssp1 = ssp0 + block->blkstate_stride;
-  int32_t *sp0  = block->sample_buf;
-  int32_t *sp1  = sp0 + block->blksampl_stride;
+  int32_t *sp0 = block->sample_buf;
+  int32_t *sp1 = sp0 + block->blksampl_stride;
 
   // Stack-allocate Eline/rholine: bounded by max codeblock width (1024 → QW ≤ 512).
   // Zero exactly the used range (matches make_unique<int32_t[]> zero-initialization).
@@ -380,7 +341,7 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
   int32_t qx = QW;
   for (; qx >= 2; qx -= 2) {
     bool uoff_flag = true;
-    make_storage(ssp0, ssp1, sp0, sp1, sig0, sig1, v0, v1, E0, E1, rho0, rho1);
+    make_storage(sp0, sp1, sig0, sig1, v0, v1, E0, E1, rho0, rho1);
     // MEL encoding for the first quad
     if (context == 0) {
       MEL_encoder.encodeMEL((rho0 != 0));
@@ -477,13 +438,11 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
     _mm_storeu_si128((__m128i *)E_p, _mm_unpackhi_epi32(E0, E1));
     E_p += 4;
     // update pointer to line buffer
-    ssp0 += 4;
-    ssp1 += 4;
     sp0 += 4;
     sp1 += 4;
   }
   if (qx) {
-    make_storage_one(ssp0, ssp1, sp0, sp1, sig0, v0, E0, rho0);
+    make_storage_one(sp0, sp1, sig0, v0, E0, rho0);
     // MEL encoding for the first quad
     if (context == 0) {
       MEL_encoder.encodeMEL((rho0 != 0));
@@ -551,83 +510,25 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
     E_p   = Eline + 1;
     rho_p = rholine + 1;
 
-    ssp0 = block->block_states + (2U * qy + 1U) * (block->blkstate_stride) + 1U;
-    ssp1 = ssp0 + block->blkstate_stride;
-    sp0  = block->sample_buf + 2U * (qy * block->blksampl_stride);
-    sp1  = sp0 + block->blksampl_stride;
+    sp0 = block->sample_buf + 2U * (qy * block->blksampl_stride);
+    sp1 = sp0 + block->blksampl_stride;
 
     // ===== PHASE 1: Pre-compute rho/E/v/sig for ALL quads (AVX-512, 8 quads/iter) =====
     {
-      uint8_t *s0p = ssp0, *s1p = ssp1;
       int32_t *p0 = sp0, *p1 = sp1;
       int32_t q = 0;
 #ifdef __AVX512CD__
       // Permutation index for interleaving two __m512i of 16 columns from row0/row1
       // into quad order: [r0c0,r1c0,r0c1,r1c1] for 4 quads per output register.
-      // unpacklo gives: [r0[0],r1[0],r0[1],r1[1] | r0[4],r1[4],r0[5],r1[5] | ...]
-      // unpackhi gives: [r0[2],r1[2],r0[3],r1[3] | r0[6],r1[6],r0[7],r1[7] | ...]
-      // We need quads in order: q0=[c0,c1], q1=[c2,c3], q2=[c4,c5], ...
-      // So output0 = {lo_lane0, hi_lane0, lo_lane1, hi_lane1} = quads 0,1,2,3
-      // output1 = {lo_lane2, hi_lane2, lo_lane3, hi_lane3} = quads 4,5,6,7
       const __m512i perm_lo = _mm512_setr_epi32(
           0,1,2,3, 16,17,18,19, 4,5,6,7, 20,21,22,23);
       const __m512i perm_hi = _mm512_setr_epi32(
           8,9,10,11, 24,25,26,27, 12,13,14,15, 28,29,30,31);
       const __m512i V32 = _mm512_set1_epi32(32);
+      const __m512i vmask31 = _mm512_set1_epi32(0x7FFFFFFF);
 
       for (; q + 7 < QW; q += 8) {
-        // --- Significance from block_states (16 bytes per row) ---
-        // Load 16 uint8 from each row, AND with 1 to extract sigma bit
-        __m128i st0_raw = _mm_loadu_si128(reinterpret_cast<const __m128i *>(s0p));
-        __m128i st1_raw = _mm_loadu_si128(reinterpret_cast<const __m128i *>(s1p));
-        __m128i ones_8  = _mm_set1_epi8(1);
-        __m128i st0     = _mm_and_si128(st0_raw, ones_8);  // sig row0[0..15]
-        __m128i st1     = _mm_and_si128(st1_raw, ones_8);  // sig row1[0..15]
-
-        // Compute rho for 8 quads from 16 columns:
-        // rho[q] = sig_r0[2q] | (sig_r1[2q] << 1) | (sig_r0[2q+1] << 2) | (sig_r1[2q+1] << 3)
-        // Deinterleave even/odd bytes:
-        // even: positions 0,2,4,...,14 → sig_r0_even[0..7], sig_r1_even[0..7]
-        // odd:  positions 1,3,5,...,15 → sig_r0_odd[0..7], sig_r1_odd[0..7]
-        const __m128i shuf_even = _mm_setr_epi8(0,2,4,6,8,10,12,14, -1,-1,-1,-1,-1,-1,-1,-1);
-        const __m128i shuf_odd  = _mm_setr_epi8(1,3,5,7,9,11,13,15, -1,-1,-1,-1,-1,-1,-1,-1);
-        __m128i s0_even = _mm_shuffle_epi8(st0, shuf_even);  // row0 even cols
-        __m128i s0_odd  = _mm_shuffle_epi8(st0, shuf_odd);   // row0 odd cols
-        __m128i s1_even = _mm_shuffle_epi8(st1, shuf_even);  // row1 even cols
-        __m128i s1_odd  = _mm_shuffle_epi8(st1, shuf_odd);   // row1 odd cols
-
-        // rho = s0_even | (s1_even << 1) | (s0_odd << 2) | (s1_odd << 3)
-        // All values are 0 or 1, so shifts within byte are safe
-        __m128i rho_bytes = _mm_or_si128(
-            _mm_or_si128(s0_even, _mm_slli_epi16(s1_even, 1)),
-            _mm_or_si128(_mm_slli_epi16(s0_odd, 2), _mm_slli_epi16(s1_odd, 3)));
-        // rho_bytes low 8 bytes contain rho[0..7] as uint8 (values 0-15)
-        // Zero-extend to int32 and store
-        __m256i rho_32 = _mm256_cvtepu8_epi32(rho_bytes);
-        _mm256_storeu_si256(reinterpret_cast<__m256i *>(rho_a + q), rho_32);
-
-        // --- Significance masks (int32, 0 or -1) in quad order ---
-        // Target per-quad: [r0c0, r1c0, r0c1, r1c1]
-        // Build pairs: even_pairs=[s0e[0],s1e[0], s0e[1],s1e[1],...] (16-bit chunks)
-        //              odd_pairs =[s0o[0],s1o[0], s0o[1],s1o[1],...]
-        // Then unpack at 16-bit to interleave pairs:
-        //   [s0e[0],s1e[0], s0o[0],s1o[0], ...] = [r0c0,r1c0,r0c1,r1c1, ...]
-        __m128i even_pairs = _mm_unpacklo_epi8(s0_even, s1_even);
-        __m128i odd_pairs  = _mm_unpacklo_epi8(s0_odd, s1_odd);
-        __m128i sig_lo_bytes = _mm_unpacklo_epi16(even_pairs, odd_pairs);  // quads 0-3
-        __m128i sig_hi_bytes = _mm_unpackhi_epi16(even_pairs, odd_pairs);  // quads 4-7
-
-        // Expand bytes (0 or 1) to int32 sign-extended masks (0 or -1)
-        __m512i sig_lo = _mm512_cvtepi8_epi32(sig_lo_bytes);
-        sig_lo = _mm512_srai_epi32(_mm512_slli_epi32(sig_lo, 31), 31);
-
-        __m512i sig_hi = _mm512_cvtepi8_epi32(sig_hi_bytes);
-        sig_hi = _mm512_srai_epi32(_mm512_slli_epi32(sig_hi, 31), 31);
-
-        _mm512_storeu_si512(sig_flat + q * 4, sig_lo);
-        _mm512_storeu_si512(sig_flat + q * 4 + 16, sig_hi);
-
-        // --- Sample values in quad order ---
+        // --- Sample values in quad order, derive sigma from bit 31 ---
         __m512i row0 = _mm512_loadu_si512(p0);  // sp0[0..15]
         __m512i row1 = _mm512_loadu_si512(p1);  // sp1[0..15]
 
@@ -636,11 +537,32 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
         __m512i hi = _mm512_unpackhi_epi32(row0, row1);
 
         // Permute to get consecutive quads:
-        __m512i v_q0123 = _mm512_permutex2var_epi32(lo, perm_lo, hi);  // quads 0-3
-        __m512i v_q4567 = _mm512_permutex2var_epi32(lo, perm_hi, hi);  // quads 4-7
+        __m512i raw_q0123 = _mm512_permutex2var_epi32(lo, perm_lo, hi);  // quads 0-3
+        __m512i raw_q4567 = _mm512_permutex2var_epi32(lo, perm_hi, hi);  // quads 4-7
 
+        // Derive sigma from bit 31
+        __m512i sig_lo = _mm512_srai_epi32(raw_q0123, 31);
+        __m512i sig_hi = _mm512_srai_epi32(raw_q4567, 31);
+
+        // Mask to get clean v values
+        __m512i v_q0123 = _mm512_and_epi32(raw_q0123, vmask31);
+        __m512i v_q4567 = _mm512_and_epi32(raw_q4567, vmask31);
+
+        _mm512_storeu_si512(sig_flat + q * 4, sig_lo);
+        _mm512_storeu_si512(sig_flat + q * 4 + 16, sig_hi);
         _mm512_storeu_si512(v_flat + q * 4, v_q0123);
         _mm512_storeu_si512(v_flat + q * 4 + 16, v_q4567);
+
+        // Compute rho from sigma masks (each lane is 0 or -1)
+        // Extract per-quad rho: for each quad of 4 lanes, rho = sum of (sig>>31)&1 in positional bits
+        // sig_lo has 16 int32 lanes = 4 quads; extract bit 0 of negated sig (i.e. 1 where significant)
+        __mmask16 sig_lo_mask = _mm512_movepi32_mask(raw_q0123);  // bit i set if lane i has bit 31 set
+        __mmask16 sig_hi_mask = _mm512_movepi32_mask(raw_q4567);
+        // Each quad occupies 4 consecutive bits: quad0 = bits[0..3], quad1 = bits[4..7], ...
+        for (int i = 0; i < 4; ++i) {
+          rho_a[q + i]     = (sig_lo_mask >> (i * 4)) & 0xF;
+          rho_a[q + 4 + i] = (sig_hi_mask >> (i * 4)) & 0xF;
+        }
 
         // --- E = (32 - lzcnt(v)) & sig ---
         __m512i lz_lo = _mm512_lzcnt_epi32(v_q0123);
@@ -651,18 +573,18 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
         _mm512_storeu_si512(E_flat + q * 4, E_lo);
         _mm512_storeu_si512(E_flat + q * 4 + 16, E_hi);
 
-        s0p += 16; s1p += 16; p0 += 16; p1 += 16;
+        p0 += 16; p1 += 16;
       }
 #endif  // __AVX512CD__
       // Scalar tail for remaining quads
       for (; q + 1 < QW; q += 2) {
-        make_storage(s0p, s1p, p0, p1,
+        make_storage(p0, p1,
                      sig_a[q], sig_a[q + 1], v_a[q], v_a[q + 1],
                      E_a[q], E_a[q + 1], rho_a[q], rho_a[q + 1]);
-        s0p += 4; s1p += 4; p0 += 4; p1 += 4;
+        p0 += 4; p1 += 4;
       }
       if (q < QW) {
-        make_storage_one(s0p, s1p, p0, p1, sig_a[q], v_a[q], E_a[q], rho_a[q]);
+        make_storage_one(p0, p1, sig_a[q], v_a[q], E_a[q], rho_a[q]);
       }
     }
 

--- a/source/core/coding/ht_block_encoding_avx512.cpp
+++ b/source/core/coding/ht_block_encoding_avx512.cpp
@@ -556,8 +556,9 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
         // Compute rho from sigma masks (each lane is 0 or -1)
         // Extract per-quad rho: for each quad of 4 lanes, rho = sum of (sig>>31)&1 in positional bits
         // sig_lo has 16 int32 lanes = 4 quads; extract bit 0 of negated sig (i.e. 1 where significant)
-        __mmask16 sig_lo_mask = _mm512_movepi32_mask(raw_q0123);  // bit i set if lane i has bit 31 set
-        __mmask16 sig_hi_mask = _mm512_movepi32_mask(raw_q4567);
+        const __m512i vz = _mm512_setzero_si512();
+        __mmask16 sig_lo_mask = _mm512_cmpgt_epi32_mask(vz, raw_q0123);
+        __mmask16 sig_hi_mask = _mm512_cmpgt_epi32_mask(vz, raw_q4567);
         // Each quad occupies 4 consecutive bits: quad0 = bits[0..3], quad1 = bits[4..7], ...
         for (int i = 0; i < 4; ++i) {
           rho_a[q + i]     = (sig_lo_mask >> (i * 4)) & 0xF;

--- a/source/core/coding/ht_block_encoding_avx512.cpp
+++ b/source/core/coding/ht_block_encoding_avx512.cpp
@@ -60,7 +60,7 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
   #endif
   const __m256i vone      = _mm256_set1_epi32(1);
   const __m256 vscale     = _mm256_set1_ps(fscale);
-  const __m256i vsentinel = _mm256_set1_epi32(static_cast<int32_t>(0x80000000u));
+  const __m256i vsentinel = _mm256_set1_epi32(INT32_MIN);
   __m256i vor_val = _mm256_setzero_si256();
   for (uint16_t i = 0; i < static_cast<uint16_t>(height); ++i) {
     sprec_t *sp = this->band_buf + i * stride;
@@ -119,7 +119,7 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
         temp--;
         temp <<= 1;
         temp += static_cast<uint8_t>(sign >> 31);
-        temp |= static_cast<int32_t>(0x80000000u);
+        temp |= INT32_MIN;
       }
       dp[0] = temp;
       ++sp;

--- a/source/core/coding/ht_block_encoding_neon.cpp
+++ b/source/core/coding/ht_block_encoding_neon.cpp
@@ -55,7 +55,7 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
   #endif
   const float32x4_t vscale    = vdupq_n_f32(fscale);
   const int32x4_t vone        = vdupq_n_s32(1);
-  const int32x4_t vsentinel   = vdupq_n_s32(static_cast<int32_t>(0x80000000u));
+  const int32x4_t vsentinel   = vdupq_n_s32(INT32_MIN);
   int32x4_t vorval            = vdupq_n_s32(0);
   for (uint16_t i = 0; i < static_cast<uint16_t>(height); ++i) {
     sprec_t *sp = this->band_buf + i * stride;
@@ -113,7 +113,7 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
         temp--;
         temp <<= 1;
         temp += static_cast<uint8_t>(sign >> 31);
-        temp |= static_cast<int32_t>(0x80000000u);
+        temp |= INT32_MIN;
       }
       dp[0] = temp;
       ++sp;

--- a/source/core/coding/ht_block_encoding_neon.cpp
+++ b/source/core/coding/ht_block_encoding_neon.cpp
@@ -53,16 +53,13 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
   const int32_t pshift = (refsegment) ? 1 : 0;
   const int32_t pLSB   = (refsegment) ? 1 : 1;
   #endif
-  float32x4_t vscale = vdupq_n_f32(fscale);
-  int32x4_t vorval   = vdupq_n_s32(0);
+  const float32x4_t vscale    = vdupq_n_f32(fscale);
+  const int32x4_t vone        = vdupq_n_s32(1);
+  const int32x4_t vsentinel   = vdupq_n_s32(static_cast<int32_t>(0x80000000u));
+  int32x4_t vorval            = vdupq_n_s32(0);
   for (uint16_t i = 0; i < static_cast<uint16_t>(height); ++i) {
-    sprec_t *sp        = this->band_buf + i * stride;
-    int32_t *dp        = this->sample_buf + i * blksampl_stride;
-    size_t block_index = (i + 1U) * (blkstate_stride) + 1U;
-    uint8_t *dstblk    = block_states + block_index;
-  #if defined(ENABLE_SP_MR)
-    int32x4_t vpLSB = vdupq_n_s32(pLSB);
-  #endif
+    sprec_t *sp = this->band_buf + i * stride;
+    int32_t *dp = this->sample_buf + i * blksampl_stride;
     int16_t len = static_cast<int16_t>(width);
     for (; len >= 8; len -= 8) {
       int32x4_t v0, v1;
@@ -74,45 +71,34 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
         v1 = vcvtq_s32_f32(vmulq_f32(vld1q_f32(sp + 4), vscale));
       }
       // Take sign bit
-      int32x4_t s0 = vshrq_n_u32(v0, 31);
-      int32x4_t s1 = vshrq_n_u32(v1, 31);
+      int32x4_t s0 = vreinterpretq_s32_u32(vshrq_n_u32(vreinterpretq_u32_s32(v0), 31));
+      int32x4_t s1 = vreinterpretq_s32_u32(vshrq_n_u32(vreinterpretq_u32_s32(v1), 31));
       // Absolute value
       v0 = vabsq_s32(v0);
       v1 = vabsq_s32(v1);
-  #if defined(ENABLE_SP_MR)
-      int32x4_t z0 = vandq_s32(v0, vpLSB);
-      int32x4_t z1 = vandq_s32(v1, vpLSB);
-      v0 = v0 >> pshift;
-      v1 = v1 >> pshift;
-  #endif
-      uint8x8_t vblkstate = vdup_n_u8(0);
-      vblkstate = vorr_u8(
-          vblkstate,
-          vmovn_s16(vandq_s16(vcgtzq_s16(vcombine_s16(vqmovn_s32(v0), vqmovn_s32(v1))), vdupq_n_s16(1))));
-  #if defined(ENABLE_SP_MR)
-      vblkstate |= vmovn_s16(vshlq_n_s16(vcombine_s16(vmovn_s32(z0), vmovn_s32(z1)), SHIFT_SMAG));
-      vblkstate |= vmovn_s16(vshlq_n_s16(vcombine_s16(vmovn_s32(s0), vmovn_s32(s1)), SHIFT_SSGN));
-  #endif
-      vst1_u8(dstblk, vblkstate);
-      dstblk += 8;
-  #if defined(ENABLE_SP_MR)
-      s0 = vandq_s32(vcgtzq_s32(v0), s0);
-      s1 = vandq_s32(vcgtzq_s32(v1), s1);
-  #endif
-      vorval = vorrq_s32(vorval, v0);
-      vorval = vorrq_s32(vorval, v1);
-      v0 = vqsubq_u32(v0, vdupq_n_u32(1));
-      v1 = vqsubq_u32(v1, vdupq_n_u32(1));
+      // Generate nonzero masks
+      uint32x4_t mask0 = vcgtq_s32(v0, vdupq_n_s32(0));
+      uint32x4_t mask1 = vcgtq_s32(v1, vdupq_n_s32(0));
+      // Accumulate or_val
+      vorval = vorrq_s32(vorval, vreinterpretq_s32_u32(mask0));
+      vorval = vorrq_s32(vorval, vreinterpretq_s32_u32(mask1));
+      // Convert to MagSgn form: (abs-1)<<1 | sign, only for nonzero
+      int32x4_t vone0 = vandq_s32(vreinterpretq_s32_u32(mask0), vone);
+      int32x4_t vone1 = vandq_s32(vreinterpretq_s32_u32(mask1), vone);
+      v0 = vsubq_s32(v0, vone0);
+      v1 = vsubq_s32(v1, vone1);
       v0 = vshlq_n_s32(v0, 1);
       v1 = vshlq_n_s32(v1, 1);
-      v0 = vaddq_s32(v0, s0);
-      v1 = vaddq_s32(v1, s1);
+      v0 = vaddq_s32(v0, vandq_s32(s0, vreinterpretq_s32_u32(mask0)));
+      v1 = vaddq_s32(v1, vandq_s32(s1, vreinterpretq_s32_u32(mask1)));
+      // Set sentinel bit 31 for significant samples
+      v0 = vorrq_s32(v0, vandq_s32(vreinterpretq_s32_u32(mask0), vsentinel));
+      v1 = vorrq_s32(v1, vandq_s32(vreinterpretq_s32_u32(mask1), vsentinel));
       vst1q_s32(dp, v0);
       vst1q_s32(dp + 4, v1);
       sp += 8;
       dp += 8;
     }
-    or_val |= static_cast<unsigned int>(vmaxvq_s32(vorval));
     for (; len > 0; --len) {
       int32_t temp;
       if (lossless)
@@ -120,27 +106,18 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
       else
         temp = static_cast<int32_t>(static_cast<float>(sp[0]) * fscale);
       uint32_t sign = static_cast<uint32_t>(temp) & 0x80000000;
-  #if defined(ENABLE_SP_MR)
-      dstblk[0] |= static_cast<uint8_t>(((temp & pLSB) & 1) << SHIFT_SMAG);
-      dstblk[0] |= static_cast<uint8_t>((sign >> 31) << SHIFT_SSGN);
-  #endif
       temp = (temp < 0) ? -temp : temp;
       temp &= 0x7FFFFFFF;
-  #if defined(ENABLE_SP_MR)
-      temp >>= pshift;
-      sign = (temp > 0) ? sign : 0;
-  #endif
       if (temp) {
         or_val |= 1;
-        dstblk[0] |= 1;
         temp--;
         temp <<= 1;
         temp += static_cast<uint8_t>(sign >> 31);
+        temp |= static_cast<int32_t>(0x80000000u);
       }
       dp[0] = temp;
       ++sp;
       ++dp;
-      ++dstblk;
     }
     if (blksampl_stride > width)
       memset(dp, 0, (blksampl_stride - width) * sizeof(int32_t));
@@ -148,6 +125,9 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
   const uint32_t QHx2 = (height + 7U) & ~7U;
   for (uint32_t i = height; i < QHx2; ++i)
     memset(this->sample_buf + i * blksampl_stride, 0, blksampl_stride * sizeof(int32_t));
+  if (vmaxvq_u32(vreinterpretq_u32_s32(vorval)) != 0) {
+    or_val |= 1;
+  }
 }
 
 /********************************************************************************
@@ -203,57 +183,54 @@ void state_MEL_enc::termMEL() {
 /********************************************************************************
  * HT cleanup encoding: helper functions
  *******************************************************************************/
-auto make_storage = [](uint8_t *ssp0, uint8_t *ssp1, int32_t *sp0, int32_t *sp1, int32x4_t &sig0,
-                       int32x4_t &sig1, int32x4_t &v0, int32x4_t &v1, int32x4_t &E0, int32x4_t &E1,
+auto make_storage = [](int32_t *sp0, int32_t *sp1, int32x4_t &sig0, int32x4_t &sig1,
+                       int32x4_t &v0, int32x4_t &v1, int32x4_t &E0, int32x4_t &E1,
                        int32_t &rho0, int32_t &rho1) {
   // This function shall be called on the assumption that there are two quads
-  int32x4_t t0 = vld1q_s32(sp0);
-  int32x4_t t1 = vld1q_s32(sp1);
-  v0           = vzip1q_s32(t0, t1);
-  v1           = vzip2q_s32(t0, t1);
-  //  int32x4x2_t v = vzipq_s32(vld1q_s32(sp0), vld1q_s32(sp1));
-  //  v0            = v.val[0];
-  //  v1            = v.val[1];
-
-  uint8x8_t sig01 = vand_u8(vzip1_u8(vld1_u8(ssp0), vld1_u8(ssp1)), vdup_n_u8(1));
-  sig0            = vcgtzq_s32(vmovl_u16(vget_low_u16(vmovl_u8(sig01))));
-  sig1            = vcgtzq_s32(vmovl_u16(vget_high_u16(vmovl_u8(sig01))));
-  // int8x8_t shift  = {0, 1, 2, 3, 4, 5, 6, 7};
-  int8x8_t shift = vcreate_s8(0x0706050403020100);
-  uint8_t rho01  = vaddv_u8(vshl_u8(sig01, shift));
-  rho0           = rho01 & 0xF;
-  rho1           = rho01 >> 4;
-
-  E0 = vandq_s32(vsubq_u32(vdupq_n_s32(32), vclzq_u32(v0)), sig0);
-  E1 = vandq_s32(vsubq_u32(vdupq_n_s32(32), vclzq_u32(v1)), sig1);
+  const int32x4_t mask31 = vdupq_n_s32(0x7FFFFFFF);
+  int32x4_t t0   = vld1q_s32(sp0);
+  int32x4_t t1   = vld1q_s32(sp1);
+  int32x4_t raw0 = vzip1q_s32(t0, t1);
+  int32x4_t raw1 = vzip2q_s32(t0, t1);
+  // Derive sigma from sentinel bit 31: arithmetic shift right gives -1 or 0
+  sig0 = vshrq_n_s32(raw0, 31);
+  sig1 = vshrq_n_s32(raw1, 31);
+  // Strip sentinel to get MagSgn value
+  v0 = vandq_s32(raw0, mask31);
+  v1 = vandq_s32(raw1, mask31);
+  // rho from sigma bits (negate -1→1, 0→0)
+  uint32x4_t sig0_u = vreinterpretq_u32_s32(vnegq_s32(sig0));
+  uint32x4_t sig1_u = vreinterpretq_u32_s32(vnegq_s32(sig1));
+  rho0 = vgetq_lane_u32(sig0_u, 0) | (vgetq_lane_u32(sig0_u, 1) << 1)
+       | (vgetq_lane_u32(sig0_u, 2) << 2) | (vgetq_lane_u32(sig0_u, 3) << 3);
+  rho1 = vgetq_lane_u32(sig1_u, 0) | (vgetq_lane_u32(sig1_u, 1) << 1)
+       | (vgetq_lane_u32(sig1_u, 2) << 2) | (vgetq_lane_u32(sig1_u, 3) << 3);
+  // E = (32 - clz(v)) & sig
+  E0 = vandq_s32(vsubq_s32(vdupq_n_s32(32), vreinterpretq_s32_u32(vclzq_u32(vreinterpretq_u32_s32(v0)))),
+                  sig0);
+  E1 = vandq_s32(vsubq_s32(vdupq_n_s32(32), vreinterpretq_s32_u32(vclzq_u32(vreinterpretq_u32_s32(v1)))),
+                  sig1);
 };
 
-auto make_storage_one = [](uint8_t *ssp0, uint8_t *ssp1, int32_t *sp0, int32_t *sp1, int32x4_t &sig0,
+auto make_storage_one = [](int32_t *sp0, int32_t *sp1, int32x4_t &sig0,
                            int32x4_t &v0, int32x4_t &E0, int32_t &rho0) {
-  //  v0 = {sp0[0], sp1[0], sp0[1], sp1[1]};
-  v0 = vsetq_lane_s32(sp0[0], v0, 0);
-  v0 = vsetq_lane_s32(sp1[0], v0, 1);
-  v0 = vsetq_lane_s32(sp0[1], v0, 2);
-  v0 = vsetq_lane_s32(sp1[1], v0, 3);
-
-  //  int32x4_t sig   = {ssp0[0] & 1, ssp1[0] & 1, ssp0[1] & 1, ssp1[1] & 1};
-  //  int32x4_t shift = {0, 1, 2, 3};
-  int32x4_t sig   = {0};
-  sig             = vsetq_lane_s32(ssp0[0] & 1, sig, 0);
-  sig             = vsetq_lane_s32(ssp1[0] & 1, sig, 1);
-  sig             = vsetq_lane_s32(ssp0[1] & 1, sig, 2);
-  sig             = vsetq_lane_s32(ssp1[1] & 1, sig, 3);
-  int32x4_t shift = {0};
-  shift           = vsetq_lane_s32(0, shift, 0);
-  shift           = vsetq_lane_s32(1, shift, 1);
-  shift           = vsetq_lane_s32(2, shift, 2);
-  shift           = vsetq_lane_s32(3, shift, 3);
-
-  uint32x4_t vtmp = vshlq_s32(sig, shift);
-  rho0            = vaddvq_u32(vtmp) & 0xF;
-  sig0            = vcgtzq_s32(sig);
-
-  E0 = vandq_s32(vsubq_u32(vdupq_n_s32(32), vclzq_u32(v0)), sig0);
+  const int32x4_t mask31 = vdupq_n_s32(0x7FFFFFFF);
+  int32x4_t raw0 = {0};
+  raw0 = vsetq_lane_s32(sp0[0], raw0, 0);
+  raw0 = vsetq_lane_s32(sp1[0], raw0, 1);
+  raw0 = vsetq_lane_s32(sp0[1], raw0, 2);
+  raw0 = vsetq_lane_s32(sp1[1], raw0, 3);
+  // Derive sigma from sentinel bit 31
+  sig0 = vshrq_n_s32(raw0, 31);
+  // Strip sentinel
+  v0 = vandq_s32(raw0, mask31);
+  // rho from sigma
+  uint32x4_t sig0_u = vreinterpretq_u32_s32(vnegq_s32(sig0));
+  rho0 = vgetq_lane_u32(sig0_u, 0) | (vgetq_lane_u32(sig0_u, 1) << 1)
+       | (vgetq_lane_u32(sig0_u, 2) << 2) | (vgetq_lane_u32(sig0_u, 3) << 3);
+  // E = (32 - clz(v)) & sig
+  E0 = vandq_s32(
+      vsubq_s32(vdupq_n_s32(32), vreinterpretq_s32_u32(vclzq_u32(vreinterpretq_u32_s32(v0)))), sig0);
 };
 
 // joint termination of MEL and VLC
@@ -380,16 +357,14 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
   /*******************************************************************************************************************/
   // Initial line-pair
   /*******************************************************************************************************************/
-  uint8_t *ssp0 = block->block_states + 1U * (block->blkstate_stride) + 1U;
-  uint8_t *ssp1 = ssp0 + block->blkstate_stride;
-  int32_t *sp0  = block->sample_buf;
-  int32_t *sp1  = sp0 + block->blksampl_stride;
+  int32_t *sp0 = block->sample_buf;
+  int32_t *sp1 = sp0 + block->blksampl_stride;
   uint32_t qx;
   for (qx = QW; qx >= 2; qx -= 2) {
     bool uoff_flag = true;
 
     // MAKE_STORAGE()
-    make_storage(ssp0, ssp1, sp0, sp1, sig0, sig1, v0, v1, E0, E1, rho0, rho1);
+    make_storage(sp0, sp1, sig0, sig1, v0, v1, E0, E1, rho0, rho1);
     // update Eline
     vst1q_s32(E_p, vuzp2q_s32(E0, E1));  // vzip2q_s32(vzip1q_s32(E0, E1), vzip2q_s32(E0, E1)));
     E_p += 4;
@@ -481,13 +456,11 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
     *rho_p++ = rho0;
     *rho_p++ = rho1;
     // update pointer to line buffer
-    ssp0 += 4;
-    ssp1 += 4;
     sp0 += 4;
     sp1 += 4;
   }
   if (qx) {
-    make_storage_one(ssp0, ssp1, sp0, sp1, sig0, v0, E0, rho0);
+    make_storage_one(sp0, sp1, sig0, v0, E0, rho0);
     *E_p++ = vgetq_lane_s32(E0, 1);
     *E_p++ = vgetq_lane_s32(E0, 3);
 
@@ -547,12 +520,10 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
     context |= ((rho_p[-1] & 0x8) << 5) | ((rho_p[0] & 0x2) << 7);  // (nw | n) << 8
     context |= ((rho_p[0] & 0x8) << 7) | ((rho_p[1] & 0x2) << 9);   // (ne | nf) << 10
 
-    ssp0 = block->block_states + (2U * qy + 1U) * (block->blkstate_stride) + 1U;
-    ssp1 = ssp0 + block->blkstate_stride;
-    sp0  = block->sample_buf + 2U * (qy * block->blksampl_stride);
-    sp1  = sp0 + block->blksampl_stride;
+    sp0 = block->sample_buf + 2U * (qy * block->blksampl_stride);
+    sp1 = sp0 + block->blksampl_stride;
     for (qx = QW; qx >= 2; qx -= 2) {
-      make_storage(ssp0, ssp1, sp0, sp1, sig0, sig1, v0, v1, E0, E1, rho0, rho1);
+      make_storage(sp0, sp1, sig0, sig1, v0, v1, E0, E1, rho0, rho1);
       // MEL encoding of the first quad
       if (context == 0) {
         MEL_encoder.encodeMEL((rho0 != 0));
@@ -634,13 +605,11 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
       *rho_p++ = rho0;
       *rho_p++ = rho1;
       // update pointer to line buffer
-      ssp0 += 4;
-      ssp1 += 4;
       sp0 += 4;
       sp1 += 4;
     }
     if (qx) {
-      make_storage_one(ssp0, ssp1, sp0, sp1, sig0, v0, E0, rho0);
+      make_storage_one(sp0, sp1, sig0, v0, E0, rho0);
       *E_p++ = vgetq_lane_s32(E0, 1);
       *E_p++ = vgetq_lane_s32(E0, 3);
 

--- a/source/core/coding/ht_block_encoding_wasm.cpp
+++ b/source/core/coding/ht_block_encoding_wasm.cpp
@@ -100,7 +100,7 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
 
   const v128_t vscale    = wasm_f32x4_splat(fscale);
   const v128_t vone      = wasm_i32x4_const_splat(1);
-  const v128_t vsentinel = wasm_i32x4_const_splat(static_cast<int32_t>(0x80000000u));
+  const v128_t vsentinel = wasm_i32x4_const_splat(INT32_MIN);
   v128_t vorval          = wasm_i32x4_const_splat(0);
   for (uint16_t i = 0; i < static_cast<uint16_t>(height); ++i) {
     sprec_t *sp = this->band_buf + i * stride;
@@ -156,7 +156,7 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
         temp--;
         temp <<= 1;
         temp += static_cast<uint8_t>(sign >> 31);
-        temp |= static_cast<int32_t>(0x80000000u);
+        temp |= INT32_MIN;
       }
       dp[0] = temp;
       ++sp;

--- a/source/core/coding/ht_block_encoding_wasm.cpp
+++ b/source/core/coding/ht_block_encoding_wasm.cpp
@@ -98,14 +98,14 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
     fscale /= (1 << (FRACBITS));
   }
 
-  v128_t vscale         = wasm_f32x4_splat(fscale);
-  v128_t vorval         = wasm_i32x4_const_splat(0);
+  const v128_t vscale    = wasm_f32x4_splat(fscale);
+  const v128_t vone      = wasm_i32x4_const_splat(1);
+  const v128_t vsentinel = wasm_i32x4_const_splat(static_cast<int32_t>(0x80000000u));
+  v128_t vorval          = wasm_i32x4_const_splat(0);
   for (uint16_t i = 0; i < static_cast<uint16_t>(height); ++i) {
-    sprec_t *sp        = this->band_buf + i * stride;
-    int32_t *dp        = this->sample_buf + i * blksampl_stride;
-    size_t block_index = (i + 1U) * (blkstate_stride) + 1U;
-    uint8_t *dstblk    = block_states + block_index;
-    int16_t len        = static_cast<int16_t>(width);
+    sprec_t *sp = this->band_buf + i * stride;
+    int32_t *dp = this->sample_buf + i * blksampl_stride;
+    int16_t len = static_cast<int16_t>(width);
     for (; len >= 8; len -= 8) {
       v128_t v0, v1;
       if (lossless) {
@@ -119,49 +119,48 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
       v128_t s1 = wasm_u32x4_shr(v1, 31);
       v0 = wasm_i32x4_abs(v0);
       v1 = wasm_i32x4_abs(v1);
-      v128_t narrow0     = wasm_i16x8_narrow_i32x4(v0, v0);
-      v128_t narrow1     = wasm_i16x8_narrow_i32x4(v1, v1);
-      v128_t combined16  = wasm_i8x16_shuffle(narrow0, narrow1, 0, 1, 2, 3, 4, 5, 6, 7, 16, 17, 18, 19, 20,
-                                             21, 22, 23);
-      v128_t gt0_mask    = wasm_i16x8_gt(combined16, wasm_i16x8_const_splat(0));
-      v128_t vblkstate_v = wasm_v128_and(gt0_mask, wasm_i16x8_const_splat(1));
-      v128_t narrow8     = wasm_i8x16_narrow_i16x8(vblkstate_v, vblkstate_v);
-      *(uint64_t *)dstblk = (uint64_t)wasm_i64x2_extract_lane(narrow8, 0);
-      dstblk += 8;
-      vorval = wasm_v128_or(vorval, v0);
-      vorval = wasm_v128_or(vorval, v1);
-      v0 = wasm_u32x4_qsub(v0, wasm_i32x4_const_splat(1));
-      v1 = wasm_u32x4_qsub(v1, wasm_i32x4_const_splat(1));
+      // Generate nonzero masks
+      v128_t mask0 = wasm_i32x4_gt(v0, wasm_i32x4_const_splat(0));
+      v128_t mask1 = wasm_i32x4_gt(v1, wasm_i32x4_const_splat(0));
+      // Accumulate or_val
+      vorval = wasm_v128_or(vorval, mask0);
+      vorval = wasm_v128_or(vorval, mask1);
+      // Convert to MagSgn form: (abs-1)<<1 | sign, only for nonzero
+      v128_t vone0 = wasm_v128_and(mask0, vone);
+      v128_t vone1 = wasm_v128_and(mask1, vone);
+      v0 = wasm_i32x4_sub(v0, vone0);
+      v1 = wasm_i32x4_sub(v1, vone1);
       v0 = wasm_i32x4_shl(v0, 1);
       v1 = wasm_i32x4_shl(v1, 1);
-      v0 = wasm_i32x4_add(v0, s0);
-      v1 = wasm_i32x4_add(v1, s1);
+      v0 = wasm_i32x4_add(v0, wasm_v128_and(s0, mask0));
+      v1 = wasm_i32x4_add(v1, wasm_v128_and(s1, mask1));
+      // Set sentinel bit 31 for significant samples
+      v0 = wasm_v128_or(v0, wasm_v128_and(mask0, vsentinel));
+      v1 = wasm_v128_or(v1, wasm_v128_and(mask1, vsentinel));
       wasm_v128_store(dp, v0);
       wasm_v128_store(dp + 4, v1);
       sp += 8;
       dp += 8;
     }
-    or_val |= static_cast<unsigned int>(wasm_i32x4_reduce_max(vorval));
     for (; len > 0; --len) {
       int32_t temp;
       if (lossless)
         temp = static_cast<int32_t>(sp[0]);
       else
         temp = static_cast<int32_t>(static_cast<float>(sp[0]) * fscale);
-      uint32_t sign    = static_cast<uint32_t>(temp) & 0x80000000;
-      temp             = (temp < 0) ? -temp : temp;
+      uint32_t sign = static_cast<uint32_t>(temp) & 0x80000000;
+      temp = (temp < 0) ? -temp : temp;
       temp &= 0x7FFFFFFF;
       if (temp) {
         or_val |= 1;
-        dstblk[0] |= 1;
         temp--;
         temp <<= 1;
         temp += static_cast<uint8_t>(sign >> 31);
+        temp |= static_cast<int32_t>(0x80000000u);
       }
       dp[0] = temp;
       ++sp;
       ++dp;
-      ++dstblk;
     }
     if (blksampl_stride > width)
       memset(dp, 0, (blksampl_stride - width) * sizeof(int32_t));
@@ -169,6 +168,9 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
   const uint32_t QHx2 = (height + 7U) & ~7U;
   for (uint32_t i = height; i < QHx2; ++i)
     memset(this->sample_buf + i * blksampl_stride, 0, blksampl_stride * sizeof(int32_t));
+  if (wasm_i32x4_reduce_max(vorval) != 0) {
+    or_val |= 1;
+  }
 }
 
 /********************************************************************************
@@ -223,46 +225,46 @@ void state_MEL_enc::termMEL() {
 /********************************************************************************
  * HT cleanup encoding: helper functions
  *******************************************************************************/
-auto make_storage = [](uint8_t *ssp0, uint8_t *ssp1, int32_t *sp0, int32_t *sp1, v128_t &sig0,
-                       v128_t &sig1, v128_t &v0, v128_t &v1, v128_t &E0, v128_t &E1, int32_t &rho0,
+auto make_storage = [](int32_t *sp0, int32_t *sp1, v128_t &sig0, v128_t &sig1,
+                       v128_t &v0, v128_t &v1, v128_t &E0, v128_t &E1, int32_t &rho0,
                        int32_t &rho1) {
-  v128_t t0 = wasm_v128_load(sp0);
-  v128_t t1 = wasm_v128_load(sp1);
-  v0        = wasm_i32x4_shuffle(t0, t1, 0, 4, 1, 5);
-  v1        = wasm_i32x4_shuffle(t0, t1, 2, 6, 3, 7);
-
-  v128_t vssp0_l = wasm_v128_load64_zero(ssp0);
-  v128_t vssp1_l = wasm_v128_load64_zero(ssp1);
-  v128_t sig01_v = wasm_v128_and(
-      wasm_i8x16_shuffle(vssp0_l, vssp1_l, 0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23),
-      wasm_i8x16_const_splat(1));
-  // sig0 from bytes 0-3 of sig01_v
-  v128_t sig01_u16 = wasm_u16x8_extend_low_u8x16(sig01_v);
-  sig0             = wasm_i32x4_gt(wasm_u32x4_extend_low_u16x8(sig01_u16), wasm_i32x4_const_splat(0));
-  // sig1 from bytes 4-7 of sig01_v
-  v128_t sig01_hi     = wasm_i8x16_shuffle(sig01_v, sig01_v, 4, 5, 6, 7, 8, 9, 10, 11, 0, 1, 2, 3, 4, 5,
-                                           6, 7);
-  v128_t sig01_hi_u16 = wasm_u16x8_extend_low_u8x16(sig01_hi);
-  sig1                = wasm_i32x4_gt(wasm_u32x4_extend_low_u16x8(sig01_hi_u16), wasm_i32x4_const_splat(0));
-  // rho computation
-  uint64_t sig_bits  = (uint64_t)wasm_i64x2_extract_lane(sig01_v, 0);
-  uint8_t rho01_byte = 0;
-  for (int k = 0; k < 8; k++) rho01_byte |= (uint8_t)(((sig_bits >> (8 * k)) & 1) << k);
-  rho0 = rho01_byte & 0xF;
-  rho1 = rho01_byte >> 4;
-
+  const v128_t mask31 = wasm_i32x4_const_splat(0x7FFFFFFF);
+  v128_t t0   = wasm_v128_load(sp0);
+  v128_t t1   = wasm_v128_load(sp1);
+  v128_t raw0 = wasm_i32x4_shuffle(t0, t1, 0, 4, 1, 5);
+  v128_t raw1 = wasm_i32x4_shuffle(t0, t1, 2, 6, 3, 7);
+  // Derive sigma from sentinel bit 31: arithmetic shift right gives -1 or 0
+  sig0 = wasm_i32x4_shr(raw0, 31);
+  sig1 = wasm_i32x4_shr(raw1, 31);
+  // Strip sentinel to get MagSgn value
+  v0 = wasm_v128_and(raw0, mask31);
+  v1 = wasm_v128_and(raw1, mask31);
+  // rho from sigma bits: sig is all-ones (-1) for significant, negate to get 0/1
+  v128_t sig0_01 = wasm_i32x4_neg(sig0);
+  v128_t sig1_01 = wasm_i32x4_neg(sig1);
+  rho0 = wasm_i32x4_extract_lane(sig0_01, 0) | (wasm_i32x4_extract_lane(sig0_01, 1) << 1)
+       | (wasm_i32x4_extract_lane(sig0_01, 2) << 2) | (wasm_i32x4_extract_lane(sig0_01, 3) << 3);
+  rho1 = wasm_i32x4_extract_lane(sig1_01, 0) | (wasm_i32x4_extract_lane(sig1_01, 1) << 1)
+       | (wasm_i32x4_extract_lane(sig1_01, 2) << 2) | (wasm_i32x4_extract_lane(sig1_01, 3) << 3);
+  // E = (32 - clz(v)) & sig
   E0 = wasm_v128_and(wasm_i32x4_sub(wasm_i32x4_const_splat(32), wasm_u32x4_clz(v0)), sig0);
   E1 = wasm_v128_and(wasm_i32x4_sub(wasm_i32x4_const_splat(32), wasm_u32x4_clz(v1)), sig1);
 };
 
-auto make_storage_one = [](uint8_t *ssp0, uint8_t *ssp1, int32_t *sp0, int32_t *sp1, v128_t &sig0,
+auto make_storage_one = [](int32_t *sp0, int32_t *sp1, v128_t &sig0,
                            v128_t &v0, v128_t &E0, int32_t &rho0) {
-  v0              = wasm_i32x4_make(sp0[0], sp1[0], sp0[1], sp1[1]);
-  v128_t sig      = wasm_i32x4_make(ssp0[0] & 1, ssp1[0] & 1, ssp0[1] & 1, ssp1[1] & 1);
-  const v128_t shift = wasm_i32x4_const(0, 1, 2, 3);
-  rho0  = (int32_t)((uint32_t)wasm_i32x4_reduce_add(wasm_i32x4_shlv(sig, shift))) & 0xF;
-  sig0  = wasm_i32x4_gt(sig, wasm_i32x4_const_splat(0));
-  E0    = wasm_v128_and(wasm_i32x4_sub(wasm_i32x4_const_splat(32), wasm_u32x4_clz(v0)), sig0);
+  const v128_t mask31 = wasm_i32x4_const_splat(0x7FFFFFFF);
+  v128_t raw0 = wasm_i32x4_make(sp0[0], sp1[0], sp0[1], sp1[1]);
+  // Derive sigma from sentinel bit 31
+  sig0 = wasm_i32x4_shr(raw0, 31);
+  // Strip sentinel
+  v0 = wasm_v128_and(raw0, mask31);
+  // rho from sigma
+  v128_t sig0_01 = wasm_i32x4_neg(sig0);
+  rho0 = wasm_i32x4_extract_lane(sig0_01, 0) | (wasm_i32x4_extract_lane(sig0_01, 1) << 1)
+       | (wasm_i32x4_extract_lane(sig0_01, 2) << 2) | (wasm_i32x4_extract_lane(sig0_01, 3) << 3);
+  // E = (32 - clz(v)) & sig
+  E0 = wasm_v128_and(wasm_i32x4_sub(wasm_i32x4_const_splat(32), wasm_u32x4_clz(v0)), sig0);
 };
 
 // joint termination of MEL and VLC
@@ -369,15 +371,13 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
   /*******************************************************************************************************************/
   // Initial line-pair
   /*******************************************************************************************************************/
-  uint8_t *ssp0 = block->block_states + 1U * (block->blkstate_stride) + 1U;
-  uint8_t *ssp1 = ssp0 + block->blkstate_stride;
-  int32_t *sp0  = block->sample_buf;
-  int32_t *sp1  = sp0 + block->blksampl_stride;
+  int32_t *sp0 = block->sample_buf;
+  int32_t *sp1 = sp0 + block->blksampl_stride;
   uint32_t qx;
   for (qx = QW; qx >= 2; qx -= 2) {
     bool uoff_flag = true;
 
-    make_storage(ssp0, ssp1, sp0, sp1, sig0, sig1, v0, v1, E0, E1, rho0, rho1);
+    make_storage(sp0, sp1, sig0, sig1, v0, v1, E0, E1, rho0, rho1);
     // update Eline
     wasm_v128_store(E_p, wasm_i32x4_shuffle(E0, E1, 1, 3, 5, 7));
     E_p += 4;
@@ -469,13 +469,11 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
     *rho_p++ = rho0;
     *rho_p++ = rho1;
     // update pointer to line buffer
-    ssp0 += 4;
-    ssp1 += 4;
     sp0 += 4;
     sp1 += 4;
   }
   if (qx) {
-    make_storage_one(ssp0, ssp1, sp0, sp1, sig0, v0, E0, rho0);
+    make_storage_one(sp0, sp1, sig0, v0, E0, rho0);
     *E_p++ = wasm_i32x4_extract_lane(E0, 1);
     *E_p++ = wasm_i32x4_extract_lane(E0, 3);
 
@@ -534,12 +532,10 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
     context |= ((rho_p[-1] & 0x8) << 5) | ((rho_p[0] & 0x2) << 7);
     context |= ((rho_p[0] & 0x8) << 7) | ((rho_p[1] & 0x2) << 9);
 
-    ssp0 = block->block_states + (2U * qy + 1U) * (block->blkstate_stride) + 1U;
-    ssp1 = ssp0 + block->blkstate_stride;
-    sp0  = block->sample_buf + 2U * (qy * block->blksampl_stride);
-    sp1  = sp0 + block->blksampl_stride;
+    sp0 = block->sample_buf + 2U * (qy * block->blksampl_stride);
+    sp1 = sp0 + block->blksampl_stride;
     for (qx = QW; qx >= 2; qx -= 2) {
-      make_storage(ssp0, ssp1, sp0, sp1, sig0, sig1, v0, v1, E0, E1, rho0, rho1);
+      make_storage(sp0, sp1, sig0, sig1, v0, v1, E0, E1, rho0, rho1);
       // MEL encoding of the first quad
       if (context == 0) {
         MEL_encoder.encodeMEL((rho0 != 0));
@@ -621,13 +617,11 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
       *rho_p++ = rho0;
       *rho_p++ = rho1;
       // update pointer to line buffer
-      ssp0 += 4;
-      ssp1 += 4;
       sp0 += 4;
       sp1 += 4;
     }
     if (qx) {
-      make_storage_one(ssp0, ssp1, sp0, sp1, sig0, v0, E0, rho0);
+      make_storage_one(sp0, sp1, sig0, v0, E0, rho0);
       *E_p++ = wasm_i32x4_extract_lane(E0, 1);
       *E_p++ = wasm_i32x4_extract_lane(E0, 3);
 

--- a/source/core/coding/ht_block_encoding_wasm.cpp
+++ b/source/core/coding/ht_block_encoding_wasm.cpp
@@ -168,7 +168,7 @@ void j2k_codeblock::quantize(uint32_t &or_val) {
   const uint32_t QHx2 = (height + 7U) & ~7U;
   for (uint32_t i = height; i < QHx2; ++i)
     memset(this->sample_buf + i * blksampl_stride, 0, blksampl_stride * sizeof(int32_t));
-  if (wasm_i32x4_reduce_max(vorval) != 0) {
+  if (wasm_v128_any_true(vorval)) {
     or_val |= 1;
   }
 }


### PR DESCRIPTION
## Summary

- Fuse significance tracking into the sample buffer by reserving bit 31 as a sentinel: significant samples store `((|x|-1)<<1)|sign|0x80000000`, non-significant remain `0`
- The cleanup encoder derives sigma from `sample>>31` and masks `v_n` with `&0x7FFFFFFF`, removing all `block_states` reads, writes, allocation, and zeroing from the encoder hot path
- Output is bit-identical to main; the sentinel never reaches the codestream

## Benchmark

ElephantDream 4K (3840x2160, 16-bit RGB), single-thread, `taskset -c 4`, median of 10 runs (excluding first cold run):

| | main | branch | delta |
|---|---|---|---|
| **Lossy wall time** | 128.7 ms | 125.5 ms | **-2.5%** |
| **Lossless wall time** | 128.8 ms | 126.4 ms | **-1.9%** |
| **Lossy RSS** | 32.8 MB | 30.3 MB | **-7.6%** |
| **Lossless RSS** | 40.8 MB | 38.2 MB | **-6.4%** |

## Test plan

- [x] 402/402 conformance tests pass (`ctest` in build dir)
- [x] Bit-identical output verified via binary diff for both lossy and lossless (kodim23 + ElephantDream 4K)
- [x] Encode→decode round-trip succeeds (decoder reads the codestream correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)