### PR TITLE
fix: resolve all compiler warnings in Release build

### DIFF
--- a/source/apps/jpip_benchmark/main_jpip_benchmark.cpp
+++ b/source/apps/jpip_benchmark/main_jpip_benchmark.cpp
@@ -49,7 +49,7 @@ std::vector<uint8_t> read_file(const char *path) {
   auto sz = static_cast<std::size_t>(std::ftell(f));
   std::fseek(f, 0, SEEK_SET);
   std::vector<uint8_t> buf(sz);
-  std::fread(buf.data(), 1, sz, f);
+  if (std::fread(buf.data(), 1, sz, f) != sz) { std::fclose(f); return {}; }
   std::fclose(f);
   return buf;
 }

--- a/source/core/codestream/j2kmarkers.cpp
+++ b/source/core/codestream/j2kmarkers.cpp
@@ -1440,7 +1440,7 @@ TLM_marker::TLM_marker(uint8_t ztlm, const std::vector<uint16_t> &tile_indices,
 void TLM_marker::write(j2c_dst_memory &buf) const {
   uint8_t ST = (Stlm >> 4) & 0x03;
   uint8_t SP = ((Stlm >> 4) & 0x0C) >> 2;
-  size_t entry_size = (ST == 0 ? 0 : (ST == 1 ? 1 : 2)) + (SP == 0 ? 2 : 4);
+  size_t entry_size = static_cast<size_t>((ST == 0 ? 0 : (ST == 1 ? 1 : 2)) + (SP == 0 ? 2 : 4));
   uint16_t Ltlm = static_cast<uint16_t>(4 + Ptlm.size() * entry_size);
   buf.put_word(_TLM);
   buf.put_word(Ltlm);

--- a/source/core/coding/coding_units.cpp
+++ b/source/core/coding/coding_units.cpp
@@ -7220,7 +7220,6 @@ uint8_t *j2k_tile::encode_line_based_stream(
           ncy_total             = cpb->num_codeblock_y;
           const int32_t band_x0 = static_cast<int32_t>(cpb->pos0.x);
           for (uint32_t cy_cb = 0; cy_cb < cpb->num_codeblock_y; ++cy_cb) {
-            int32_t x_acc = 0;
             for (uint32_t cx_cb = 0; cx_cb < cpb->num_codeblock_x; ++cx_cb) {
               j2k_codeblock *block = cpb->access_codeblock(cx_cb + cy_cb * cpb->num_codeblock_x);
               vec.push_back(block);

--- a/source/core/coding/ht_block_encoding_avx512.cpp
+++ b/source/core/coding/ht_block_encoding_avx512.cpp
@@ -654,9 +654,6 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
       const __m512i VONE = _mm512_set1_epi32(1);
       const __m512i VZERO = _mm512_setzero_si512();
 #ifdef __AVX512CD__
-      // Stride-4 gather indices: pick element k from each of 16 consecutive quads in E_flat
-      const __m512i stride4 = _mm512_setr_epi32(0,4,8,12,16,20,24,28,32,36,40,44,48,52,56,60);
-      // Permutation for interleaving two __m512i into consecutive pairs (zip)
       const __m512i zip_lo_idx = _mm512_setr_epi32(0,16, 1,17, 2,18, 3,19, 4,20, 5,21, 6,22, 7,23);
       const __m512i zip_hi_idx = _mm512_setr_epi32(8,24, 9,25, 10,26, 11,27, 12,28, 13,29, 14,30, 15,31);
 #endif
@@ -686,7 +683,7 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
 
         // Per-lane hMax: each 128-bit lane holds 4 E values for one quad
         // Reduce within each lane: swap pairs then max, swap halves then max
-        __m512i t1, t2;
+        __m512i t1;
         t1 = _mm512_shuffle_epi32(Eq03, _MM_PERM_CDAB); // swap pairs within lane
         Eq03 = _mm512_max_epi32(Eq03, t1);
         t1 = _mm512_shuffle_epi32(Eq03, _MM_PERM_BADC); // swap halves within lane

--- a/tests/tools/jpip_index_check/main.cpp
+++ b/tests/tools/jpip_index_check/main.cpp
@@ -106,12 +106,18 @@ static bool parse_vw_spec(const char *spec, open_htj2k::jpip::ViewWindow &vw,
     return !out.empty();
   };
   std::string field;
-  if (!next(field)) return false; vw.fx = static_cast<uint32_t>(std::stoul(field));
-  if (!next(field)) return false; vw.fy = static_cast<uint32_t>(std::stoul(field));
-  if (!next(field)) return false; vw.ox = static_cast<uint32_t>(std::stoul(field));
-  if (!next(field)) return false; vw.oy = static_cast<uint32_t>(std::stoul(field));
-  if (!next(field)) return false; vw.sx = static_cast<uint32_t>(std::stoul(field));
-  if (!next(field)) return false; vw.sy = static_cast<uint32_t>(std::stoul(field));
+  if (!next(field)) return false;
+  vw.fx = static_cast<uint32_t>(std::stoul(field));
+  if (!next(field)) return false;
+  vw.fy = static_cast<uint32_t>(std::stoul(field));
+  if (!next(field)) return false;
+  vw.ox = static_cast<uint32_t>(std::stoul(field));
+  if (!next(field)) return false;
+  vw.oy = static_cast<uint32_t>(std::stoul(field));
+  if (!next(field)) return false;
+  vw.sx = static_cast<uint32_t>(std::stoul(field));
+  if (!next(field)) return false;
+  vw.sy = static_cast<uint32_t>(std::stoul(field));
   while (next(field)) {
     if (field == "down")    vw.round = open_htj2k::jpip::ViewWindow::Round::Down;
     else if (field == "up") vw.round = open_htj2k::jpip::ViewWindow::Round::Up;

--- a/tests/tools/jpip_parser_check/main.cpp
+++ b/tests/tools/jpip_parser_check/main.cpp
@@ -159,7 +159,7 @@ int main(int argc, char **argv) {
 
   // Malformed stream: truncated mid-message.
   {
-    std::vector<uint8_t> bad(stream.begin(), stream.begin() + stream.size() / 2);
+    std::vector<uint8_t> bad(stream.begin(), stream.begin() + static_cast<ptrdiff_t>(stream.size() / 2));
     DataBinSet t;
     CHECK(!parse_jpp_stream(bad.data(), bad.size(), &t),
           "truncated stream should be rejected");


### PR DESCRIPTION
## Summary

- Remove unused variables: `x_acc` in coding_units.cpp, `stride4` and `t2` in ht_block_encoding_avx512.cpp
- Check `fread` return value instead of discarding it (main_jpip_benchmark.cpp)
- Add explicit `static_cast<size_t>` for int-to-size_t sign conversion (j2kmarkers.cpp)
- Fix misleading indentation: split same-line `if`/assignment onto separate lines (jpip_index_check/main.cpp)
- Add `static_cast<ptrdiff_t>` for size_t-to-difference_type conversion (jpip_parser_check/main.cpp)

Clean Release build now produces zero warnings with GCC.

## Test plan

- [x] `cmake --build` produces zero warnings
- [x] 402/402 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)