### PR TITLE
perf: NEON emitFlat encoder + int32 reversible IDWT pipeline

### DIFF
--- a/source/core/coding/block_decoding.cpp
+++ b/source/core/coding/block_decoding.cpp
@@ -592,6 +592,6 @@ void j2k_decode(j2k_codeblock *block, const uint8_t ROIshift) {
 
   j2k_dequant(block->sample_buf, block->blksampl_stride, block->block_states, block->blkstate_stride,
               block->band_buf, block->band_stride, block->size.x, block->size.y, M_b, ROIshift,
-              block->transformation, block->stepsize);
+              block->transformation, block->stepsize, block->dequant_i32);
   // TODO: if k !=0
 }

--- a/source/core/coding/block_dequant.cpp
+++ b/source/core/coding/block_dequant.cpp
@@ -31,15 +31,53 @@
 #include "block_dequant.hpp"
 #include <cassert>
 
-void j2k_dequant(int32_t *sample_buf, size_t blksampl_stride, const uint8_t *block_states,
-                 size_t blkstate_stride, sprec_t *band_buf, uint32_t band_stride, uint32_t width,
-                 uint32_t height, int32_t M_b, uint8_t ROIshift, uint8_t transformation,
-                 float stepsize) {
+template <bool StoreI32>
+static void j2k_dequant_rev_scalar(int32_t *sample_buf, size_t blksampl_stride,
+                                   const uint8_t *block_states, size_t blkstate_stride,
+                                   sprec_t *band_buf, uint32_t band_stride, uint32_t width,
+                                   uint32_t height, int32_t M_b, uint8_t ROIshift) {
   int32_t N_b;
   const int32_t pLSB  = 31 - M_b;
   const uint32_t mask = UINT32_MAX >> (M_b + 1);
-  int32_t r_val;
-  int32_t offset = 0;
+
+  for (uint32_t y = 0; y < height; y++) {
+    for (uint32_t x = 0; x < width; x++) {
+      const uint32_t n = x + y * band_stride;
+      int32_t *val     = &sample_buf[x + y * blksampl_stride];
+      uint8_t state    = block_states[(x + 1) + (y + 1) * blkstate_stride];
+      sprec_t *dst     = band_buf + n;
+      int32_t sign     = *val & INT32_MIN;
+      *val &= INT32_MAX;
+      if (ROIshift && (((uint32_t)*val & ~mask) == 0)) {
+        *val <<= ROIshift;
+      }
+      if (ROIshift) {
+        N_b = 30 - pLSB + 1;
+      } else {
+        N_b = 30 - (state >> 3) + 1;
+      }
+      if (*val != 0 && N_b < M_b) {
+        *val |= 1 << (pLSB - 1 + M_b - N_b);
+      }
+      int32_t smask = sign >> 31;
+      *val          = (*val ^ smask) - smask;
+      assert(pLSB >= 0);
+      int32_t QF32 = *val >> pLSB;
+      if constexpr (StoreI32)
+        *reinterpret_cast<int32_t *>(dst) = QF32;
+      else
+        *dst = static_cast<float>(QF32);
+    }
+  }
+}
+
+void j2k_dequant(int32_t *sample_buf, size_t blksampl_stride, const uint8_t *block_states,
+                 size_t blkstate_stride, sprec_t *band_buf, uint32_t band_stride, uint32_t width,
+                 uint32_t height, int32_t M_b, uint8_t ROIshift, uint8_t transformation,
+                 float stepsize, bool dequant_i32) {
+  int32_t N_b;
+  const int32_t pLSB  = 31 - M_b;
+  const uint32_t mask = UINT32_MAX >> (M_b + 1);
 
   float fscale = stepsize;
   fscale *= (1 << FRACBITS);
@@ -53,35 +91,12 @@ void j2k_dequant(int32_t *sample_buf, size_t blksampl_stride, const uint8_t *blo
   const auto scale = (int32_t)(fscale + 0.5);
 
   if (transformation == 1) {
-    // reversible path
-    for (uint32_t y = 0; y < height; y++) {
-      for (uint32_t x = 0; x < width; x++) {
-        const uint32_t n = x + y * band_stride;
-        int32_t *val     = &sample_buf[x + y * blksampl_stride];
-        uint8_t state    = block_states[(x + 1) + (y + 1) * blkstate_stride];
-        sprec_t *dst     = band_buf + n;
-        int32_t sign     = *val & INT32_MIN;
-        *val &= INT32_MAX;
-        if (ROIshift && (((uint32_t)*val & ~mask) == 0)) {
-          *val <<= ROIshift;
-        }
-        if (ROIshift) {
-          N_b = 30 - pLSB + 1;
-        } else {
-          N_b = 30 - (state >> 3) + 1;
-        }
-        offset        = (M_b > N_b) ? M_b - N_b : 0;
-        r_val         = 1 << (pLSB - 1 + offset);
-        if (*val != 0 && N_b < M_b) {
-          *val |= r_val;
-        }
-        int32_t smask = sign >> 31;
-        *val          = (*val ^ smask) - smask;
-        assert(pLSB >= 0);
-        int32_t QF32 = *val >> pLSB;
-        *dst         = static_cast<float>(QF32);
-      }
-    }
+    if (dequant_i32)
+      j2k_dequant_rev_scalar<true>(sample_buf, blksampl_stride, block_states, blkstate_stride,
+                                   band_buf, band_stride, width, height, M_b, ROIshift);
+    else
+      j2k_dequant_rev_scalar<false>(sample_buf, blksampl_stride, block_states, blkstate_stride,
+                                    band_buf, band_stride, width, height, M_b, ROIshift);
   } else {
     // irreversible path
     for (uint32_t y = 0; y < height; y++) {
@@ -100,10 +115,12 @@ void j2k_dequant(int32_t *sample_buf, size_t blksampl_stride, const uint8_t *blo
         } else {
           N_b = 30 - (state >> 3) + 1;
         }
-        offset        = (M_b > N_b) ? M_b - N_b : 0;
-        r_val         = 1 << (pLSB - 1 + offset);
-        if (*val != 0) {
-          *val |= r_val;
+        {
+          int32_t offset = (M_b > N_b) ? M_b - N_b : 0;
+          int32_t r_val  = 1 << (pLSB - 1 + offset);
+          if (*val != 0) {
+            *val |= r_val;
+          }
         }
         *val          = (*val + (1 << 15)) >> 16;
         *val         *= scale;

--- a/source/core/coding/block_dequant.hpp
+++ b/source/core/coding/block_dequant.hpp
@@ -35,4 +35,4 @@
 void j2k_dequant(int32_t *sample_buf, size_t blksampl_stride, const uint8_t *block_states,
                  size_t blkstate_stride, sprec_t *band_buf, uint32_t band_stride, uint32_t width,
                  uint32_t height, int32_t M_b, uint8_t ROIshift, uint8_t transformation,
-                 float stepsize);
+                 float stepsize, bool dequant_i32 = false);

--- a/source/core/coding/block_dequant_avx2.cpp
+++ b/source/core/coding/block_dequant_avx2.cpp
@@ -36,10 +36,102 @@
 #include "block_dequant.hpp"
 #include <cassert>
 
+template <bool StoreI32>
+static void j2k_dequant_rev_avx2(int32_t *sample_buf, size_t blksampl_stride,
+                                  const uint8_t *block_states, size_t blkstate_stride,
+                                  sprec_t *band_buf, uint32_t band_stride, uint32_t width,
+                                  uint32_t height, int32_t M_b, uint8_t ROIshift) {
+  int32_t N_b;
+  const int32_t pLSB    = 31 - M_b;
+  const uint32_t mask   = UINT32_MAX >> (M_b + 1);
+  const int32_t pLSB_m1 = pLSB - 1;
+
+  const __m256i v_M_b      = _mm256_set1_epi32(M_b);
+  const __m256i v_30       = _mm256_set1_epi32(30);
+  const __m256i v_1        = _mm256_set1_epi32(1);
+  const __m256i v_pLSB_m1  = _mm256_set1_epi32(pLSB_m1);
+  const __m256i v_int32max = _mm256_set1_epi32(INT32_MAX);
+  const __m256i v_zero     = _mm256_setzero_si256();
+
+  for (uint32_t y = 0; y < height; y++) {
+    int32_t *val_row      = sample_buf + y * blksampl_stride;
+    const uint8_t *st_row = block_states + (y + 1) * blkstate_stride + 1;
+    sprec_t *dst_row      = band_buf + y * band_stride;
+    uint32_t x            = 0;
+
+    for (; x + 8 <= width; x += 8) {
+      __m256i v_val = _mm256_loadu_si256((__m256i *)(val_row + x));
+      __m256i v_sign = _mm256_srai_epi32(v_val, 31);
+      v_val = _mm256_and_si256(v_val, v_int32max);
+
+      if (ROIshift) {
+        const __m256i v_notmask = _mm256_set1_epi32((int32_t)~mask);
+        const __m256i v_cond_roi =
+            _mm256_cmpeq_epi32(_mm256_and_si256(v_val, v_notmask), v_zero);
+        const __m256i v_shifted = _mm256_slli_epi32(v_val, ROIshift);
+        v_val = _mm256_blendv_epi8(v_val, v_shifted, v_cond_roi);
+      }
+
+      __m256i v_state;
+      if (ROIshift) {
+        v_state = _mm256_set1_epi32(30 - pLSB + 1);
+      } else {
+        __m128i v_st8 = _mm_loadl_epi64((__m128i *)(st_row + x));
+        __m256i v_st  = _mm256_cvtepu8_epi32(v_st8);
+        v_st          = _mm256_srli_epi32(v_st, 3);
+        v_state       = _mm256_add_epi32(_mm256_sub_epi32(v_30, v_st), v_1);
+      }
+
+      __m256i v_offset = _mm256_max_epi32(_mm256_sub_epi32(v_M_b, v_state), v_zero);
+      __m256i v_shift  = _mm256_add_epi32(v_pLSB_m1, v_offset);
+      __m256i v_rval   = _mm256_sllv_epi32(v_1, v_shift);
+
+      __m256i v_nonzero = _mm256_cmpgt_epi32(v_val, v_zero);
+      __m256i v_nb_lt   = _mm256_cmpgt_epi32(v_M_b, v_state);
+      __m256i v_cond    = _mm256_and_si256(v_nonzero, v_nb_lt);
+      v_val = _mm256_or_si256(v_val, _mm256_and_si256(v_rval, v_cond));
+
+      v_val = _mm256_sub_epi32(_mm256_xor_si256(v_val, v_sign), v_sign);
+      __m256i v_qf32 = _mm256_srai_epi32(v_val, pLSB);
+
+      if constexpr (StoreI32)
+        _mm256_storeu_si256((__m256i *)(dst_row + x), v_qf32);
+      else
+        _mm256_storeu_ps(dst_row + x, _mm256_cvtepi32_ps(v_qf32));
+    }
+
+    for (; x < width; x++) {
+      int32_t *val = val_row + x;
+      int32_t sign = *val & INT32_MIN;
+      *val &= INT32_MAX;
+      if (ROIshift && (((uint32_t)*val & ~mask) == 0)) {
+        *val <<= ROIshift;
+      }
+      uint8_t state = st_row[x];
+      if (ROIshift) {
+        N_b = 30 - pLSB + 1;
+      } else {
+        N_b = 30 - (state >> 3) + 1;
+      }
+      if (*val != 0 && N_b < M_b) {
+        *val |= 1 << (pLSB_m1 + M_b - N_b);
+      }
+      int32_t smask = sign >> 31;
+      *val          = (*val ^ smask) - smask;
+      assert(pLSB >= 0);
+      int32_t QF32 = *val >> pLSB;
+      if constexpr (StoreI32)
+        reinterpret_cast<int32_t *>(dst_row)[x] = QF32;
+      else
+        dst_row[x] = static_cast<float>(QF32);
+    }
+  }
+}
+
 void j2k_dequant(int32_t *sample_buf, size_t blksampl_stride, const uint8_t *block_states,
                  size_t blkstate_stride, sprec_t *band_buf, uint32_t band_stride, uint32_t width,
                  uint32_t height, int32_t M_b, uint8_t ROIshift, uint8_t transformation,
-                 float stepsize) {
+                 float stepsize, bool dequant_i32) {
   int32_t N_b;
   const int32_t pLSB    = 31 - M_b;
   const uint32_t mask   = UINT32_MAX >> (M_b + 1);
@@ -57,101 +149,12 @@ void j2k_dequant(int32_t *sample_buf, size_t blksampl_stride, const uint8_t *blo
   const auto scale = (int32_t)(fscale + 0.5);
 
   if (transformation == 1) {
-    // Reversible path
-    const __m256i v_M_b      = _mm256_set1_epi32(M_b);
-    const __m256i v_30       = _mm256_set1_epi32(30);
-    const __m256i v_1        = _mm256_set1_epi32(1);
-    const __m256i v_pLSB_m1  = _mm256_set1_epi32(pLSB_m1);
-    const __m256i v_int32max = _mm256_set1_epi32(INT32_MAX);
-    const __m256i v_zero     = _mm256_setzero_si256();
-
-    for (uint32_t y = 0; y < height; y++) {
-      int32_t *val_row      = sample_buf + y * blksampl_stride;
-      const uint8_t *st_row = block_states + (y + 1) * blkstate_stride + 1;
-      sprec_t *dst_row      = band_buf + y * band_stride;
-      uint32_t x            = 0;
-
-      for (; x + 8 <= width; x += 8) {
-        __m256i v_val = _mm256_loadu_si256((__m256i *)(val_row + x));
-
-        // Extract sign (bit 31) as mask: 0 or -1
-        __m256i v_sign = _mm256_srai_epi32(v_val, 31);
-
-        // Clear sign bit
-        v_val = _mm256_and_si256(v_val, v_int32max);
-
-        if (ROIshift) {
-          // Upshift lanes where (val & ~mask) == 0. Pure vector; no scalar round-trip
-          // through a stack array — MSVC miscompiles the store-loop-reload pattern
-          // via __m256i* / int32_t* aliasing (observed on VS 2022 /arch:AVX2 /O2).
-          const __m256i v_notmask = _mm256_set1_epi32((int32_t)~mask);
-          const __m256i v_cond_roi =
-              _mm256_cmpeq_epi32(_mm256_and_si256(v_val, v_notmask), v_zero);
-          const __m256i v_shifted = _mm256_slli_epi32(v_val, ROIshift);
-          v_val = _mm256_blendv_epi8(v_val, v_shifted, v_cond_roi);
-        }
-
-        // Load 8 state bytes, widen to int32, compute N_b = 30 - (state >> 3) + 1
-        __m256i v_state;
-        if (ROIshift) {
-          v_state = _mm256_set1_epi32(30 - pLSB + 1);
-        } else {
-          __m128i v_st8 = _mm_loadl_epi64((__m128i *)(st_row + x));
-          __m256i v_st  = _mm256_cvtepu8_epi32(v_st8);
-          v_st          = _mm256_srli_epi32(v_st, 3);
-          v_state       = _mm256_add_epi32(_mm256_sub_epi32(v_30, v_st), v_1);
-        }
-
-        // offset = max(M_b - N_b, 0)
-        __m256i v_offset = _mm256_max_epi32(_mm256_sub_epi32(v_M_b, v_state), v_zero);
-
-        // r_val = 1 << (pLSB - 1 + offset)
-        __m256i v_shift = _mm256_add_epi32(v_pLSB_m1, v_offset);
-        __m256i v_rval  = _mm256_sllv_epi32(v_1, v_shift);
-
-        // Add r_val if val != 0 && N_b < M_b
-        __m256i v_nonzero = _mm256_cmpgt_epi32(v_val, v_zero);
-        __m256i v_nb_lt   = _mm256_cmpgt_epi32(v_M_b, v_state);  // M_b > N_b
-        __m256i v_cond    = _mm256_and_si256(v_nonzero, v_nb_lt);
-        v_val = _mm256_or_si256(v_val, _mm256_and_si256(v_rval, v_cond));
-
-        // Sign-magnitude to two's complement (branchless)
-        v_val = _mm256_sub_epi32(_mm256_xor_si256(v_val, v_sign), v_sign);
-
-        // Right shift by pLSB
-        __m256i v_qf32 = _mm256_srai_epi32(v_val, pLSB);
-
-        // Convert to float and store
-        __m256 v_out = _mm256_cvtepi32_ps(v_qf32);
-        _mm256_storeu_ps(dst_row + x, v_out);
-      }
-
-      // Scalar tail
-      for (; x < width; x++) {
-        int32_t *val = val_row + x;
-        int32_t sign = *val & INT32_MIN;
-        *val &= INT32_MAX;
-        if (ROIshift && (((uint32_t)*val & ~mask) == 0)) {
-          *val <<= ROIshift;
-        }
-        uint8_t state = st_row[x];
-        if (ROIshift) {
-          N_b = 30 - pLSB + 1;
-        } else {
-          N_b = 30 - (state >> 3) + 1;
-        }
-        int32_t offset = (M_b > N_b) ? M_b - N_b : 0;
-        int32_t r_val  = 1 << (pLSB_m1 + offset);
-        if (*val != 0 && N_b < M_b) {
-          *val |= r_val;
-        }
-        int32_t smask = sign >> 31;
-        *val          = (*val ^ smask) - smask;
-        assert(pLSB >= 0);
-        int32_t QF32 = *val >> pLSB;
-        dst_row[x]   = static_cast<float>(QF32);
-      }
-    }
+    if (dequant_i32)
+      j2k_dequant_rev_avx2<true>(sample_buf, blksampl_stride, block_states, blkstate_stride,
+                                  band_buf, band_stride, width, height, M_b, ROIshift);
+    else
+      j2k_dequant_rev_avx2<false>(sample_buf, blksampl_stride, block_states, blkstate_stride,
+                                   band_buf, band_stride, width, height, M_b, ROIshift);
   } else {
     // Irreversible path
     const __m256i v_M_b      = _mm256_set1_epi32(M_b);
@@ -243,10 +246,11 @@ void j2k_dequant(int32_t *sample_buf, size_t blksampl_stride, const uint8_t *blo
         } else {
           N_b = 30 - (state >> 3) + 1;
         }
-        int32_t offset = (M_b > N_b) ? M_b - N_b : 0;
-        int32_t r_val  = 1 << (pLSB_m1 + offset);
-        if (*val != 0) {
-          *val |= r_val;
+        {
+          int32_t offset = (M_b > N_b) ? M_b - N_b : 0;
+          if (*val != 0) {
+            *val |= 1 << (pLSB_m1 + offset);
+          }
         }
         *val          = (*val + (1 << 15)) >> 16;
         *val         *= scale;

--- a/source/core/coding/block_dequant_avx512.cpp
+++ b/source/core/coding/block_dequant_avx512.cpp
@@ -36,10 +36,101 @@
 #include "block_dequant.hpp"
 #include <cassert>
 
+template <bool StoreI32>
+static void j2k_dequant_rev_avx512(int32_t *sample_buf, size_t blksampl_stride,
+                                    const uint8_t *block_states, size_t blkstate_stride,
+                                    sprec_t *band_buf, uint32_t band_stride, uint32_t width,
+                                    uint32_t height, int32_t M_b, uint8_t ROIshift) {
+  int32_t N_b;
+  const int32_t pLSB    = 31 - M_b;
+  const uint32_t mask   = UINT32_MAX >> (M_b + 1);
+  const int32_t pLSB_m1 = pLSB - 1;
+
+  const __m512i v_M_b      = _mm512_set1_epi32(M_b);
+  const __m512i v_30       = _mm512_set1_epi32(30);
+  const __m512i v_1        = _mm512_set1_epi32(1);
+  const __m512i v_pLSB_m1  = _mm512_set1_epi32(pLSB_m1);
+  const __m512i v_int32max = _mm512_set1_epi32(INT32_MAX);
+  const __m512i v_zero     = _mm512_setzero_si512();
+
+  for (uint32_t y = 0; y < height; y++) {
+    int32_t *val_row      = sample_buf + y * blksampl_stride;
+    const uint8_t *st_row = block_states + (y + 1) * blkstate_stride + 1;
+    sprec_t *dst_row      = band_buf + y * band_stride;
+    uint32_t x            = 0;
+
+    for (; x + 16 <= width; x += 16) {
+      __m512i v_val = _mm512_loadu_si512(val_row + x);
+      __m512i v_sign = _mm512_srai_epi32(v_val, 31);
+      v_val = _mm512_and_si512(v_val, v_int32max);
+
+      if (ROIshift) {
+        const __m512i v_notmask = _mm512_set1_epi32((int32_t)~mask);
+        const __mmask16 k_roi =
+            _mm512_cmpeq_epi32_mask(_mm512_and_si512(v_val, v_notmask), v_zero);
+        v_val = _mm512_mask_slli_epi32(v_val, k_roi, v_val, ROIshift);
+      }
+
+      __m512i v_state;
+      if (ROIshift) {
+        v_state = _mm512_set1_epi32(30 - pLSB + 1);
+      } else {
+        __m128i v_st8 = _mm_loadu_si128((__m128i *)(st_row + x));
+        __m512i v_st  = _mm512_cvtepu8_epi32(v_st8);
+        v_st          = _mm512_srli_epi32(v_st, 3);
+        v_state       = _mm512_add_epi32(_mm512_sub_epi32(v_30, v_st), v_1);
+      }
+
+      __m512i v_offset = _mm512_max_epi32(_mm512_sub_epi32(v_M_b, v_state), v_zero);
+      __m512i v_shift  = _mm512_add_epi32(v_pLSB_m1, v_offset);
+      __m512i v_rval   = _mm512_sllv_epi32(v_1, v_shift);
+
+      __mmask16 k_nonzero = _mm512_cmpgt_epi32_mask(v_val, v_zero);
+      __mmask16 k_nb_lt   = _mm512_cmpgt_epi32_mask(v_M_b, v_state);
+      __mmask16 k_cond    = _kand_mask16(k_nonzero, k_nb_lt);
+      v_val = _mm512_mask_or_epi32(v_val, k_cond, v_val, v_rval);
+
+      v_val = _mm512_sub_epi32(_mm512_xor_si512(v_val, v_sign), v_sign);
+      __m512i v_qf32 = _mm512_srai_epi32(v_val, static_cast<unsigned int>(pLSB));
+
+      if constexpr (StoreI32)
+        _mm512_storeu_si512(dst_row + x, v_qf32);
+      else
+        _mm512_storeu_ps(dst_row + x, _mm512_cvtepi32_ps(v_qf32));
+    }
+
+    for (; x < width; x++) {
+      int32_t *val = val_row + x;
+      int32_t sign = *val & INT32_MIN;
+      *val &= INT32_MAX;
+      if (ROIshift && (((uint32_t)*val & ~mask) == 0)) {
+        *val <<= ROIshift;
+      }
+      uint8_t state = st_row[x];
+      if (ROIshift) {
+        N_b = 30 - pLSB + 1;
+      } else {
+        N_b = 30 - (state >> 3) + 1;
+      }
+      if (*val != 0 && N_b < M_b) {
+        *val |= 1 << (pLSB_m1 + M_b - N_b);
+      }
+      int32_t smask = sign >> 31;
+      *val          = (*val ^ smask) - smask;
+      assert(pLSB >= 0);
+      int32_t QF32 = *val >> pLSB;
+      if constexpr (StoreI32)
+        reinterpret_cast<int32_t *>(dst_row)[x] = QF32;
+      else
+        dst_row[x] = static_cast<float>(QF32);
+    }
+  }
+}
+
 void j2k_dequant(int32_t *sample_buf, size_t blksampl_stride, const uint8_t *block_states,
                  size_t blkstate_stride, sprec_t *band_buf, uint32_t band_stride, uint32_t width,
                  uint32_t height, int32_t M_b, uint8_t ROIshift, uint8_t transformation,
-                 float stepsize) {
+                 float stepsize, bool dequant_i32) {
   int32_t N_b;
   const int32_t pLSB    = 31 - M_b;
   const uint32_t mask   = UINT32_MAX >> (M_b + 1);
@@ -57,100 +148,12 @@ void j2k_dequant(int32_t *sample_buf, size_t blksampl_stride, const uint8_t *blo
   const auto scale = (int32_t)(fscale + 0.5);
 
   if (transformation == 1) {
-    // Reversible path
-    const __m512i v_M_b      = _mm512_set1_epi32(M_b);
-    const __m512i v_30       = _mm512_set1_epi32(30);
-    const __m512i v_1        = _mm512_set1_epi32(1);
-    const __m512i v_pLSB_m1  = _mm512_set1_epi32(pLSB_m1);
-    const __m512i v_int32max = _mm512_set1_epi32(INT32_MAX);
-    const __m512i v_zero     = _mm512_setzero_si512();
-
-    for (uint32_t y = 0; y < height; y++) {
-      int32_t *val_row      = sample_buf + y * blksampl_stride;
-      const uint8_t *st_row = block_states + (y + 1) * blkstate_stride + 1;
-      sprec_t *dst_row      = band_buf + y * band_stride;
-      uint32_t x            = 0;
-
-      for (; x + 16 <= width; x += 16) {
-        __m512i v_val = _mm512_loadu_si512(val_row + x);
-
-        // Extract sign (bit 31) as mask: 0 or -1
-        __m512i v_sign = _mm512_srai_epi32(v_val, 31);
-
-        // Clear sign bit
-        v_val = _mm512_and_si512(v_val, v_int32max);
-
-        if (ROIshift) {
-          // Upshift lanes where (val & ~mask) == 0. Pure vector via AVX-512 mask ops;
-          // avoids the scalar store-loop-reload round-trip that MSVC miscompiles on
-          // its AVX2 counterpart (see block_dequant_avx2.cpp).
-          const __m512i v_notmask = _mm512_set1_epi32((int32_t)~mask);
-          const __mmask16 k_roi =
-              _mm512_cmpeq_epi32_mask(_mm512_and_si512(v_val, v_notmask), v_zero);
-          v_val = _mm512_mask_slli_epi32(v_val, k_roi, v_val, ROIshift);
-        }
-
-        // Load 16 state bytes, widen to int32, compute N_b = 30 - (state >> 3) + 1
-        __m512i v_state;
-        if (ROIshift) {
-          v_state = _mm512_set1_epi32(30 - pLSB + 1);
-        } else {
-          __m128i v_st8 = _mm_loadu_si128((__m128i *)(st_row + x));
-          __m512i v_st  = _mm512_cvtepu8_epi32(v_st8);
-          v_st          = _mm512_srli_epi32(v_st, 3);
-          v_state       = _mm512_add_epi32(_mm512_sub_epi32(v_30, v_st), v_1);
-        }
-
-        // offset = max(M_b - N_b, 0)
-        __m512i v_offset = _mm512_max_epi32(_mm512_sub_epi32(v_M_b, v_state), v_zero);
-
-        // r_val = 1 << (pLSB - 1 + offset)
-        __m512i v_shift = _mm512_add_epi32(v_pLSB_m1, v_offset);
-        __m512i v_rval  = _mm512_sllv_epi32(v_1, v_shift);
-
-        // Add r_val if val != 0 && N_b < M_b (using mask registers)
-        __mmask16 k_nonzero = _mm512_cmpgt_epi32_mask(v_val, v_zero);
-        __mmask16 k_nb_lt   = _mm512_cmpgt_epi32_mask(v_M_b, v_state);
-        __mmask16 k_cond    = _kand_mask16(k_nonzero, k_nb_lt);
-        v_val = _mm512_mask_or_epi32(v_val, k_cond, v_val, v_rval);
-
-        // Sign-magnitude to two's complement (branchless)
-        v_val = _mm512_sub_epi32(_mm512_xor_si512(v_val, v_sign), v_sign);
-
-        // Right shift by pLSB
-        __m512i v_qf32 = _mm512_srai_epi32(v_val, static_cast<unsigned int>(pLSB));
-
-        // Convert to float and store
-        __m512 v_out = _mm512_cvtepi32_ps(v_qf32);
-        _mm512_storeu_ps(dst_row + x, v_out);
-      }
-
-      // Scalar tail
-      for (; x < width; x++) {
-        int32_t *val = val_row + x;
-        int32_t sign = *val & INT32_MIN;
-        *val &= INT32_MAX;
-        if (ROIshift && (((uint32_t)*val & ~mask) == 0)) {
-          *val <<= ROIshift;
-        }
-        uint8_t state = st_row[x];
-        if (ROIshift) {
-          N_b = 30 - pLSB + 1;
-        } else {
-          N_b = 30 - (state >> 3) + 1;
-        }
-        int32_t offset = (M_b > N_b) ? M_b - N_b : 0;
-        int32_t r_val  = 1 << (pLSB_m1 + offset);
-        if (*val != 0 && N_b < M_b) {
-          *val |= r_val;
-        }
-        int32_t smask = sign >> 31;
-        *val          = (*val ^ smask) - smask;
-        assert(pLSB >= 0);
-        int32_t QF32 = *val >> pLSB;
-        dst_row[x]   = static_cast<float>(QF32);
-      }
-    }
+    if (dequant_i32)
+      j2k_dequant_rev_avx512<true>(sample_buf, blksampl_stride, block_states, blkstate_stride,
+                                    band_buf, band_stride, width, height, M_b, ROIshift);
+    else
+      j2k_dequant_rev_avx512<false>(sample_buf, blksampl_stride, block_states, blkstate_stride,
+                                     band_buf, band_stride, width, height, M_b, ROIshift);
   } else {
     // Irreversible path
     const __m512i v_M_b      = _mm512_set1_epi32(M_b);
@@ -241,10 +244,11 @@ void j2k_dequant(int32_t *sample_buf, size_t blksampl_stride, const uint8_t *blo
         } else {
           N_b = 30 - (state >> 3) + 1;
         }
-        int32_t offset = (M_b > N_b) ? M_b - N_b : 0;
-        int32_t r_val  = 1 << (pLSB_m1 + offset);
-        if (*val != 0) {
-          *val |= r_val;
+        {
+          int32_t offset = (M_b > N_b) ? M_b - N_b : 0;
+          if (*val != 0) {
+            *val |= 1 << (pLSB_m1 + offset);
+          }
         }
         *val          = (*val + (1 << 15)) >> 16;
         *val         *= scale;

--- a/source/core/coding/block_dequant_neon.cpp
+++ b/source/core/coding/block_dequant_neon.cpp
@@ -33,16 +33,111 @@
 #include <cassert>
 #include <cstddef>
 
-void j2k_dequant(int32_t *sample_buf, size_t blksampl_stride, const uint8_t *block_states,
-                 size_t blkstate_stride, sprec_t *band_buf, uint32_t band_stride, uint32_t width,
-                 uint32_t height, int32_t M_b, uint8_t ROIshift, uint8_t transformation,
-                 float stepsize) {
+template <bool StoreI32>
+static void j2k_dequant_rev_neon(int32_t *sample_buf, size_t blksampl_stride,
+                                 const uint8_t *block_states, size_t blkstate_stride,
+                                 sprec_t *band_buf, uint32_t band_stride, uint32_t width,
+                                 uint32_t height, int32_t M_b, uint8_t ROIshift) {
   int32_t N_b;
   const int32_t pLSB    = 31 - M_b;
   const uint32_t mask   = UINT32_MAX >> (M_b + 1);
   const int32_t pLSB_m1 = pLSB - 1;
 
-  // Precompute irreversible scale
+  const int32x4_t v_M_b      = vdupq_n_s32(M_b);
+  const int32x4_t v_30       = vdupq_n_s32(30);
+  const int32x4_t v_1        = vdupq_n_s32(1);
+  const int32x4_t v_pLSB_m1  = vdupq_n_s32(pLSB_m1);
+  const int32x4_t v_neg_pLSB = vdupq_n_s32(-pLSB);
+
+  for (uint32_t y = 0; y < height; y++) {
+    int32_t *val_row        = sample_buf + y * blksampl_stride;
+    const uint8_t *st_row   = block_states + (y + 1) * blkstate_stride + 1;
+    sprec_t *dst_row        = band_buf + y * band_stride;
+    uint32_t x              = 0;
+
+    for (; x + 4 <= width; x += 4) {
+      int32x4_t v_val = vld1q_s32(val_row + x);
+
+      int32x4_t v_sign = vshrq_n_s32(v_val, 31);
+      v_val = vandq_s32(v_val, vdupq_n_s32(INT32_MAX));
+
+      if (ROIshift) {
+        int32_t tmp[4];
+        vst1q_s32(tmp, v_val);
+        for (int i = 0; i < 4; i++) {
+          if (((uint32_t)tmp[i] & ~mask) == 0) {
+            tmp[i] <<= ROIshift;
+          }
+        }
+        v_val = vld1q_s32(tmp);
+      }
+
+      uint8_t st_bytes[4] = {st_row[x], st_row[x + 1], st_row[x + 2], st_row[x + 3]};
+      int32x4_t v_state;
+      if (ROIshift) {
+        v_state = vdupq_n_s32(30 - pLSB + 1);
+      } else {
+        int32_t st_vals[4] = {st_bytes[0] >> 3, st_bytes[1] >> 3, st_bytes[2] >> 3,
+                              st_bytes[3] >> 3};
+        int32x4_t v_st = vld1q_s32(st_vals);
+        v_state        = vaddq_s32(vsubq_s32(v_30, v_st), v_1);
+      }
+
+      int32x4_t v_offset = vmaxq_s32(vsubq_s32(v_M_b, v_state), vdupq_n_s32(0));
+      int32x4_t v_shift  = vaddq_s32(v_pLSB_m1, v_offset);
+      int32x4_t v_rval   = vshlq_s32(v_1, v_shift);
+
+      uint32x4_t v_nonzero = vcgtq_s32(v_val, vdupq_n_s32(0));
+      uint32x4_t v_nb_lt   = vcltq_s32(v_state, v_M_b);
+      uint32x4_t v_cond    = vandq_u32(v_nonzero, v_nb_lt);
+      v_val = vorrq_s32(v_val, vandq_s32(v_rval, vreinterpretq_s32_u32(v_cond)));
+
+      v_val = vsubq_s32(veorq_s32(v_val, v_sign), v_sign);
+      int32x4_t v_qf32 = vshlq_s32(v_val, v_neg_pLSB);
+
+      if constexpr (StoreI32)
+        vst1q_s32(reinterpret_cast<int32_t *>(dst_row + x), v_qf32);
+      else
+        vst1q_f32(dst_row + x, vcvtq_f32_s32(v_qf32));
+    }
+
+    for (; x < width; x++) {
+      int32_t *val = val_row + x;
+      int32_t sign = *val & INT32_MIN;
+      *val &= INT32_MAX;
+      if (ROIshift && (((uint32_t)*val & ~mask) == 0)) {
+        *val <<= ROIshift;
+      }
+      uint8_t state = st_row[x];
+      if (ROIshift) {
+        N_b = 30 - pLSB + 1;
+      } else {
+        N_b = 30 - (state >> 3) + 1;
+      }
+      if (*val != 0 && N_b < M_b) {
+        *val |= 1 << (pLSB_m1 + M_b - N_b);
+      }
+      int32_t smask = sign >> 31;
+      *val          = (*val ^ smask) - smask;
+      assert(pLSB >= 0);
+      int32_t QF32 = *val >> pLSB;
+      if constexpr (StoreI32)
+        reinterpret_cast<int32_t *>(dst_row)[x] = QF32;
+      else
+        dst_row[x] = static_cast<float>(QF32);
+    }
+  }
+}
+
+void j2k_dequant(int32_t *sample_buf, size_t blksampl_stride, const uint8_t *block_states,
+                 size_t blkstate_stride, sprec_t *band_buf, uint32_t band_stride, uint32_t width,
+                 uint32_t height, int32_t M_b, uint8_t ROIshift, uint8_t transformation,
+                 float stepsize, bool dequant_i32) {
+  int32_t N_b;
+  const int32_t pLSB    = 31 - M_b;
+  const uint32_t mask   = UINT32_MAX >> (M_b + 1);
+  const int32_t pLSB_m1 = pLSB - 1;
+
   float fscale = stepsize;
   fscale *= (1 << FRACBITS);
   if (M_b <= 31) {
@@ -55,103 +150,12 @@ void j2k_dequant(int32_t *sample_buf, size_t blksampl_stride, const uint8_t *blo
   const auto scale = (int32_t)(fscale + 0.5);
 
   if (transformation == 1) {
-    // Reversible path
-    const int32x4_t v_M_b     = vdupq_n_s32(M_b);
-    const int32x4_t v_30      = vdupq_n_s32(30);
-    const int32x4_t v_1       = vdupq_n_s32(1);
-    const int32x4_t v_pLSB_m1 = vdupq_n_s32(pLSB_m1);
-    const int32x4_t v_neg_pLSB = vdupq_n_s32(-pLSB);
-
-    for (uint32_t y = 0; y < height; y++) {
-      int32_t *val_row        = sample_buf + y * blksampl_stride;
-      const uint8_t *st_row   = block_states + (y + 1) * blkstate_stride + 1;
-      sprec_t *dst_row        = band_buf + y * band_stride;
-      uint32_t x              = 0;
-
-      for (; x + 4 <= width; x += 4) {
-        // Load 4 samples
-        int32x4_t v_val = vld1q_s32(val_row + x);
-
-        // Extract sign (bit 31)
-        int32x4_t v_sign = vshrq_n_s32(v_val, 31);  // 0 or -1
-
-        // Clear sign bit
-        v_val = vandq_s32(v_val, vdupq_n_s32(INT32_MAX));
-
-        if (ROIshift) {
-          // ROI handling: scalar fallback for this rare case
-          int32_t tmp[4];
-          vst1q_s32(tmp, v_val);
-          for (int i = 0; i < 4; i++) {
-            if (((uint32_t)tmp[i] & ~mask) == 0) {
-              tmp[i] <<= ROIshift;
-            }
-          }
-          v_val = vld1q_s32(tmp);
-        }
-
-        // Load 4 state bytes and extract N_b = 31 - (state >> 3)
-        uint8_t st_bytes[4] = {st_row[x], st_row[x + 1], st_row[x + 2], st_row[x + 3]};
-        int32x4_t v_state;
-        if (ROIshift) {
-          v_state = vdupq_n_s32(30 - pLSB + 1);
-        } else {
-          int32_t st_vals[4] = {st_bytes[0] >> 3, st_bytes[1] >> 3, st_bytes[2] >> 3,
-                                st_bytes[3] >> 3};
-          int32x4_t v_st = vld1q_s32(st_vals);
-          v_state        = vaddq_s32(vsubq_s32(v_30, v_st), v_1);  // 30 - (state>>3) + 1
-        }
-
-        // offset = max(M_b - N_b, 0)
-        int32x4_t v_offset = vmaxq_s32(vsubq_s32(v_M_b, v_state), vdupq_n_s32(0));
-
-        // r_val = 1 << (pLSB - 1 + offset)
-        int32x4_t v_shift = vaddq_s32(v_pLSB_m1, v_offset);
-        int32x4_t v_rval  = vshlq_s32(v_1, v_shift);  // per-element variable shift
-
-        // Add r_val if val != 0 && N_b < M_b
-        uint32x4_t v_nonzero = vcgtq_s32(v_val, vdupq_n_s32(0));  // val > 0 (sign cleared)
-        uint32x4_t v_nb_lt   = vcltq_s32(v_state, v_M_b);         // N_b < M_b
-        uint32x4_t v_cond    = vandq_u32(v_nonzero, v_nb_lt);
-        v_val = vorrq_s32(v_val, vandq_s32(v_rval, vreinterpretq_s32_u32(v_cond)));
-
-        // Sign-magnitude to two's complement (branchless)
-        v_val = vsubq_s32(veorq_s32(v_val, v_sign), v_sign);
-
-        // Right shift by pLSB
-        int32x4_t v_qf32 = vshlq_s32(v_val, v_neg_pLSB);
-
-        // Convert to float and store
-        float32x4_t v_out = vcvtq_f32_s32(v_qf32);
-        vst1q_f32(dst_row + x, v_out);
-      }
-
-      // Scalar tail
-      for (; x < width; x++) {
-        int32_t *val = val_row + x;
-        int32_t sign = *val & INT32_MIN;
-        *val &= INT32_MAX;
-        if (ROIshift && (((uint32_t)*val & ~mask) == 0)) {
-          *val <<= ROIshift;
-        }
-        uint8_t state = st_row[x];
-        if (ROIshift) {
-          N_b = 30 - pLSB + 1;
-        } else {
-          N_b = 30 - (state >> 3) + 1;
-        }
-        int32_t offset = (M_b > N_b) ? M_b - N_b : 0;
-        int32_t r_val  = 1 << (pLSB_m1 + offset);
-        if (*val != 0 && N_b < M_b) {
-          *val |= r_val;
-        }
-        int32_t smask = sign >> 31;
-        *val          = (*val ^ smask) - smask;
-        assert(pLSB >= 0);
-        int32_t QF32       = *val >> pLSB;
-        dst_row[x]         = static_cast<float>(QF32);
-      }
-    }
+    if (dequant_i32)
+      j2k_dequant_rev_neon<true>(sample_buf, blksampl_stride, block_states, blkstate_stride,
+                                 band_buf, band_stride, width, height, M_b, ROIshift);
+    else
+      j2k_dequant_rev_neon<false>(sample_buf, blksampl_stride, block_states, blkstate_stride,
+                                  band_buf, band_stride, width, height, M_b, ROIshift);
   } else {
     // Irreversible path
     const int32x4_t v_M_b     = vdupq_n_s32(M_b);
@@ -246,10 +250,11 @@ void j2k_dequant(int32_t *sample_buf, size_t blksampl_stride, const uint8_t *blo
         } else {
           N_b = 30 - (state >> 3) + 1;
         }
-        int32_t offset = (M_b > N_b) ? M_b - N_b : 0;
-        int32_t r_val  = 1 << (pLSB_m1 + offset);
-        if (*val != 0) {
-          *val |= r_val;
+        {
+          int32_t offset = (M_b > N_b) ? M_b - N_b : 0;
+          if (*val != 0) {
+            *val |= 1 << (pLSB_m1 + offset);
+          }
         }
         *val          = (*val + (1 << 15)) >> 16;
         // Modular 32-bit multiply, matching vmulq_s32 exactly (no signed-overflow UB).

--- a/source/core/coding/coding_units.cpp
+++ b/source/core/coding/coding_units.cpp
@@ -139,6 +139,7 @@ struct idwt_level_src_ctx {
   // circuit rows below row_lo with a zero-filled output.
   int32_t row_lo;
   int32_t row_hi;
+  bool use_i32;
 };
 
 // Whole-sample symmetric extension: reflect idx into [0, len).
@@ -255,20 +256,43 @@ static void idwt_level_src_fn(void *ctx, int32_t abs_row, sprec_t *out) {
     // Interleave: LP at u0%2, HP at 1-u0%2.
     const int32_t u_off = c->u0 & 1;
     const int32_t min_w = std::min(c->lp_width, c->hp_width);
-    if (u_off == 0) {
-      for (int32_t j = 0; j < c->lp_width; ++j) out[2 * j] = lp_ptr[j];
-      for (int32_t j = 0; j < c->hp_width; ++j) out[2 * j + 1] = hp_ptr[j];
+    if (c->use_i32) {
+      // int32 data stored in sprec_t (float) buffers — use int32 assignment
+      // to avoid strict-aliasing UB from float-typed loads/stores.
+      int32_t *out_i       = reinterpret_cast<int32_t *>(out);
+      const int32_t *lp_i  = reinterpret_cast<const int32_t *>(lp_ptr);
+      const int32_t *hp_i  = reinterpret_cast<const int32_t *>(hp_ptr);
+      if (u_off == 0) {
+        for (int32_t j = 0; j < c->lp_width; ++j) out_i[2 * j] = lp_i[j];
+        for (int32_t j = 0; j < c->hp_width; ++j) out_i[2 * j + 1] = hp_i[j];
+      } else {
+        for (int32_t j = 0; j < c->hp_width; ++j) out_i[2 * j] = hp_i[j];
+        for (int32_t j = 0; j < c->lp_width; ++j) out_i[2 * j + 1] = lp_i[j];
+      }
     } else {
-      for (int32_t j = 0; j < c->hp_width; ++j) out[2 * j] = hp_ptr[j];
-      for (int32_t j = 0; j < c->lp_width; ++j) out[2 * j + 1] = lp_ptr[j];
+      if (u_off == 0) {
+        for (int32_t j = 0; j < c->lp_width; ++j) out[2 * j] = lp_ptr[j];
+        for (int32_t j = 0; j < c->hp_width; ++j) out[2 * j + 1] = hp_ptr[j];
+      } else {
+        for (int32_t j = 0; j < c->hp_width; ++j) out[2 * j] = hp_ptr[j];
+        for (int32_t j = 0; j < c->lp_width; ++j) out[2 * j + 1] = lp_ptr[j];
+      }
     }
     (void)min_w;  // suppress unused-variable warning (used in BIDIR path below)
     if (width == 1) {
-      if ((c->u0 % 2 != 0) && (c->transformation == 1)) out[0] /= 2.0f;
+      if ((c->u0 % 2 != 0) && (c->transformation == 1)) {
+        if (c->use_i32)
+          reinterpret_cast<int32_t *>(out)[0] >>= 1;
+        else
+          out[0] /= 2.0f;
+      }
       return;
     }
-    idwt_1d_row_inplace_range(out, c->h_pse_left, c->h_pse_right, c->u0, c->u1, c->transformation,
-                              c->col_lo, c->col_hi);
+    if (c->use_i32)
+      idwt_1d_row_inplace_i32(reinterpret_cast<int32_t *>(out), c->h_pse_left, c->h_pse_right, c->u0, c->u1);
+    else
+      idwt_1d_row_inplace_range(out, c->h_pse_left, c->h_pse_right, c->u0, c->u1, c->transformation,
+                                c->col_lo, c->col_hi);
     return;
   }
 
@@ -319,7 +343,33 @@ static void idwt_level_src_fn(void *ctx, int32_t abs_row, sprec_t *out) {
   const int32_t u_off = c->u0 & 1;
   const int32_t min_w = std::min(c->lp_width, c->hp_width);
 #if defined(OPENHTJ2K_TRY_AVX2) && defined(__AVX2__)
-  {
+  if (c->use_i32) {
+    // AVX2 int32 interleave — avoids strict-aliasing UB from float-typed
+    // SIMD on int32_t data.  Same algorithm as the float path below.
+    const int32_t *a_ptr = reinterpret_cast<const int32_t *>((u_off == 0) ? lp_ptr : hp_ptr);
+    const int32_t *b_ptr = reinterpret_cast<const int32_t *>((u_off == 0) ? hp_ptr : lp_ptr);
+    int32_t *out_i       = reinterpret_cast<int32_t *>(out);
+    int32_t i            = 0;
+    for (; i + 8 <= min_w; i += 8) {
+      __m256i va = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(a_ptr + i));
+      __m256i vb = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(b_ptr + i));
+      __m256i lo = _mm256_unpacklo_epi32(va, vb);
+      __m256i hi = _mm256_unpackhi_epi32(va, vb);
+      __m256i r0 = _mm256_permute2x128_si256(lo, hi, 0x20);
+      __m256i r1 = _mm256_permute2x128_si256(lo, hi, 0x31);
+      _mm256_storeu_si256(reinterpret_cast<__m256i *>(out_i + 2 * i), r0);
+      _mm256_storeu_si256(reinterpret_cast<__m256i *>(out_i + 2 * i + 8), r1);
+    }
+    const int32_t *lp_i = reinterpret_cast<const int32_t *>(lp_ptr);
+    const int32_t *hp_i = reinterpret_cast<const int32_t *>(hp_ptr);
+    if (u_off == 0) {
+      for (int32_t j = i; j < c->lp_width; ++j) out_i[2 * j] = lp_i[j];
+      for (int32_t j = i; j < c->hp_width; ++j) out_i[2 * j + 1] = hp_i[j];
+    } else {
+      for (int32_t j = i; j < c->hp_width; ++j) out_i[2 * j] = hp_i[j];
+      for (int32_t j = i; j < c->lp_width; ++j) out_i[2 * j + 1] = lp_i[j];
+    }
+  } else {
     // AVX2: process 8 LP + 8 HP → 16 interleaved floats per iteration.
     // _mm256_unpacklo/hi_ps interleave lanes, permute2f128 reorders 128-bit halves.
     const sprec_t *a_ptr = (u_off == 0) ? lp_ptr : hp_ptr;  // → even slots
@@ -346,29 +396,87 @@ static void idwt_level_src_fn(void *ctx, int32_t abs_row, sprec_t *out) {
   }
 #elif defined(OPENHTJ2K_ENABLE_WASM_SIMD)
   {
+    // WASM SIMD: wasm_v128_load / wasm_i8x16_shuffle / wasm_v128_store are
+    // type-agnostic (operate on v128_t), so the SIMD loop is shared.  Only
+    // the scalar tail needs separate int32 / float assignment.
     const sprec_t *a_ptr = (u_off == 0) ? lp_ptr : hp_ptr;
     const sprec_t *b_ptr = (u_off == 0) ? hp_ptr : lp_ptr;
     int32_t i            = 0;
     for (; i + 4 <= min_w; i += 4) {
       v128_t va = wasm_v128_load(a_ptr + i);
       v128_t vb = wasm_v128_load(b_ptr + i);
-      // Interleave 4 floats: lo=a0,b0,a1,b1  hi=a2,b2,a3,b3
       v128_t lo = wasm_i8x16_shuffle(va, vb, 0, 1, 2, 3, 16, 17, 18, 19, 4, 5, 6, 7, 20, 21, 22, 23);
       v128_t hi = wasm_i8x16_shuffle(va, vb, 8, 9, 10, 11, 24, 25, 26, 27, 12, 13, 14, 15, 28, 29, 30, 31);
       wasm_v128_store(out + 2 * i, lo);
       wasm_v128_store(out + 2 * i + 4, hi);
     }
-    if (u_off == 0) {
-      for (int32_t j = i; j < c->lp_width; ++j) out[2 * j] = lp_ptr[j];
-      for (int32_t j = i; j < c->hp_width; ++j) out[2 * j + 1] = hp_ptr[j];
+    if (c->use_i32) {
+      int32_t *out_i       = reinterpret_cast<int32_t *>(out);
+      const int32_t *lp_i  = reinterpret_cast<const int32_t *>(lp_ptr);
+      const int32_t *hp_i  = reinterpret_cast<const int32_t *>(hp_ptr);
+      if (u_off == 0) {
+        for (int32_t j = i; j < c->lp_width; ++j) out_i[2 * j] = lp_i[j];
+        for (int32_t j = i; j < c->hp_width; ++j) out_i[2 * j + 1] = hp_i[j];
+      } else {
+        for (int32_t j = i; j < c->hp_width; ++j) out_i[2 * j] = hp_i[j];
+        for (int32_t j = i; j < c->lp_width; ++j) out_i[2 * j + 1] = lp_i[j];
+      }
     } else {
-      for (int32_t j = i; j < c->hp_width; ++j) out[2 * j] = hp_ptr[j];
-      for (int32_t j = i; j < c->lp_width; ++j) out[2 * j + 1] = lp_ptr[j];
+      if (u_off == 0) {
+        for (int32_t j = i; j < c->lp_width; ++j) out[2 * j] = lp_ptr[j];
+        for (int32_t j = i; j < c->hp_width; ++j) out[2 * j + 1] = hp_ptr[j];
+      } else {
+        for (int32_t j = i; j < c->hp_width; ++j) out[2 * j] = hp_ptr[j];
+        for (int32_t j = i; j < c->lp_width; ++j) out[2 * j + 1] = lp_ptr[j];
+      }
     }
   }
 #elif defined(OPENHTJ2K_ENABLE_ARM_NEON)
-  {
-    // NEON: vzipq_f32 interleaves two float32x4 vectors. 4× unrolled to process 16 pairs/iter.
+  if (c->use_i32) {
+    // NEON int32 interleave — avoids strict-aliasing UB from float-typed
+    // vzipq_f32 on int32_t data.  Same structure as the float path below.
+    const int32_t *a_ptr = reinterpret_cast<const int32_t *>((u_off == 0) ? lp_ptr : hp_ptr);
+    const int32_t *b_ptr = reinterpret_cast<const int32_t *>((u_off == 0) ? hp_ptr : lp_ptr);
+    int32_t *out_i       = reinterpret_cast<int32_t *>(out);
+    int32_t i            = 0;
+    for (; i + 16 <= min_w; i += 16) {
+      int32x4x2_t z0 = vzipq_s32(vld1q_s32(a_ptr + i), vld1q_s32(b_ptr + i));
+      int32x4x2_t z1 = vzipq_s32(vld1q_s32(a_ptr + i + 4), vld1q_s32(b_ptr + i + 4));
+      int32x4x2_t z2 = vzipq_s32(vld1q_s32(a_ptr + i + 8), vld1q_s32(b_ptr + i + 8));
+      int32x4x2_t z3 = vzipq_s32(vld1q_s32(a_ptr + i + 12), vld1q_s32(b_ptr + i + 12));
+      vst1q_s32(out_i + 2 * i, z0.val[0]);
+      vst1q_s32(out_i + 2 * i + 4, z0.val[1]);
+      vst1q_s32(out_i + 2 * i + 8, z1.val[0]);
+      vst1q_s32(out_i + 2 * i + 12, z1.val[1]);
+      vst1q_s32(out_i + 2 * i + 16, z2.val[0]);
+      vst1q_s32(out_i + 2 * i + 20, z2.val[1]);
+      vst1q_s32(out_i + 2 * i + 24, z3.val[0]);
+      vst1q_s32(out_i + 2 * i + 28, z3.val[1]);
+    }
+    for (; i + 8 <= min_w; i += 8) {
+      int32x4x2_t z0 = vzipq_s32(vld1q_s32(a_ptr + i), vld1q_s32(b_ptr + i));
+      int32x4x2_t z1 = vzipq_s32(vld1q_s32(a_ptr + i + 4), vld1q_s32(b_ptr + i + 4));
+      vst1q_s32(out_i + 2 * i, z0.val[0]);
+      vst1q_s32(out_i + 2 * i + 4, z0.val[1]);
+      vst1q_s32(out_i + 2 * i + 8, z1.val[0]);
+      vst1q_s32(out_i + 2 * i + 12, z1.val[1]);
+    }
+    for (; i + 4 <= min_w; i += 4) {
+      int32x4x2_t zipped = vzipq_s32(vld1q_s32(a_ptr + i), vld1q_s32(b_ptr + i));
+      vst1q_s32(out_i + 2 * i, zipped.val[0]);
+      vst1q_s32(out_i + 2 * i + 4, zipped.val[1]);
+    }
+    const int32_t *lp_i = reinterpret_cast<const int32_t *>(lp_ptr);
+    const int32_t *hp_i = reinterpret_cast<const int32_t *>(hp_ptr);
+    if (u_off == 0) {
+      for (int32_t j = i; j < c->lp_width; ++j) out_i[2 * j] = lp_i[j];
+      for (int32_t j = i; j < c->hp_width; ++j) out_i[2 * j + 1] = hp_i[j];
+    } else {
+      for (int32_t j = i; j < c->hp_width; ++j) out_i[2 * j] = hp_i[j];
+      for (int32_t j = i; j < c->lp_width; ++j) out_i[2 * j + 1] = lp_i[j];
+    }
+  } else {
+    // NEON: vzipq_f32 interleaves two float32x4 vectors. 4x unrolled to process 16 pairs/iter.
     const sprec_t *a_ptr = (u_off == 0) ? lp_ptr : hp_ptr;
     const sprec_t *b_ptr = (u_off == 0) ? hp_ptr : lp_ptr;
     int32_t i            = 0;
@@ -408,14 +516,27 @@ static void idwt_level_src_fn(void *ctx, int32_t abs_row, sprec_t *out) {
     }
   }
 #else
-  (void)min_w;
-  if (u_off == 0) {
-    for (int32_t i = 0; i < c->lp_width; ++i) out[2 * i] = lp_ptr[i];
-    for (int32_t i = 0; i < c->hp_width; ++i) out[2 * i + 1] = hp_ptr[i];
+  if (c->use_i32) {
+    int32_t *out_i       = reinterpret_cast<int32_t *>(out);
+    const int32_t *lp_i  = reinterpret_cast<const int32_t *>(lp_ptr);
+    const int32_t *hp_i  = reinterpret_cast<const int32_t *>(hp_ptr);
+    if (u_off == 0) {
+      for (int32_t i = 0; i < c->lp_width; ++i) out_i[2 * i] = lp_i[i];
+      for (int32_t i = 0; i < c->hp_width; ++i) out_i[2 * i + 1] = hp_i[i];
+    } else {
+      for (int32_t i = 0; i < c->hp_width; ++i) out_i[2 * i] = hp_i[i];
+      for (int32_t i = 0; i < c->lp_width; ++i) out_i[2 * i + 1] = lp_i[i];
+    }
   } else {
-    for (int32_t i = 0; i < c->hp_width; ++i) out[2 * i] = hp_ptr[i];
-    for (int32_t i = 0; i < c->lp_width; ++i) out[2 * i + 1] = lp_ptr[i];
+    if (u_off == 0) {
+      for (int32_t i = 0; i < c->lp_width; ++i) out[2 * i] = lp_ptr[i];
+      for (int32_t i = 0; i < c->hp_width; ++i) out[2 * i + 1] = hp_ptr[i];
+    } else {
+      for (int32_t i = 0; i < c->hp_width; ++i) out[2 * i] = hp_ptr[i];
+      for (int32_t i = 0; i < c->lp_width; ++i) out[2 * i + 1] = lp_ptr[i];
+    }
   }
+  (void)min_w;
 #endif
 
   // In-place horizontal IDWT: the ring buffer slot has IDWT_RING_PSE_LEFT scratch floats
@@ -424,12 +545,19 @@ static void idwt_level_src_fn(void *ctx, int32_t abs_row, sprec_t *out) {
   const int32_t width = c->u1 - c->u0;
   if (width <= 0) return;
   if (width == 1) {
-    // Single-sample edge case (same as idwt_1d_row_fixed).
-    if ((c->u0 % 2 != 0) && (c->transformation == 1)) out[0] /= 2.0f;
+    if ((c->u0 % 2 != 0) && (c->transformation == 1)) {
+      if (c->use_i32)
+        reinterpret_cast<int32_t *>(out)[0] >>= 1;
+      else
+        out[0] /= 2.0f;
+    }
     return;
   }
-  idwt_1d_row_inplace_range(out, c->h_pse_left, c->h_pse_right, c->u0, c->u1, c->transformation, c->col_lo,
-                            c->col_hi);
+  if (c->use_i32)
+    idwt_1d_row_inplace_i32(reinterpret_cast<int32_t *>(out), c->h_pse_left, c->h_pse_right, c->u0, c->u1);
+  else
+    idwt_1d_row_inplace_range(out, c->h_pse_left, c->h_pse_right, c->u0, c->u1, c->transformation, c->col_lo,
+                              c->col_hi);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -2894,7 +3022,9 @@ void j2k_tile_component::init_line_decode(bool ring_mode) {
 
   // Coarsest active resolution: resolution[0] (always LL0 regardless of reduce_NL).
   j2k_resolution *r0 = access_resolution(0);
+  const bool use_i32_pipe = (transformation == 1);
   ld->ll0_buf.init(r0, 0, cb_h_val, ROIshift, ring_mode);
+  ld->ll0_buf.dequant_i32 = use_i32_pipe;
   ld->next_row = static_cast<int32_t>(r0->get_pos0().y);
 
   if (NL_act == 0) {
@@ -2947,9 +3077,13 @@ void j2k_tile_component::init_line_decode(bool ring_mode) {
       hl_bufs[i].init(cr, 0, cb_h_val, ROIshift, ring_mode);
       lh_bufs[i].init(cr, 1, cb_h_val, ROIshift, ring_mode);
       hh_bufs[i].init(cr, 2, cb_h_val, ROIshift, ring_mode);
+      hl_bufs[i].dequant_i32 = use_i32_pipe;
+      lh_bufs[i].dequant_i32 = use_i32_pipe;
+      hh_bufs[i].dequant_i32 = use_i32_pipe;
     } else if (level_dir == DWT_HORZ) {
       sb_HL = cr->access_subband(0);  // H band (horizontal high-pass)
       hl_bufs[i].init(cr, 0, cb_h_val, ROIshift, ring_mode);
+      hl_bufs[i].dequant_i32 = use_i32_pipe;
       // lh_bufs[i] and hh_bufs[i] left default-constructed (no high-freq vertical bands).
     }
     // DWT_NO: no high-freq subbands at all.
@@ -3000,6 +3134,7 @@ void j2k_tile_component::init_line_decode(bool ring_mode) {
     c.col_hi              = u1;
     c.row_lo              = v0;
     c.row_hi              = v1;
+    c.use_i32             = use_i32_pipe;
 
     // lp_tmp only needed when has_child (child state writes output into it as fallback).
     // hp_tmp eliminated: HP data is read directly from subband row buffers.
@@ -3008,7 +3143,8 @@ void j2k_tile_component::init_line_decode(bool ring_mode) {
                              sizeof(sprec_t) * static_cast<size_t>(lp_width + SIMD_PADDING), 32))
                        : nullptr;
 
-    idwt_2d_state_init(&states[i], u0, u1, v0, v1, transformation, level_dir, idwt_level_src_fn, &ctxs[i]);
+    idwt_2d_state_init(&states[i], u0, u1, v0, v1, transformation, level_dir, idwt_level_src_fn, &ctxs[i],
+                       c.use_i32);
   }
 
   // In ring mode: free full-tile sample buffers — ring bufs are used instead.
@@ -3161,7 +3297,13 @@ sprec_t *j2k_tile_component::pull_strip_into_buf(uint32_t count, uint32_t stride
                   sizeof(sprec_t) * stride_floats * tail_rows);
       break;
     }
-    std::memcpy(dst + static_cast<size_t>(r) * stride_floats, src, sizeof(sprec_t) * stride_floats);
+    sprec_t *row_dst = dst + static_cast<size_t>(r) * stride_floats;
+    if (transformation == 1) {
+      const int32_t *ip = reinterpret_cast<const int32_t *>(src);
+      for (uint32_t n = 0; n < stride_floats; ++n) row_dst[n] = static_cast<sprec_t>(ip[n]);
+    } else {
+      std::memcpy(row_dst, src, sizeof(sprec_t) * stride_floats);
+    }
   }
   return dst;
 }
@@ -5629,6 +5771,13 @@ void j2k_tile::decode_line_based(j2k_main_header &hdr, uint8_t reduce_NL_val, st
   // ATK (xform>=2) is irreversible; dispatch table has only 2 entries (0=irrev, 1=rev).
   const uint8_t xform_ct = (xform == 1) ? 1 : 0;
   const uint32_t mct_w   = ci[0].csize_x;
+  sprec_t *mct_scratch0 = nullptr, *mct_scratch1 = nullptr, *mct_scratch2 = nullptr;
+  if (do_mct && xform == 1) {
+    const size_t nb = sizeof(sprec_t) * static_cast<size_t>(mct_w + SIMD_PADDING);
+    mct_scratch0 = static_cast<sprec_t *>(aligned_mem_alloc(nb, 32));
+    mct_scratch1 = static_cast<sprec_t *>(aligned_mem_alloc(nb, 32));
+    mct_scratch2 = static_cast<sprec_t *>(aligned_mem_alloc(nb, 32));
+  }
 
   // Pre-build FinalizeParams for the fused MCT+finalize path.
   FinalizeParams fp[3] = {};
@@ -5659,9 +5808,21 @@ void j2k_tile::decode_line_based(j2k_main_header &hdr, uint8_t reduce_NL_val, st
     if (do_mct) {
       // Fused: get read-only ring buffer pointers for the 3 MCT components, apply inverse
       // MCT + float→int32 finalize in a single pass (no scratch buffer, no memcpy).
-      const sprec_t *p0 = tcomp[0].pull_line_ref();
-      const sprec_t *p1 = tcomp[1].pull_line_ref();
-      const sprec_t *p2 = tcomp[2].pull_line_ref();
+      sprec_t *p0 = tcomp[0].pull_line_ref();
+      sprec_t *p1 = tcomp[1].pull_line_ref();
+      sprec_t *p2 = tcomp[2].pull_line_ref();
+      if (xform == 1) {
+        auto cvt_i32_to_f = [](sprec_t *dst, const sprec_t *src, uint32_t w) {
+          const int32_t *ip = reinterpret_cast<const int32_t *>(src);
+          for (uint32_t i = 0; i < w; ++i) dst[i] = static_cast<sprec_t>(ip[i]);
+        };
+        cvt_i32_to_f(mct_scratch0, p0, mct_w);
+        cvt_i32_to_f(mct_scratch1, p1, mct_w);
+        cvt_i32_to_f(mct_scratch2, p2, mct_w);
+        p0 = mct_scratch0;
+        p1 = mct_scratch1;
+        p2 = mct_scratch2;
+      }
       int32_t *dp0      = ci[0].cdst + ci[0].x_offset + (y + ci[0].y_offset) * ci[0].out_stride;
       int32_t *dp1      = ci[1].cdst + ci[1].x_offset + (y + ci[1].y_offset) * ci[1].out_stride;
       int32_t *dp2      = ci[2].cdst + ci[2].x_offset + (y + ci[2].y_offset) * ci[2].out_stride;
@@ -5671,10 +5832,11 @@ void j2k_tile::decode_line_based(j2k_main_header &hdr, uint8_t reduce_NL_val, st
         if (y >= ci[c].csize_y) continue;
         tcomp[c].pull_line(rows[c].data());
         const CInfo &I     = ci[c];
-        const sprec_t *spf = rows[c].data();
+        const bool is_i32  = (tcomp[c].get_transformation() == 1);
         int32_t *dp        = I.cdst + I.x_offset + (y + I.y_offset) * I.out_stride;
         for (uint32_t n = 0; n < I.csize_x; ++n) {
-          int32_t v = static_cast<int32_t>(spf[n]);
+          int32_t v = is_i32 ? reinterpret_cast<const int32_t *>(rows[c].data())[n]
+                             : static_cast<int32_t>(rows[c][n]);
           v         = (I.downshift < 0)   ? (v + I.rnd) << -I.downshift
                       : (I.downshift > 0) ? (v + I.rnd) >> I.downshift
                                           : v;
@@ -5688,13 +5850,24 @@ void j2k_tile::decode_line_based(j2k_main_header &hdr, uint8_t reduce_NL_val, st
       // No MCT: each component is independent. Use pull_line_ref + per-component finalize.
       for (uint16_t c = 0; c < NC; ++c) {
         if (y >= ci[c].csize_y) continue;
-        const sprec_t *spf = tcomp[c].pull_line_ref();
+        sprec_t *spf_mut = tcomp[c].pull_line_ref();
+        const bool is_i32 = (tcomp[c].get_transformation() == 1);
+        if (!is_i32) {
+          // Float path: nothing to convert.
+        }
+        const sprec_t *spf = spf_mut;
         const CInfo &I     = ci[c];
         int32_t *dp        = I.cdst + I.x_offset + (y + I.y_offset) * I.out_stride;
         const int16_t ds   = I.downshift;
         const int16_t ro   = I.rnd;
 #if defined(OPENHTJ2K_TRY_AVX2) && defined(__AVX2__)
         {
+          auto load_sample = [&](uint32_t n) -> __m256i {
+            if (is_i32)
+              return _mm256_loadu_si256(reinterpret_cast<const __m256i *>(spf + n));
+            else
+              return _mm256_cvttps_epi32(_mm256_loadu_ps(spf + n));
+          };
           const __m256i vdco = _mm256_set1_epi32(I.DC_OFFSET);
           const __m256i vmx  = _mm256_set1_epi32(I.MAXVAL);
           const __m256i vmn  = _mm256_set1_epi32(I.MINVAL);
@@ -5703,10 +5876,8 @@ void j2k_tile::decode_line_based(j2k_main_header &hdr, uint8_t reduce_NL_val, st
             const __m128i vsh  = _mm_cvtsi32_si128(-ds);
             const __m256i vrnd = _mm256_set1_epi32(ro);
             for (; n + 16 <= I.csize_x; n += 16) {
-              __m256i v0 = _mm256_sll_epi32(
-                  _mm256_add_epi32(_mm256_cvttps_epi32(_mm256_loadu_ps(spf + n)), vrnd), vsh);
-              __m256i v1 = _mm256_sll_epi32(
-                  _mm256_add_epi32(_mm256_cvttps_epi32(_mm256_loadu_ps(spf + n + 8)), vrnd), vsh);
+              __m256i v0 = _mm256_sll_epi32(_mm256_add_epi32(load_sample(n), vrnd), vsh);
+              __m256i v1 = _mm256_sll_epi32(_mm256_add_epi32(load_sample(n + 8), vrnd), vsh);
               _mm256_storeu_si256((__m256i *)(dp + n),
                                   _mm256_min_epi32(_mm256_max_epi32(_mm256_add_epi32(v0, vdco), vmn), vmx));
               _mm256_storeu_si256((__m256i *)(dp + n + 8),
@@ -5716,10 +5887,8 @@ void j2k_tile::decode_line_based(j2k_main_header &hdr, uint8_t reduce_NL_val, st
             const __m128i vsh  = _mm_cvtsi32_si128(ds);
             const __m256i vrnd = _mm256_set1_epi32(ro);
             for (; n + 16 <= I.csize_x; n += 16) {
-              __m256i v0 = _mm256_sra_epi32(
-                  _mm256_add_epi32(_mm256_cvttps_epi32(_mm256_loadu_ps(spf + n)), vrnd), vsh);
-              __m256i v1 = _mm256_sra_epi32(
-                  _mm256_add_epi32(_mm256_cvttps_epi32(_mm256_loadu_ps(spf + n + 8)), vrnd), vsh);
+              __m256i v0 = _mm256_sra_epi32(_mm256_add_epi32(load_sample(n), vrnd), vsh);
+              __m256i v1 = _mm256_sra_epi32(_mm256_add_epi32(load_sample(n + 8), vrnd), vsh);
               _mm256_storeu_si256((__m256i *)(dp + n),
                                   _mm256_min_epi32(_mm256_max_epi32(_mm256_add_epi32(v0, vdco), vmn), vmx));
               _mm256_storeu_si256((__m256i *)(dp + n + 8),
@@ -5727,8 +5896,8 @@ void j2k_tile::decode_line_based(j2k_main_header &hdr, uint8_t reduce_NL_val, st
             }
           } else {
             for (; n + 16 <= I.csize_x; n += 16) {
-              __m256i v0 = _mm256_cvttps_epi32(_mm256_loadu_ps(spf + n));
-              __m256i v1 = _mm256_cvttps_epi32(_mm256_loadu_ps(spf + n + 8));
+              __m256i v0 = load_sample(n);
+              __m256i v1 = load_sample(n + 8);
               _mm256_storeu_si256((__m256i *)(dp + n),
                                   _mm256_min_epi32(_mm256_max_epi32(_mm256_add_epi32(v0, vdco), vmn), vmx));
               _mm256_storeu_si256((__m256i *)(dp + n + 8),
@@ -5736,7 +5905,7 @@ void j2k_tile::decode_line_based(j2k_main_header &hdr, uint8_t reduce_NL_val, st
             }
           }
           for (; n < I.csize_x; ++n) {
-            int32_t v = static_cast<int32_t>(spf[n]);
+            int32_t v = is_i32 ? reinterpret_cast<const int32_t *>(spf)[n] : static_cast<int32_t>(spf[n]);
             v         = (ds < 0) ? (v + ro) << -ds : (ds > 0) ? (v + ro) >> ds : v;
             v += I.DC_OFFSET;
             if (v > I.MAXVAL) v = I.MAXVAL;
@@ -5745,19 +5914,34 @@ void j2k_tile::decode_line_based(j2k_main_header &hdr, uint8_t reduce_NL_val, st
           }
         }
 #else
-        for (uint32_t n = 0; n < I.csize_x; ++n) {
-          int32_t v = static_cast<int32_t>(spf[n]);
-          v         = (ds < 0) ? (v + ro) << -ds : (ds > 0) ? (v + ro) >> ds : v;
-          v += I.DC_OFFSET;
-          if (v > I.MAXVAL) v = I.MAXVAL;
-          if (v < I.MINVAL) v = I.MINVAL;
-          dp[n] = v;
+        if (is_i32) {
+          const int32_t *ip = reinterpret_cast<const int32_t *>(spf);
+          for (uint32_t n = 0; n < I.csize_x; ++n) {
+            int32_t v = ip[n];
+            v         = (ds < 0) ? (v + ro) << -ds : (ds > 0) ? (v + ro) >> ds : v;
+            v += I.DC_OFFSET;
+            if (v > I.MAXVAL) v = I.MAXVAL;
+            if (v < I.MINVAL) v = I.MINVAL;
+            dp[n] = v;
+          }
+        } else {
+          for (uint32_t n = 0; n < I.csize_x; ++n) {
+            int32_t v = static_cast<int32_t>(spf[n]);
+            v         = (ds < 0) ? (v + ro) << -ds : (ds > 0) ? (v + ro) >> ds : v;
+            v += I.DC_OFFSET;
+            if (v > I.MAXVAL) v = I.MAXVAL;
+            if (v < I.MINVAL) v = I.MINVAL;
+            dp[n] = v;
+          }
         }
 #endif
       }
     }
   }
 
+  aligned_mem_free(mct_scratch0);
+  aligned_mem_free(mct_scratch1);
+  aligned_mem_free(mct_scratch2);
   for (uint16_t c = 0; c < NC; ++c) tcomp[c].finalize_line_decode();
 }
 

--- a/source/core/coding/coding_units.hpp
+++ b/source/core/coding/coding_units.hpp
@@ -154,6 +154,7 @@ class j2k_codeblock : public j2k_region {
   const uint32_t band_stride;
   OPENHTJ2K_MAYBE_UNUSED const uint8_t R_b;
   const uint8_t transformation;
+  bool dequant_i32 = false;
   const float stepsize;
 
   const uint16_t num_layers;

--- a/source/core/coding/ht_block_decoding.cpp
+++ b/source/core/coding/ht_block_decoding.cpp
@@ -52,6 +52,7 @@ uint8_t j2k_codeblock::calc_mbr(const uint32_t i, const uint32_t j, const uint8_
 }
 
 // Scalar fused dequantize-and-store: convert sign-magnitude int32 to dequantized float.
+template <bool StoreI32 = false>
 static FORCE_INLINE void dequant_store_scalar(void *dst, int32_t val, uint8_t transformation,
                                               int32_t pLSB_dq, float fscale_direct) {
   if (transformation == 1) {
@@ -59,7 +60,10 @@ static FORCE_INLINE void dequant_store_scalar(void *dst, int32_t val, uint8_t tr
     val &= INT32_MAX;
     val >>= pLSB_dq;
     if (sign) val = -(val & INT32_MAX);
-    *reinterpret_cast<float *>(dst) = static_cast<float>(val);
+    if constexpr (StoreI32)
+      *reinterpret_cast<int32_t *>(dst) = val;
+    else
+      *reinterpret_cast<float *>(dst) = static_cast<float>(val);
   } else {
     int32_t sign = val & INT32_MIN;
     float f      = static_cast<float>(val & INT32_MAX) * fscale_direct;
@@ -68,7 +72,7 @@ static FORCE_INLINE void dequant_store_scalar(void *dst, int32_t val, uint8_t tr
   }
 }
 
-template <bool skip_sigma, bool fuse_dequant = false>
+template <bool skip_sigma, bool fuse_dequant = false, bool store_i32 = false>
 void ht_cleanup_decode(j2k_codeblock *block, const uint8_t &pLSB, const int32_t Lcup, const int32_t Pcup,
                        const int32_t Scup) {
   uint8_t *compressed_data = block->get_compressed_data();
@@ -298,7 +302,7 @@ void ht_cleanup_decode(j2k_codeblock *block, const uint8_t &pLSB, const int32_t 
     // Helper to store a decoded sample, optionally fusing dequantize.
     auto store_sample = [&](int32_t *dst, int32_t ival) {
       if constexpr (fuse_dequant) {
-        dequant_store_scalar(dst, ival, block->transformation, pLSB_dq, fscale_direct);
+        dequant_store_scalar<store_i32>(dst, ival, block->transformation, pLSB_dq, fscale_direct);
       } else {
         *dst = ival;
       }
@@ -1021,30 +1025,32 @@ void j2k_codeblock::dequantize(uint8_t ROIshift) const {
   fscale *= (float)(1 << 16) * (float)(1 << downshift);
   const auto scale = (int32_t)(fscale + 0.5);
   if (this->transformation == 1) {
-    // lossless path
-    for (size_t i = 0; i < static_cast<size_t>(this->size.y); i++) {
-      int32_t *val = this->sample_buf + i * this->blksampl_stride;
-      sprec_t *dst = this->band_buf + i * this->band_stride;
-      size_t len   = this->size.x;
-      for (; len > 0; --len) {
-        int32_t sign = *val & INT32_MIN;
-        *val &= INT32_MAX;
-        // detect background region and upshift it
-        if (ROIshift && (((uint32_t)*val & ~mask) == 0)) {
-          *val <<= ROIshift;
+    auto rev_loop = [&](auto store_fn) {
+      for (size_t i = 0; i < static_cast<size_t>(this->size.y); i++) {
+        int32_t *val = this->sample_buf + i * this->blksampl_stride;
+        sprec_t *dst = this->band_buf + i * this->band_stride;
+        size_t len   = this->size.x;
+        for (; len > 0; --len) {
+          int32_t sign = *val & INT32_MIN;
+          *val &= INT32_MAX;
+          if (ROIshift && (((uint32_t)*val & ~mask) == 0)) {
+            *val <<= ROIshift;
+          }
+          *val >>= pLSB;
+          if (sign) {
+            *val = -(*val & INT32_MAX);
+          }
+          assert(pLSB >= 0);
+          store_fn(dst, *val);
+          val++;
+          dst++;
         }
-        *val >>= pLSB;
-        // convert sign-magnitude to two's complement form
-        if (sign) {
-          *val = -(*val & INT32_MAX);
-        }
-
-        assert(pLSB >= 0);  // assure downshift is not negative
-        *dst = static_cast<sprec_t>(*val);
-        val++;
-        dst++;
       }
-    }
+    };
+    if (this->dequant_i32)
+      rev_loop([](sprec_t *d, int32_t v) { *reinterpret_cast<int32_t *>(d) = v; });
+    else
+      rev_loop([](sprec_t *d, int32_t v) { *d = static_cast<sprec_t>(v); });
   } else {
     // lossy path
     OPENHTJ2K_MAYBE_UNUSED int32_t ROImask = 0;
@@ -1191,7 +1197,10 @@ bool htj2k_decode(j2k_codeblock *block, const uint8_t ROIshift) {
     const bool fuseable = (num_ht_passes == 1) && (ROIshift == 0)
                           && ((block->size.y & 1u) == 0u);
     if (fuseable) {
-      ht_cleanup_decode<true, true>(block, static_cast<uint8_t>(30 - S_blk), Lcup, Pcup, Scup);
+      if (block->dequant_i32)
+        ht_cleanup_decode<true, true, true>(block, static_cast<uint8_t>(30 - S_blk), Lcup, Pcup, Scup);
+      else
+        ht_cleanup_decode<true, true>(block, static_cast<uint8_t>(30 - S_blk), Lcup, Pcup, Scup);
       dequant_done = true;
     } else if (num_ht_passes == 1) {
       ht_cleanup_decode<true>(block, static_cast<uint8_t>(30 - S_blk), Lcup, Pcup, Scup);

--- a/source/core/coding/ht_block_decoding_avx2.cpp
+++ b/source/core/coding/ht_block_decoding_avx2.cpp
@@ -108,13 +108,17 @@ static FORCE_INLINE __m256i expand_two_quads(__m128i qinf128) {
 // Fused dequantize-and-store for 8 × int32 MagSgn samples → 8 × float.
 // Lossless (transformation==1): sign-magnitude → two's-complement shift → float.
 // Lossy   (transformation==0): magnitude → float → scale → apply sign via XOR.
+template <bool StoreI32 = false>
 static FORCE_INLINE void dequant_store_256(int32_t *dst, __m256i val, uint8_t transformation,
                                            int32_t pLSB_dq, __m256 vfscale, __m256i vmagmask,
                                            __m256i vsignmask) {
   if (transformation == 1) {
     __m256i mag  = _mm256_and_si256(val, vmagmask);
     __m256i res  = _mm256_sign_epi32(_mm256_srai_epi32(mag, pLSB_dq), val);
-    _mm256_storeu_ps(reinterpret_cast<float *>(dst), _mm256_cvtepi32_ps(res));
+    if constexpr (StoreI32)
+      _mm256_storeu_si256(reinterpret_cast<__m256i *>(dst), res);
+    else
+      _mm256_storeu_ps(reinterpret_cast<float *>(dst), _mm256_cvtepi32_ps(res));
   } else {
     __m256i mag = _mm256_and_si256(val, vmagmask);
     __m256 f    = _mm256_mul_ps(_mm256_cvtepi32_ps(mag), vfscale);
@@ -123,14 +127,17 @@ static FORCE_INLINE void dequant_store_256(int32_t *dst, __m256i val, uint8_t tr
   }
 }
 
-// SSE 128-bit variant: 4 × int32 → 4 × float.
+template <bool StoreI32 = false>
 static FORCE_INLINE void dequant_store_128(int32_t *dst, __m128i val, uint8_t transformation,
                                            int32_t pLSB_dq, __m256 vfscale256, __m128i vmagmask,
                                            __m128i vsignmask) {
   if (transformation == 1) {
     __m128i mag = _mm_and_si128(val, vmagmask);
     __m128i res = _mm_sign_epi32(_mm_srai_epi32(mag, pLSB_dq), val);
-    _mm_storeu_ps(reinterpret_cast<float *>(dst), _mm_cvtepi32_ps(res));
+    if constexpr (StoreI32)
+      _mm_storeu_si128(reinterpret_cast<__m128i *>(dst), res);
+    else
+      _mm_storeu_ps(reinterpret_cast<float *>(dst), _mm_cvtepi32_ps(res));
   } else {
     __m128i mag = _mm_and_si128(val, vmagmask);
     __m128 f    = _mm_mul_ps(_mm_cvtepi32_ps(mag), _mm256_castps256_ps128(vfscale256));
@@ -139,7 +146,7 @@ static FORCE_INLINE void dequant_store_128(int32_t *dst, __m128i val, uint8_t tr
   }
 }
 
-template <bool skip_sigma, bool fuse_dequant = false>
+template <bool skip_sigma, bool fuse_dequant = false, bool store_i32 = false>
 void ht_cleanup_decode(j2k_codeblock *block, const uint8_t &pLSB, const int32_t Lcup, const int32_t Pcup,
                        const int32_t Scup) {
   uint8_t *compressed_data = block->get_compressed_data();
@@ -406,9 +413,9 @@ void ht_cleanup_decode(j2k_codeblock *block, const uint8_t &pLSB, const int32_t 
       __m256i row256   = MagSgn.decode_four_quads(qinf128, U_q128, pLSB_adj, v_n);
 
       if constexpr (fuse_dequant) {
-        dequant_store_256(mp0, _mm256_shuffle_epi8(row256, shuffle_r0), block->transformation, pLSB_dq,
+        dequant_store_256<store_i32>(mp0, _mm256_shuffle_epi8(row256, shuffle_r0), block->transformation, pLSB_dq,
                           vfscale, vmagmask_dq, vsignmask_dq);
-        dequant_store_256(mp1, _mm256_shuffle_epi8(row256, shuffle_r1), block->transformation, pLSB_dq,
+        dequant_store_256<store_i32>(mp1, _mm256_shuffle_epi8(row256, shuffle_r1), block->transformation, pLSB_dq,
                           vfscale, vmagmask_dq, vsignmask_dq);
       } else {
         _mm256_storeu_si256((__m256i *)mp0, _mm256_shuffle_epi8(row256, shuffle_r0));
@@ -436,9 +443,9 @@ void ht_cleanup_decode(j2k_codeblock *block, const uint8_t &pLSB, const int32_t 
       mu0_n   = _mm_unpacklo_epi32(t0, t1);
       mu1_n   = _mm_unpackhi_epi32(t0, t1);
       if constexpr (fuse_dequant) {
-        dequant_store_128(mp0, mu0_n, block->transformation, pLSB_dq, vfscale,
+        dequant_store_128<store_i32>(mp0, mu0_n, block->transformation, pLSB_dq, vfscale,
                           _mm256_castsi256_si128(vmagmask_dq), _mm256_castsi256_si128(vsignmask_dq));
-        dequant_store_128(mp1, mu1_n, block->transformation, pLSB_dq, vfscale,
+        dequant_store_128<store_i32>(mp1, mu1_n, block->transformation, pLSB_dq, vfscale,
                           _mm256_castsi256_si128(vmagmask_dq), _mm256_castsi256_si128(vsignmask_dq));
       } else {
         _mm_storeu_si128((__m128i *)mp0, mu0_n);
@@ -489,9 +496,9 @@ void ht_cleanup_decode(j2k_codeblock *block, const uint8_t &pLSB, const int32_t 
         __m256i row256 = MagSgn.decode_four_quads(qinf128, U_q128, pLSB_adj, v_n);
 
         if constexpr (fuse_dequant) {
-          dequant_store_256(mp0, _mm256_shuffle_epi8(row256, shuffle_r0), block->transformation, pLSB_dq,
+          dequant_store_256<store_i32>(mp0, _mm256_shuffle_epi8(row256, shuffle_r0), block->transformation, pLSB_dq,
                             vfscale, vmagmask_dq, vsignmask_dq);
-          dequant_store_256(mp1, _mm256_shuffle_epi8(row256, shuffle_r1), block->transformation, pLSB_dq,
+          dequant_store_256<store_i32>(mp1, _mm256_shuffle_epi8(row256, shuffle_r1), block->transformation, pLSB_dq,
                             vfscale, vmagmask_dq, vsignmask_dq);
         } else {
           _mm256_storeu_si256((__m256i *)mp0, _mm256_shuffle_epi8(row256, shuffle_r0));
@@ -541,9 +548,9 @@ void ht_cleanup_decode(j2k_codeblock *block, const uint8_t &pLSB, const int32_t 
         mu0_n   = _mm_unpacklo_epi32(t0, t1);
         mu1_n   = _mm_unpackhi_epi32(t0, t1);
         if constexpr (fuse_dequant) {
-          dequant_store_128(mp0, mu0_n, block->transformation, pLSB_dq, vfscale,
+          dequant_store_128<store_i32>(mp0, mu0_n, block->transformation, pLSB_dq, vfscale,
                             _mm256_castsi256_si128(vmagmask_dq), _mm256_castsi256_si128(vsignmask_dq));
-          dequant_store_128(mp1, mu1_n, block->transformation, pLSB_dq, vfscale,
+          dequant_store_128<store_i32>(mp1, mu1_n, block->transformation, pLSB_dq, vfscale,
                             _mm256_castsi256_si128(vmagmask_dq), _mm256_castsi256_si128(vsignmask_dq));
         } else {
           _mm_storeu_si128((__m128i *)mp0, mu0_n);
@@ -579,9 +586,9 @@ void ht_cleanup_decode(j2k_codeblock *block, const uint8_t &pLSB, const int32_t 
       mu0_n   = _mm_unpacklo_epi32(t0, t1);
       mu1_n   = _mm_unpackhi_epi32(t0, t1);
       if constexpr (fuse_dequant) {
-        dequant_store_128(mp0, mu0_n, block->transformation, pLSB_dq, vfscale,
+        dequant_store_128<store_i32>(mp0, mu0_n, block->transformation, pLSB_dq, vfscale,
                           _mm256_castsi256_si128(vmagmask_dq), _mm256_castsi256_si128(vsignmask_dq));
-        dequant_store_128(mp1, mu1_n, block->transformation, pLSB_dq, vfscale,
+        dequant_store_128<store_i32>(mp1, mu1_n, block->transformation, pLSB_dq, vfscale,
                           _mm256_castsi256_si128(vmagmask_dq), _mm256_castsi256_si128(vsignmask_dq));
       } else {
         _mm_storeu_si128((__m128i *)mp0, mu0_n);
@@ -636,9 +643,9 @@ void ht_cleanup_decode(j2k_codeblock *block, const uint8_t &pLSB, const int32_t 
         mu0_n          = _mm_unpacklo_epi32(t0, t1);
         mu1_n          = _mm_unpackhi_epi32(t0, t1);
         if constexpr (fuse_dequant) {
-          dequant_store_128(mp0, mu0_n, block->transformation, pLSB_dq, vfscale,
+          dequant_store_128<store_i32>(mp0, mu0_n, block->transformation, pLSB_dq, vfscale,
                             _mm256_castsi256_si128(vmagmask_dq), _mm256_castsi256_si128(vsignmask_dq));
-          dequant_store_128(mp1, mu1_n, block->transformation, pLSB_dq, vfscale,
+          dequant_store_128<store_i32>(mp1, mu1_n, block->transformation, pLSB_dq, vfscale,
                             _mm256_castsi256_si128(vmagmask_dq), _mm256_castsi256_si128(vsignmask_dq));
         } else {
           _mm_storeu_si128((__m128i *)mp0, mu0_n);
@@ -835,82 +842,77 @@ void j2k_codeblock::dequantize(uint8_t ROIshift) const {
   const __m256i shift   = _mm256_set1_epi32(ROIshift);
   __m256i v0, v1, s0, s1, vdst0, vdst1, vROImask;
   if (this->transformation == 1) {
-    // lossless path
-    for (size_t i = 0; i < static_cast<size_t>(this->size.y); i++) {
-      int32_t *val = this->sample_buf + i * this->blksampl_stride;
-      sprec_t *dst = this->band_buf + i * this->band_stride;
-      size_t len   = this->size.x;
-      if (ROIshift == 0) {
-        // Common case: no ROI — skip the ROI upshift entirely.
-        // val = sample_buf + i * blksampl_stride; blksampl_stride = round_up(width,8) is a
-        // multiple of 8 int32 = 32 bytes, and sample_buf is 32-byte aligned → _mm256_load_si256 ok.
-        for (; len >= 16; len -= 16) {
-          v0    = _mm256_load_si256((__m256i *)val);
-          v1    = _mm256_load_si256((__m256i *)(val + 8));
-          s0    = v0;
-          s1    = v1;
-          v0    = _mm256_and_si256(v0, magmask);
-          v1    = _mm256_and_si256(v1, magmask);
-          vdst0 = _mm256_sign_epi32(_mm256_srai_epi32(v0, pLSB), s0);
-          vdst1 = _mm256_sign_epi32(_mm256_srai_epi32(v1, pLSB), s1);
-          _mm256_storeu_ps(dst, _mm256_cvtepi32_ps(vdst0));
-          _mm256_storeu_ps(dst + 8, _mm256_cvtepi32_ps(vdst1));
-          val += 16;
-          dst += 16;
+    auto rev_dequant = [&](auto simd_store, auto scalar_store) {
+      for (size_t i = 0; i < static_cast<size_t>(this->size.y); i++) {
+        int32_t *val = this->sample_buf + i * this->blksampl_stride;
+        sprec_t *dst = this->band_buf + i * this->band_stride;
+        size_t len   = this->size.x;
+        if (ROIshift == 0) {
+          for (; len >= 16; len -= 16) {
+            v0    = _mm256_load_si256((__m256i *)val);
+            v1    = _mm256_load_si256((__m256i *)(val + 8));
+            s0    = v0;
+            s1    = v1;
+            v0    = _mm256_and_si256(v0, magmask);
+            v1    = _mm256_and_si256(v1, magmask);
+            vdst0 = _mm256_sign_epi32(_mm256_srai_epi32(v0, pLSB), s0);
+            vdst1 = _mm256_sign_epi32(_mm256_srai_epi32(v1, pLSB), s1);
+            simd_store(dst, vdst0, vdst1);
+            val += 16;
+            dst += 16;
+          }
+        } else {
+          for (; len >= 16; len -= 16) {
+            v0 = _mm256_load_si256((__m256i *)val);
+            v1 = _mm256_load_si256((__m256i *)(val + 8));
+            s0 = v0;
+            s1 = v1;
+            v0 = _mm256_and_si256(v0, magmask);
+            v1 = _mm256_and_si256(v1, magmask);
+            vROImask = _mm256_and_si256(v0, vmask);
+            vROImask = _mm256_cmpeq_epi32(vROImask, zero);
+            vROImask = _mm256_and_si256(vROImask, shift);
+            v0       = _mm256_sllv_epi32(v0, vROImask);
+            vROImask = _mm256_and_si256(v1, vmask);
+            vROImask = _mm256_cmpeq_epi32(vROImask, zero);
+            vROImask = _mm256_and_si256(vROImask, shift);
+            v1       = _mm256_sllv_epi32(v1, vROImask);
+            vdst0 = _mm256_sign_epi32(_mm256_srai_epi32(v0, pLSB), s0);
+            vdst1 = _mm256_sign_epi32(_mm256_srai_epi32(v1, pLSB), s1);
+            simd_store(dst, vdst0, vdst1);
+            val += 16;
+            dst += 16;
+          }
         }
         for (; len > 0; --len) {
           int32_t sign = *val & INT32_MIN;
           *val &= INT32_MAX;
-          *val >>= pLSB;
-          if (sign) *val = -(*val & INT32_MAX);
-          *dst = static_cast<float>(*val);
-          val++;
-          dst++;
-        }
-      } else {
-        for (; len >= 16; len -= 16) {
-          v0 = _mm256_load_si256((__m256i *)val);
-          v1 = _mm256_load_si256((__m256i *)(val + 8));
-          s0 = v0;
-          s1 = v1;
-          v0 = _mm256_and_si256(v0, magmask);
-          v1 = _mm256_and_si256(v1, magmask);
-          // upshift background region, if necessary
-          vROImask = _mm256_and_si256(v0, vmask);
-          vROImask = _mm256_cmpeq_epi32(vROImask, zero);
-          vROImask = _mm256_and_si256(vROImask, shift);
-          v0       = _mm256_sllv_epi32(v0, vROImask);
-          vROImask = _mm256_and_si256(v1, vmask);
-          vROImask = _mm256_cmpeq_epi32(vROImask, zero);
-          vROImask = _mm256_and_si256(vROImask, shift);
-          v1       = _mm256_sllv_epi32(v1, vROImask);
-          // convert values from sign-magnitude form to two's complement one
-          vdst0 = _mm256_sign_epi32(_mm256_srai_epi32(v0, pLSB), s0);
-          vdst1 = _mm256_sign_epi32(_mm256_srai_epi32(v1, pLSB), s1);
-          _mm256_storeu_ps(dst, _mm256_cvtepi32_ps(vdst0));
-          _mm256_storeu_ps(dst + 8, _mm256_cvtepi32_ps(vdst1));
-          val += 16;
-          dst += 16;
-        }
-        for (; len > 0; --len) {
-          int32_t sign = *val & INT32_MIN;
-          *val &= INT32_MAX;
-          // detect background region and upshift it
           if (ROIshift && (((uint32_t)*val & ~mask) == 0)) {
             *val <<= ROIshift;
           }
           *val >>= pLSB;
-          // convert sign-magnitude to two's complement form
-          if (sign) {
-            *val = -(*val & INT32_MAX);
-          }
-
-          assert(pLSB >= 0);  // assure downshift is not negative
-          *dst = static_cast<float>(*val);
+          if (sign) *val = -(*val & INT32_MAX);
+          assert(pLSB >= 0);
+          scalar_store(dst, *val);
           val++;
           dst++;
         }
       }
+    };
+    if (this->dequant_i32) {
+      rev_dequant(
+          [](sprec_t *d, __m256i a, __m256i b) {
+            _mm256_storeu_si256(reinterpret_cast<__m256i *>(d), a);
+            _mm256_storeu_si256(reinterpret_cast<__m256i *>(d + 8), b);
+          },
+          [](sprec_t *d, int32_t v) { *reinterpret_cast<int32_t *>(d) = v; });
+    } else {
+      rev_dequant(
+          [](sprec_t *d, __m256i a, __m256i b) {
+            _mm256_storeu_ps(d, _mm256_cvtepi32_ps(a));
+            _mm256_storeu_ps(d + 8, _mm256_cvtepi32_ps(b));
+          },
+          [](sprec_t *d, int32_t v) { *d = static_cast<float>(v); });
     }
   } else {
     // lossy path: compute the direct float scale factor
@@ -1132,7 +1134,10 @@ bool htj2k_decode(j2k_codeblock *block, const uint8_t ROIshift) {
     // causes a data race in multi-threaded decode.  Gate on width % 4 == 0 to avoid this.
     if (num_ht_passes == 1 && ROIshift == 0 && (block->size.x & 3) == 0
         && (block->size.y & 1u) == 0) {
-      ht_cleanup_decode<true, true>(block, static_cast<uint8_t>(30 - S_blk), Lcup, Pcup, Scup);
+      if (block->dequant_i32)
+        ht_cleanup_decode<true, true, true>(block, static_cast<uint8_t>(30 - S_blk), Lcup, Pcup, Scup);
+      else
+        ht_cleanup_decode<true, true>(block, static_cast<uint8_t>(30 - S_blk), Lcup, Pcup, Scup);
       dequant_done = true;
     } else if (num_ht_passes == 1) {
       ht_cleanup_decode<true>(block, static_cast<uint8_t>(30 - S_blk), Lcup, Pcup, Scup);

--- a/source/core/coding/ht_block_decoding_neon.cpp
+++ b/source/core/coding/ht_block_decoding_neon.cpp
@@ -100,6 +100,7 @@ uint8_t j2k_codeblock::calc_mbr(const uint32_t i, const uint32_t j, const uint8_
 // Fused dequantize-and-store for 4 × int32 MagSgn samples → 4 × float.
 // Lossless (transformation==1): sign-magnitude → two's-complement shift → float.
 // Lossy   (transformation==0): magnitude → float → scale → apply sign via XOR.
+template <bool StoreI32 = false>
 static FORCE_INLINE void dequant_store_neon(int32_t *dst, int32x4_t val, uint8_t transformation,
                                             int32_t pLSB_dq, float32x4_t vfscale, int32x4_t vmagmask,
                                             int32x4_t vsignmask) {
@@ -108,7 +109,10 @@ static FORCE_INLINE void dequant_store_neon(int32_t *dst, int32x4_t val, uint8_t
     int32x4_t shifted = vshlq_s32(mag, vdupq_n_s32(-pLSB_dq));
     uint32x4_t neg    = vreinterpretq_u32_s32(vshrq_n_s32(val, 31));
     int32x4_t res     = vbslq_s32(neg, vnegq_s32(shifted), shifted);
-    vst1q_f32(reinterpret_cast<float *>(dst), vcvtq_f32_s32(res));
+    if constexpr (StoreI32)
+      vst1q_s32(dst, res);
+    else
+      vst1q_f32(reinterpret_cast<float *>(dst), vcvtq_f32_s32(res));
   } else {
     int32x4_t mag  = vandq_s32(val, vmagmask);
     float32x4_t f  = vmulq_f32(vcvtq_f32_s32(mag), vfscale);
@@ -118,7 +122,7 @@ static FORCE_INLINE void dequant_store_neon(int32_t *dst, int32x4_t val, uint8_t
   }
 }
 
-template <bool skip_sigma, bool fuse_dequant = false>
+template <bool skip_sigma, bool fuse_dequant = false, bool store_i32 = false>
 void ht_cleanup_decode(j2k_codeblock *block, const uint8_t &pLSB, const int32_t Lcup, const int32_t Pcup,
                        const int32_t Scup) {
   fwd_buf<0xFF> MagSgn(block->get_compressed_data(), Pcup);
@@ -285,9 +289,9 @@ void ht_cleanup_decode(j2k_codeblock *block, const uint8_t &pLSB, const int32_t 
       int16x4_t row0_16 = vuzp1_s16(lo, hi);
       int16x4_t row1_16 = vuzp2_s16(lo, hi);
       if constexpr (fuse_dequant) {
-        dequant_store_neon(mp0, vshll_n_s16(row0_16, 16), block->transformation, pLSB_dq,
+        dequant_store_neon<store_i32>(mp0, vshll_n_s16(row0_16, 16), block->transformation, pLSB_dq,
                            vfscale_dq, vmagmask_dq, vsignmask_dq);
-        dequant_store_neon(mp1, vshll_n_s16(row1_16, 16), block->transformation, pLSB_dq,
+        dequant_store_neon<store_i32>(mp1, vshll_n_s16(row1_16, 16), block->transformation, pLSB_dq,
                            vfscale_dq, vmagmask_dq, vsignmask_dq);
       } else {
         vst1q_s32(mp0, vshll_n_s16(row0_16, 16));
@@ -336,9 +340,9 @@ void ht_cleanup_decode(j2k_codeblock *block, const uint8_t &pLSB, const int32_t 
       mu1    = vandq_u32(mu1, sig1);
 
       if constexpr (fuse_dequant) {
-        dequant_store_neon(mp0, vuzp1q_s32(mu0, mu1), block->transformation, pLSB_dq,
+        dequant_store_neon<store_i32>(mp0, vuzp1q_s32(mu0, mu1), block->transformation, pLSB_dq,
                            vfscale_dq, vmagmask_dq, vsignmask_dq);
-        dequant_store_neon(mp1, vuzp2q_s32(mu0, mu1), block->transformation, pLSB_dq,
+        dequant_store_neon<store_i32>(mp1, vuzp2q_s32(mu0, mu1), block->transformation, pLSB_dq,
                            vfscale_dq, vmagmask_dq, vsignmask_dq);
       } else {
         vst1q_s32(mp0, vuzp1q_s32(mu0, mu1));
@@ -497,9 +501,9 @@ void ht_cleanup_decode(j2k_codeblock *block, const uint8_t &pLSB, const int32_t 
         int16x4_t row0_16 = vuzp1_s16(lo, hi);
         int16x4_t row1_16 = vuzp2_s16(lo, hi);
         if constexpr (fuse_dequant) {
-          dequant_store_neon(mp0, vshll_n_s16(row0_16, 16), block->transformation, pLSB_dq,
+          dequant_store_neon<store_i32>(mp0, vshll_n_s16(row0_16, 16), block->transformation, pLSB_dq,
                              vfscale_dq, vmagmask_dq, vsignmask_dq);
-          dequant_store_neon(mp1, vshll_n_s16(row1_16, 16), block->transformation, pLSB_dq,
+          dequant_store_neon<store_i32>(mp1, vshll_n_s16(row1_16, 16), block->transformation, pLSB_dq,
                              vfscale_dq, vmagmask_dq, vsignmask_dq);
         } else {
           vst1q_s32(mp0, vshll_n_s16(row0_16, 16));
@@ -560,9 +564,9 @@ void ht_cleanup_decode(j2k_codeblock *block, const uint8_t &pLSB, const int32_t 
         mu1    = vandq_u32(mu1, sig1);
 
         if constexpr (fuse_dequant) {
-          dequant_store_neon(mp0, vuzp1q_s32(mu0, mu1), block->transformation, pLSB_dq,
+          dequant_store_neon<store_i32>(mp0, vuzp1q_s32(mu0, mu1), block->transformation, pLSB_dq,
                              vfscale_dq, vmagmask_dq, vsignmask_dq);
-          dequant_store_neon(mp1, vuzp2q_s32(mu0, mu1), block->transformation, pLSB_dq,
+          dequant_store_neon<store_i32>(mp1, vuzp2q_s32(mu0, mu1), block->transformation, pLSB_dq,
                              vfscale_dq, vmagmask_dq, vsignmask_dq);
         } else {
           vst1q_s32(mp0, vuzp1q_s32(mu0, mu1));
@@ -751,53 +755,63 @@ void j2k_codeblock::dequantize(uint8_t ROIshift) const {
   vpLSB    = vdupq_n_s32(pLSB);
   vmagmask = vdupq_n_s32(INT32_MAX);
   if (this->transformation == 1) {
-    // lossless path
-    for (size_t i = 0; i < static_cast<size_t>(this->size.y); i++) {
-      int32_t *val = this->sample_buf + i * this->blksampl_stride;
-      sprec_t *dst = this->band_buf + i * this->band_stride;
-      size_t len   = this->size.x;
-      for (; len >= 8; len -= 8) {  // dequantize two vectors at a time
-        v0 = vld1q_s32(val);
-        v1 = vld1q_s32(val + 4);
-        s0 = vshrq_n_s32(v0, 31);  // generate a mask for negative values
-        s1 = vshrq_n_s32(v1, 31);  // generate a mask for negative values
-        v0 = vandq_s32(v0, vmagmask);
-        v1 = vandq_s32(v1, vmagmask);
-        // upshift background region, if necessary
-        vROImask = vandq_s32(v0, vmask);
-        vROImask = vceqzq_s32(vROImask);
-        vROImask = vandq_s32(vROImask, vROIshift);
-        v0       = vshlq_s32(v0, vsubq_s32(vROImask, vpLSB));
-        vROImask = vandq_s32(v1, vmask);
-        vROImask = vceqzq_s32(vROImask);
-        vROImask = vandq_s32(vROImask, vROIshift);
-        v1       = vshlq_s32(v1, vsubq_s32(vROImask, vpLSB));
-        // convert values from sign-magnitude form to two's complement one
-        vdst0 = vbslq_s32(vreinterpretq_u32_s32(s0), vnegq_s32(v0), v0);
-        vdst1 = vbslq_s32(vreinterpretq_u32_s32(s1), vnegq_s32(v1), v1);
-        // vst1q_s16(dst, vcombine_s16(vmovn_s32(vdst0), vmovn_s32(vdst1)));
-        vst1q_f32(dst, vcvtq_f32_s32(vdst0));
-        vst1q_f32(dst + 4, vcvtq_f32_s32(vdst1));
-        val += 8;
-        dst += 8;
-      }
-      for (; len > 0; --len) {
-        int32_t sign = *val & INT32_MIN;
-        *val &= INT32_MAX;
-        // upshift background region, if necessary
-        if (ROIshift && (((uint32_t)*val & ~mask) == 0)) {
-          *val <<= ROIshift;
+    auto rev_dequant_neon = [&](auto simd_store, auto scalar_store) {
+      for (size_t i = 0; i < static_cast<size_t>(this->size.y); i++) {
+        int32_t *val = this->sample_buf + i * this->blksampl_stride;
+        sprec_t *dst = this->band_buf + i * this->band_stride;
+        size_t len   = this->size.x;
+        for (; len >= 8; len -= 8) {
+          v0 = vld1q_s32(val);
+          v1 = vld1q_s32(val + 4);
+          s0 = vshrq_n_s32(v0, 31);
+          s1 = vshrq_n_s32(v1, 31);
+          v0 = vandq_s32(v0, vmagmask);
+          v1 = vandq_s32(v1, vmagmask);
+          vROImask = vandq_s32(v0, vmask);
+          vROImask = vceqzq_s32(vROImask);
+          vROImask = vandq_s32(vROImask, vROIshift);
+          v0       = vshlq_s32(v0, vsubq_s32(vROImask, vpLSB));
+          vROImask = vandq_s32(v1, vmask);
+          vROImask = vceqzq_s32(vROImask);
+          vROImask = vandq_s32(vROImask, vROIshift);
+          v1       = vshlq_s32(v1, vsubq_s32(vROImask, vpLSB));
+          vdst0 = vbslq_s32(vreinterpretq_u32_s32(s0), vnegq_s32(v0), v0);
+          vdst1 = vbslq_s32(vreinterpretq_u32_s32(s1), vnegq_s32(v1), v1);
+          simd_store(dst, vdst0, vdst1);
+          val += 8;
+          dst += 8;
         }
-        *val >>= pLSB;
-        // convert sign-magnitude to two's complement form
-        if (sign) {
-          *val = -(*val & INT32_MAX);
+        for (; len > 0; --len) {
+          int32_t sign = *val & INT32_MIN;
+          *val &= INT32_MAX;
+          if (ROIshift && (((uint32_t)*val & ~mask) == 0)) {
+            *val <<= ROIshift;
+          }
+          *val >>= pLSB;
+          if (sign) {
+            *val = -(*val & INT32_MAX);
+          }
+          assert(pLSB >= 0);
+          scalar_store(dst, *val);
+          val++;
+          dst++;
         }
-        assert(pLSB >= 0);  // assure downshift is not negative
-        *dst = static_cast<float>(*val);
-        val++;
-        dst++;
       }
+    };
+    if (this->dequant_i32) {
+      rev_dequant_neon(
+          [](sprec_t *d, int32x4_t a, int32x4_t b) {
+            vst1q_s32(reinterpret_cast<int32_t *>(d), a);
+            vst1q_s32(reinterpret_cast<int32_t *>(d + 4), b);
+          },
+          [](sprec_t *d, int32_t v) { *reinterpret_cast<int32_t *>(d) = v; });
+    } else {
+      rev_dequant_neon(
+          [](sprec_t *d, int32x4_t a, int32x4_t b) {
+            vst1q_f32(d, vcvtq_f32_s32(a));
+            vst1q_f32(d + 4, vcvtq_f32_s32(b));
+          },
+          [](sprec_t *d, int32_t v) { *d = static_cast<float>(v); });
     }
   } else {
     // lossy path: compute the direct float scale factor.
@@ -1005,7 +1019,10 @@ bool htj2k_decode(j2k_codeblock *block, const uint8_t ROIshift) {
     // height overflows one row into the next block's region.
     if (num_ht_passes == 1 && ROIshift == 0 && (block->size.x & 3) == 0
         && (block->size.y & 1u) == 0) {
-      ht_cleanup_decode<true, true>(block, static_cast<uint8_t>(30 - S_blk), Lcup, Pcup, Scup);
+      if (block->dequant_i32)
+        ht_cleanup_decode<true, true, true>(block, static_cast<uint8_t>(30 - S_blk), Lcup, Pcup, Scup);
+      else
+        ht_cleanup_decode<true, true>(block, static_cast<uint8_t>(30 - S_blk), Lcup, Pcup, Scup);
       dequant_done = true;
     } else if (num_ht_passes == 1) {
       ht_cleanup_decode<true>(block, static_cast<uint8_t>(30 - S_blk), Lcup, Pcup, Scup);

--- a/source/core/coding/ht_block_decoding_wasm.cpp
+++ b/source/core/coding/ht_block_decoding_wasm.cpp
@@ -118,26 +118,28 @@ static void pack_sigma(const uint8_t *states, size_t bstride, uint32_t width, ui
 }
 
 // WASM SIMD fused dequantize-and-store: 4 × int32 sign-magnitude → 4 × float.
+template <bool StoreI32 = false>
 static inline void dequant_store_wasm(int32_t *dst, v128_t val, uint8_t transformation, int32_t pLSB_dq,
                                       v128_t vfscale, v128_t vmagmask, v128_t vsignmask) {
   if (transformation == 1) {
     v128_t mag     = wasm_v128_and(val, vmagmask);
     v128_t shifted = wasm_i32x4_shr(mag, pLSB_dq);
-    // Apply sign: negate where val is negative (sign bit set)
     v128_t neg     = wasm_i32x4_lt(val, wasm_i32x4_const_splat(0));
     v128_t negated = wasm_i32x4_sub(wasm_i32x4_const_splat(0), shifted);
     v128_t res     = wasm_v128_bitselect(negated, shifted, neg);
-    wasm_v128_store(dst, wasm_f32x4_convert_i32x4(res));
+    if constexpr (StoreI32)
+      wasm_v128_store(dst, res);
+    else
+      wasm_v128_store(dst, wasm_f32x4_convert_i32x4(res));
   } else {
     v128_t mag = wasm_v128_and(val, vmagmask);
     v128_t f   = wasm_f32x4_mul(wasm_f32x4_convert_i32x4(mag), vfscale);
-    // Apply sign via XOR with sign bit
     f = wasm_v128_xor(f, wasm_v128_and(val, vsignmask));
     wasm_v128_store(dst, f);
   }
 }
 
-template <bool skip_sigma, bool fuse_dequant = false>
+template <bool skip_sigma, bool fuse_dequant = false, bool store_i32 = false>
 void ht_cleanup_decode(j2k_codeblock *block, const uint8_t &pLSB, const int32_t Lcup, const int32_t Pcup,
                        const int32_t Scup) {
   fwd_buf<0xFF> MagSgn(block->get_compressed_data(), Pcup);
@@ -290,8 +292,8 @@ void ht_cleanup_decode(j2k_codeblock *block, const uint8_t &pLSB, const int32_t 
       v128_t mu0_32  = wasm_i32x4_shl(wasm_i32x4_extend_low_i16x8(row0_16), 16);
       v128_t mu1_32  = wasm_i32x4_shl(wasm_i32x4_extend_low_i16x8(row1_16), 16);
       if constexpr (fuse_dequant) {
-        dequant_store_wasm(mp0, mu0_32, block->transformation, pLSB_dq, vfscale_dq, vmagmask_dq, vsignmask_dq);
-        dequant_store_wasm(mp1, mu1_32, block->transformation, pLSB_dq, vfscale_dq, vmagmask_dq, vsignmask_dq);
+        dequant_store_wasm<store_i32>(mp0, mu0_32, block->transformation, pLSB_dq, vfscale_dq, vmagmask_dq, vsignmask_dq);
+        dequant_store_wasm<store_i32>(mp1, mu1_32, block->transformation, pLSB_dq, vfscale_dq, vmagmask_dq, vsignmask_dq);
       } else {
         wasm_v128_store(mp0, mu0_32);
         wasm_v128_store(mp1, mu1_32);
@@ -351,9 +353,9 @@ void ht_cleanup_decode(j2k_codeblock *block, const uint8_t &pLSB, const int32_t 
       mu1   = wasm_v128_and(mu1, sig1);
 
       if constexpr (fuse_dequant) {
-        dequant_store_wasm(mp0, wasm_i32x4_shuffle(mu0, mu1, 0, 2, 4, 6), block->transformation, pLSB_dq,
+        dequant_store_wasm<store_i32>(mp0, wasm_i32x4_shuffle(mu0, mu1, 0, 2, 4, 6), block->transformation, pLSB_dq,
                            vfscale_dq, vmagmask_dq, vsignmask_dq);
-        dequant_store_wasm(mp1, wasm_i32x4_shuffle(mu0, mu1, 1, 3, 5, 7), block->transformation, pLSB_dq,
+        dequant_store_wasm<store_i32>(mp1, wasm_i32x4_shuffle(mu0, mu1, 1, 3, 5, 7), block->transformation, pLSB_dq,
                            vfscale_dq, vmagmask_dq, vsignmask_dq);
       } else {
         wasm_v128_store(mp0, wasm_i32x4_shuffle(mu0, mu1, 0, 2, 4, 6));
@@ -484,8 +486,8 @@ void ht_cleanup_decode(j2k_codeblock *block, const uint8_t &pLSB, const int32_t 
         v128_t mu0_32  = wasm_i32x4_shl(wasm_i32x4_extend_low_i16x8(row0_16), 16);
         v128_t mu1_32  = wasm_i32x4_shl(wasm_i32x4_extend_low_i16x8(row1_16), 16);
         if constexpr (fuse_dequant) {
-          dequant_store_wasm(mp0, mu0_32, block->transformation, pLSB_dq, vfscale_dq, vmagmask_dq, vsignmask_dq);
-          dequant_store_wasm(mp1, mu1_32, block->transformation, pLSB_dq, vfscale_dq, vmagmask_dq, vsignmask_dq);
+          dequant_store_wasm<store_i32>(mp0, mu0_32, block->transformation, pLSB_dq, vfscale_dq, vmagmask_dq, vsignmask_dq);
+          dequant_store_wasm<store_i32>(mp1, mu1_32, block->transformation, pLSB_dq, vfscale_dq, vmagmask_dq, vsignmask_dq);
         } else {
           wasm_v128_store(mp0, mu0_32);
           wasm_v128_store(mp1, mu1_32);
@@ -547,9 +549,9 @@ void ht_cleanup_decode(j2k_codeblock *block, const uint8_t &pLSB, const int32_t 
         mu1   = wasm_v128_and(mu1, sig1);
 
         if constexpr (fuse_dequant) {
-          dequant_store_wasm(mp0, wasm_i32x4_shuffle(mu0, mu1, 0, 2, 4, 6), block->transformation,
+          dequant_store_wasm<store_i32>(mp0, wasm_i32x4_shuffle(mu0, mu1, 0, 2, 4, 6), block->transformation,
                              pLSB_dq, vfscale_dq, vmagmask_dq, vsignmask_dq);
-          dequant_store_wasm(mp1, wasm_i32x4_shuffle(mu0, mu1, 1, 3, 5, 7), block->transformation,
+          dequant_store_wasm<store_i32>(mp1, wasm_i32x4_shuffle(mu0, mu1, 1, 3, 5, 7), block->transformation,
                              pLSB_dq, vfscale_dq, vmagmask_dq, vsignmask_dq);
         } else {
           wasm_v128_store(mp0, wasm_i32x4_shuffle(mu0, mu1, 0, 2, 4, 6));
@@ -700,48 +702,63 @@ void j2k_codeblock::dequantize(uint8_t ROIshift) const {
   vpLSB    = wasm_i32x4_splat(pLSB);
   vmagmask = wasm_i32x4_const_splat(INT32_MAX);
   if (this->transformation == 1) {
-    // lossless path
-    for (size_t i = 0; i < static_cast<size_t>(this->size.y); i++) {
-      int32_t *val = this->sample_buf + i * this->blksampl_stride;
-      sprec_t *dst = this->band_buf + i * this->band_stride;
-      size_t len   = this->size.x;
-      for (; len >= 8; len -= 8) {
-        v0       = wasm_v128_load(val);
-        v1       = wasm_v128_load(val + 4);
-        s0       = wasm_i32x4_shr(v0, 31);
-        s1       = wasm_i32x4_shr(v1, 31);
-        v0       = wasm_v128_and(v0, vmagmask);
-        v1       = wasm_v128_and(v1, vmagmask);
-        vROImask = wasm_v128_and(v0, vmask);
-        vROImask = wasm_i32x4_eq(vROImask, wasm_i32x4_const_splat(0));
-        vROImask = wasm_v128_and(vROImask, vROIshift);
-        v0       = wasm_i32x4_vshl(v0, wasm_i32x4_sub(vROImask, vpLSB));
-        vROImask = wasm_v128_and(v1, vmask);
-        vROImask = wasm_i32x4_eq(vROImask, wasm_i32x4_const_splat(0));
-        vROImask = wasm_v128_and(vROImask, vROIshift);
-        v1       = wasm_i32x4_vshl(v1, wasm_i32x4_sub(vROImask, vpLSB));
-        vdst0    = wasm_v128_bitselect(wasm_i32x4_neg(v0), v0, s0);
-        vdst1    = wasm_v128_bitselect(wasm_i32x4_neg(v1), v1, s1);
-        wasm_v128_store(dst, wasm_f32x4_convert_i32x4(vdst0));
-        wasm_v128_store(dst + 4, wasm_f32x4_convert_i32x4(vdst1));
-        val += 8;
-        dst += 8;
-      }
-      for (; len > 0; --len) {
-        int32_t sign = *val & INT32_MIN;
-        *val &= INT32_MAX;
-        if (ROIshift && (((uint32_t)*val & ~mask) == 0)) {
-          *val <<= ROIshift;
+    auto rev_dequant_wasm = [&](auto simd_store, auto scalar_store) {
+      for (size_t i = 0; i < static_cast<size_t>(this->size.y); i++) {
+        int32_t *val = this->sample_buf + i * this->blksampl_stride;
+        sprec_t *dst = this->band_buf + i * this->band_stride;
+        size_t len   = this->size.x;
+        for (; len >= 8; len -= 8) {
+          v0       = wasm_v128_load(val);
+          v1       = wasm_v128_load(val + 4);
+          s0       = wasm_i32x4_shr(v0, 31);
+          s1       = wasm_i32x4_shr(v1, 31);
+          v0       = wasm_v128_and(v0, vmagmask);
+          v1       = wasm_v128_and(v1, vmagmask);
+          vROImask = wasm_v128_and(v0, vmask);
+          vROImask = wasm_i32x4_eq(vROImask, wasm_i32x4_const_splat(0));
+          vROImask = wasm_v128_and(vROImask, vROIshift);
+          v0       = wasm_i32x4_vshl(v0, wasm_i32x4_sub(vROImask, vpLSB));
+          vROImask = wasm_v128_and(v1, vmask);
+          vROImask = wasm_i32x4_eq(vROImask, wasm_i32x4_const_splat(0));
+          vROImask = wasm_v128_and(vROImask, vROIshift);
+          v1       = wasm_i32x4_vshl(v1, wasm_i32x4_sub(vROImask, vpLSB));
+          vdst0    = wasm_v128_bitselect(wasm_i32x4_neg(v0), v0, s0);
+          vdst1    = wasm_v128_bitselect(wasm_i32x4_neg(v1), v1, s1);
+          simd_store(dst, vdst0, vdst1);
+          val += 8;
+          dst += 8;
         }
-        *val >>= pLSB;
-        if (sign) {
-          *val = -(*val & INT32_MAX);
+        for (; len > 0; --len) {
+          int32_t sign = *val & INT32_MIN;
+          *val &= INT32_MAX;
+          if (ROIshift && (((uint32_t)*val & ~mask) == 0)) {
+            *val <<= ROIshift;
+          }
+          *val >>= pLSB;
+          if (sign) {
+            *val = -(*val & INT32_MAX);
+          }
+          assert(pLSB >= 0);
+          scalar_store(dst, *val);
+          val++;
+          dst++;
         }
-        assert(pLSB >= 0);
-        *dst = static_cast<int32_t>(*val);
-        val++;
-        dst++;
       }
+    };
+    if (this->dequant_i32) {
+      rev_dequant_wasm(
+          [](sprec_t *d, v128_t a, v128_t b) {
+            wasm_v128_store(d, a);
+            wasm_v128_store(d + 4, b);
+          },
+          [](sprec_t *d, int32_t v) { *reinterpret_cast<int32_t *>(d) = v; });
+    } else {
+      rev_dequant_wasm(
+          [](sprec_t *d, v128_t a, v128_t b) {
+            wasm_v128_store(d, wasm_f32x4_convert_i32x4(a));
+            wasm_v128_store(d + 4, wasm_f32x4_convert_i32x4(b));
+          },
+          [](sprec_t *d, int32_t v) { *d = static_cast<sprec_t>(v); });
     }
   } else {
     // lossy path
@@ -936,7 +953,10 @@ bool htj2k_decode(j2k_codeblock *block, const uint8_t ROIshift) {
     // height overflows one row into the next block's region.
     if (num_ht_passes == 1 && ROIshift == 0 && (block->size.x & 3) == 0
         && (block->size.y & 1u) == 0) {
-      ht_cleanup_decode<true, true>(block, static_cast<uint8_t>(30 - S_blk), Lcup, Pcup, Scup);
+      if (block->dequant_i32)
+        ht_cleanup_decode<true, true, true>(block, static_cast<uint8_t>(30 - S_blk), Lcup, Pcup, Scup);
+      else
+        ht_cleanup_decode<true, true>(block, static_cast<uint8_t>(30 - S_blk), Lcup, Pcup, Scup);
       dequant_done = true;
     } else if (num_ht_passes == 1) {
       ht_cleanup_decode<true>(block, static_cast<uint8_t>(30 - S_blk), Lcup, Pcup, Scup);

--- a/source/core/coding/ht_block_encoding_neon.cpp
+++ b/source/core/coding/ht_block_encoding_neon.cpp
@@ -233,6 +233,15 @@ auto make_storage_one = [](int32_t *sp0, int32_t *sp1, int32x4_t &sig0,
       vsubq_s32(vdupq_n_s32(32), vreinterpretq_s32_u32(vclzq_u32(vreinterpretq_u32_s32(v0)))), sig0);
 };
 
+static inline void append_quad_to_flat(int32x4_t v, int32x4_t m, int32x4_t k1,
+                                       uint32_t *flat_v, uint32_t *flat_m,
+                                       int32_t fc) {
+  int32x4_t tmp    = vshlq_s32(k1, m);
+  int32x4_t v_corr = vsubq_s32(v, tmp);
+  vst1q_u32(flat_v + fc, vreinterpretq_u32_s32(v_corr));
+  vst1q_u32(flat_m + fc, vreinterpretq_u32_s32(m));
+}
+
 // joint termination of MEL and VLC
 int32_t termMELandVLC(state_VLC_enc &VLC, state_MEL_enc &MEL) {
   VLC.termVLC();
@@ -346,6 +355,11 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
   int32_t u_q, uoff, u_min, uvlc_idx, kappa = 1;
   int32_t emb_pattern, embk_0, embk_1, emb1_0, emb1_1;
 
+  // Deferred MagSgn: accumulate per-quad (v_corr, m) into flat arrays,
+  // drain once per line-pair via emitFlat.
+  alignas(32) uint32_t flat_v[512 * 4], flat_m[512 * 4];
+  int32_t flat_count;
+
   const int32x4_t lshift = vcombine_s32(vcreate_s32(0x0000000100000000),
                                         vcreate_s32(0x0000000300000002));  //{0, 1, 2, 3};
   const int32x4_t rshift = vcombine_s32(
@@ -360,6 +374,7 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
   int32_t *sp0 = block->sample_buf;
   int32_t *sp1 = sp0 + block->blksampl_stride;
   uint32_t qx;
+  flat_count = 0;
   for (qx = QW; qx >= 2; qx -= 2) {
     bool uoff_flag = true;
 
@@ -440,15 +455,15 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
       }
     }
 
-    // MagSgn encoding
+    // Defer MagSgn encoding
     m0       = vsubq_s32(vandq_s32(sig0, vdupq_n_s32(U0)),
                          vandq_s32(vshlq_s32(vdupq_n_s32(embk_0), rshift), vone));
     m1       = vsubq_s32(vandq_s32(sig1, vdupq_n_s32(U1)),
                          vandq_s32(vshlq_s32(vdupq_n_s32(embk_1), rshift), vone));
     known1_0 = vandq_s32(vshlq_s32(vdupq_n_s32(emb1_0), rshift), vone);
     known1_1 = vandq_s32(vshlq_s32(vdupq_n_s32(emb1_1), rshift), vone);
-    MagSgn_encoder.emitBits(v0, m0, known1_0);
-    MagSgn_encoder.emitBits(v1, m1, known1_1);
+    append_quad_to_flat(v0, m0, known1_0, flat_v, flat_m, flat_count); flat_count += 4;
+    append_quad_to_flat(v1, m1, known1_1, flat_v, flat_m, flat_count); flat_count += 4;
 
     // context for the next quad
     context = (rho1 >> 1) | (rho1 & 0x1);
@@ -493,15 +508,17 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
     cwd          = tmp >> 8;
     VLC_encoder.emitVLCBits(cwd, lw);
 
-    // MagSgn encoding
+    // Defer MagSgn encoding
     m0       = vsubq_s32(vandq_s32(sig0, vdupq_n_s32(U0)),
                          vandq_s32(vshlq_s32(vdupq_n_s32(embk_0), rshift), vone));
     known1_0 = vandq_s32(vshlq_s32(vdupq_n_s32(emb1_0), rshift), vone);
-    MagSgn_encoder.emitBits(v0, m0, known1_0);
+    append_quad_to_flat(v0, m0, known1_0, flat_v, flat_m, flat_count); flat_count += 4;
 
     // update rho_line
     *rho_p++ = rho0;
   }
+  // Drain initial line-pair MagSgn batch
+  MagSgn_encoder.emitFlat(flat_v, flat_m, flat_count);
 
   /*******************************************************************************************************************/
   // Non-initial line-pair
@@ -511,6 +528,7 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
     E_p   = Eline + 1;
     rho_p = rholine + 1;
     rho1  = 0;
+    flat_count = 0;
 
     Emax0 = find_max(E_p[-1], E_p[0], E_p[1], E_p[2]);
     Emax1 = find_max(E_p[1], E_p[2], E_p[3], E_p[4]);
@@ -581,15 +599,15 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
       cwd          = tmp >> 8;
       VLC_encoder.emitVLCBits(cwd, lw);
 
-      // MagSgn encoding
+      // Defer MagSgn encoding
       m0       = vsubq_s32(vandq_s32(sig0, vdupq_n_s32(U0)),
                            vandq_s32(vshlq_s32(vdupq_n_s32(embk_0), rshift), vone));
       m1       = vsubq_s32(vandq_s32(sig1, vdupq_n_s32(U1)),
                            vandq_s32(vshlq_s32(vdupq_n_s32(embk_1), rshift), vone));
       known1_0 = vandq_s32(vshlq_s32(vdupq_n_s32(emb1_0), rshift), vone);
       known1_1 = vandq_s32(vshlq_s32(vdupq_n_s32(emb1_1), rshift), vone);
-      MagSgn_encoder.emitBits(v0, m0, known1_0);
-      MagSgn_encoder.emitBits(v1, m1, known1_1);
+      append_quad_to_flat(v0, m0, known1_0, flat_v, flat_m, flat_count); flat_count += 4;
+      append_quad_to_flat(v1, m1, known1_1, flat_v, flat_m, flat_count); flat_count += 4;
 
       Emax0 = vmaxvq_s32(vld1q_s32(E_p + 3));  // find_max(E_p[3], E_p[4], E_p[5], E_p[6]);
       Emax1 = vmaxvq_s32(vld1q_s32(E_p + 5));  // find_max(E_p[5], E_p[6], E_p[7], E_p[8]);
@@ -644,15 +662,17 @@ int32_t htj2k_cleanup_encode(j2k_codeblock *const block, const uint8_t ROIshift)
       cwd          = tmp >> 8;
       VLC_encoder.emitVLCBits(cwd, lw);
 
-      // MagSgn encoding
+      // Defer MagSgn encoding
       m0       = vsubq_s32(vandq_s32(sig0, vdupq_n_s32(U0)),
                            vandq_s32(vshlq_s32(vdupq_n_s32(embk_0), rshift), vone));
       known1_0 = vandq_s32(vshlq_s32(vdupq_n_s32(emb1_0), rshift), vone);
-      MagSgn_encoder.emitBits(v0, m0, known1_0);
+      append_quad_to_flat(v0, m0, known1_0, flat_v, flat_m, flat_count); flat_count += 4;
 
       // update rho_line
       *rho_p++ = rho0;
     }
+    // Drain MagSgn batch for this line pair
+    MagSgn_encoder.emitFlat(flat_v, flat_m, flat_count);
   }
 
   Pcup = MagSgn_encoder.termMS();

--- a/source/core/coding/ht_block_encoding_neon.hpp
+++ b/source/core/coding/ht_block_encoding_neon.hpp
@@ -158,6 +158,68 @@ class state_MS_enc {
 #endif
   }
 
+#ifdef _MSC_VER
+  __declspec(noinline)
+#else
+  __attribute__((noinline))
+#endif
+  void emitFlat(const uint32_t *v, const uint32_t *m, int32_t count) {
+    uint64_t cr = Creg;
+    uint32_t ct = ctreg;
+    uint8_t la = last;
+    int32_t po = pos;
+
+    auto flush = [&]() {
+      uint32_t val = static_cast<uint32_t>(cr);
+      if (la < 0xFF && (val & 0xFF) < 0xFF && ((val >> 8) & 0xFF) < 0xFF
+          && ((val >> 16) & 0xFF) < 0xFF) {
+        la = static_cast<uint8_t>(val >> 24);
+        cr >>= 32; ct -= 32;
+        *reinterpret_cast<uint32_t *>(buf + po) = val; po += 4;
+      } else {
+        uint32_t bl = 0, t = 0, stuff = (la == 0xFF), tmp;
+        tmp = val & ((1U << (8U - stuff)) - 1U);
+        t |= tmp; bl += 8 - stuff; stuff = (tmp == 0xFF);
+        tmp = (val >> bl) & ((1U << (8U - stuff)) - 1U);
+        t |= tmp << 8; bl += 8 - stuff; stuff = (tmp == 0xFF);
+        tmp = (val >> bl) & ((1U << (8U - stuff)) - 1U);
+        t |= tmp << 16; bl += 8 - stuff; stuff = (tmp == 0xFF);
+        tmp = (val >> bl) & ((1U << (8U - stuff)) - 1U);
+        t |= tmp << 24; bl += 8 - stuff;
+        la = static_cast<uint8_t>(tmp); cr >>= bl; ct -= bl;
+        *reinterpret_cast<uint32_t *>(buf + po) = t; po += 4;
+      }
+    };
+
+    int32_t i = 0;
+    for (; i + 3 < count; i += 4) {
+      uint32_t m_sum = m[i] + m[i + 1] + m[i + 2] + m[i + 3];
+      if (ct + m_sum < 64) {
+        uint32_t s0 = ct;
+        cr |= static_cast<uint64_t>(v[i]) << s0; s0 += m[i];
+        cr |= static_cast<uint64_t>(v[i + 1]) << s0; s0 += m[i + 1];
+        cr |= static_cast<uint64_t>(v[i + 2]) << s0; s0 += m[i + 2];
+        cr |= static_cast<uint64_t>(v[i + 3]) << s0;
+        ct += m_sum;
+        if (ct >= 32) flush();
+      } else {
+        cr |= static_cast<uint64_t>(v[i]) << ct; ct += m[i];
+        if (ct >= 32) flush();
+        cr |= static_cast<uint64_t>(v[i + 1]) << ct; ct += m[i + 1];
+        if (ct >= 32) flush();
+        cr |= static_cast<uint64_t>(v[i + 2]) << ct; ct += m[i + 2];
+        if (ct >= 32) flush();
+        cr |= static_cast<uint64_t>(v[i + 3]) << ct; ct += m[i + 3];
+        if (ct >= 32) flush();
+      }
+    }
+    for (; i < count; ++i) {
+      cr |= static_cast<uint64_t>(v[i]) << ct; ct += m[i];
+      while (ct >= 32) flush();
+    }
+    Creg = cr; ctreg = ct; last = la; pos = po;
+  }
+
   FORCE_INLINE int32_t termMS() {
     while (true) {
       if (last == 0xFF) {

--- a/source/core/coding/subband_row_buf.cpp
+++ b/source/core/coding/subband_row_buf.cpp
@@ -324,6 +324,7 @@ void j2k_subband_row_buf::decode_strip_core(sprec_t *target_buf, int32_t y0, int
         pool->push_batch(par_tasks, [this](const CblkTask &bt) {
           auto *blk = bt.block;
           return [blk, this]() {
+            blk->dequant_i32 = this->dequant_i32;
             if ((blk->Cmodes & HT) >> 6)
               htj2k_decode(blk, ROIshift);
             else
@@ -425,6 +426,7 @@ void j2k_subband_row_buf::decode_strip_core(sprec_t *target_buf, int32_t y0, int
           block->band_buf        = target_buf + row_off + col_off;
         }
 
+        block->dequant_i32 = this->dequant_i32;
         if ((block->Cmodes & HT) >> 6)
           htj2k_decode(block, ROIshift);
         else
@@ -667,6 +669,7 @@ void j2k_subband_row_buf::trigger_prefetch(int32_t next_y0) {
   pool->push_batch(par_tasks, [this](const CblkTask &pb) {
     auto *blk = pb.block;
     return [blk, this]() {
+      blk->dequant_i32 = this->dequant_i32;
       if ((blk->Cmodes & HT) >> 6)
         htj2k_decode(blk, ROIshift);
       else

--- a/source/core/coding/subband_row_buf.hpp
+++ b/source/core/coding/subband_row_buf.hpp
@@ -58,6 +58,7 @@ struct j2k_subband_row_buf {
   j2k_resolution *res;        // to enumerate precincts
   uint8_t         band_idx;   // index within resolution's subbands (0=HL,1=LH,2=HH)
   uint8_t         ROIshift;
+  bool            dequant_i32 = false;
 
   int32_t cb_h;       // codeblock height for this resolution (max across precincts)
   int32_t strip_y0;   // y-start of the currently-decoded codeblock strip (-1 = none)

--- a/source/core/transform/dwt.hpp
+++ b/source/core/transform/dwt.hpp
@@ -172,6 +172,50 @@ static inline void dwt_pse_fill_inplace_simd(sprec_t *row, int32_t width) {
   for (int32_t i = 0; i <  8; ++i) row[width + i]     = row[width - 2 - i];
 #endif
 }
+
+// Integer variant of dwt_pse_fill_inplace_simd for use_i32 buffers.
+// Identical algorithm but uses integer SIMD intrinsics — avoids strict-aliasing
+// UB from applying float-typed operations to int32_t data.
+static inline void dwt_pse_fill_inplace_i32(int32_t *row, int32_t width) {
+#if defined(OPENHTJ2K_ENABLE_AVX2)
+  const __m256i rev = _mm256_setr_epi32(7, 6, 5, 4, 3, 2, 1, 0);
+  __m256i lv = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(row + 1));
+  __m256i lr = _mm256_permutevar8x32_epi32(lv, rev);
+  _mm256_storeu_si256(reinterpret_cast<__m256i *>(row - 8), lr);
+  __m256i rv = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(row + width - 9));
+  __m256i rr = _mm256_permutevar8x32_epi32(rv, rev);
+  _mm256_storeu_si256(reinterpret_cast<__m256i *>(row + width), rr);
+#elif defined(OPENHTJ2K_ENABLE_ARM_NEON)
+  int32x4_t lo = vld1q_s32(row + 1);
+  int32x4_t hi = vld1q_s32(row + 5);
+  int32x4_t lo_rev = vrev64q_s32(vextq_s32(lo, lo, 2));
+  int32x4_t hi_rev = vrev64q_s32(vextq_s32(hi, hi, 2));
+  vst1q_s32(row - 4, lo_rev);
+  vst1q_s32(row - 8, hi_rev);
+  int32x4_t r_lo = vld1q_s32(row + width - 9);
+  int32x4_t r_hi = vld1q_s32(row + width - 5);
+  int32x4_t r_hi_rev = vrev64q_s32(vextq_s32(r_hi, r_hi, 2));
+  int32x4_t r_lo_rev = vrev64q_s32(vextq_s32(r_lo, r_lo, 2));
+  vst1q_s32(row + width,     r_hi_rev);
+  vst1q_s32(row + width + 4, r_lo_rev);
+#elif defined(OPENHTJ2K_ENABLE_WASM_SIMD)
+  v128_t lo = wasm_v128_load(row + 1);
+  v128_t hi = wasm_v128_load(row + 5);
+  v128_t lo_rev = wasm_i32x4_shuffle(lo, lo, 3, 2, 1, 0);
+  v128_t hi_rev = wasm_i32x4_shuffle(hi, hi, 3, 2, 1, 0);
+  wasm_v128_store(row - 4, lo_rev);
+  wasm_v128_store(row - 8, hi_rev);
+  v128_t r_lo = wasm_v128_load(row + width - 9);
+  v128_t r_hi = wasm_v128_load(row + width - 5);
+  v128_t r_hi_rev = wasm_i32x4_shuffle(r_hi, r_hi, 3, 2, 1, 0);
+  v128_t r_lo_rev = wasm_i32x4_shuffle(r_lo, r_lo, 3, 2, 1, 0);
+  wasm_v128_store(row + width,     r_hi_rev);
+  wasm_v128_store(row + width + 4, r_lo_rev);
+#else
+  for (int32_t i = 1; i <= 8; ++i) row[-i]        = row[i];
+  for (int32_t i = 0; i <  8; ++i) row[width + i] = row[width - 2 - i];
+#endif
+}
 template <class T>
 static inline void dwt_1d_extr_fixed(T *extbuf, T *buf, const int32_t left, const int32_t right,
                                      const int32_t i0, const int32_t i1) {
@@ -261,6 +305,9 @@ void idwt_irrev53_ver_sr_fixed_avx512(sprec_t *in, int32_t u0, int32_t u1, int32
 void idwt_irrev_ver_step_fixed_avx512(int32_t n, float *prev, float *next, float *tgt, float coeff);
 void idwt_rev_ver_lp_step_avx512(int32_t n, const float *prev, const float *next, float *tgt);
 void idwt_rev_ver_hp_step_avx512(int32_t n, const float *prev, const float *next, float *tgt);
+void idwt_1d_filtr_rev53_i32_avx512(int32_t *X, int32_t left, int32_t u_i0, int32_t u_i1);
+void idwt_rev_ver_lp_step_i32_avx512(int32_t n, const int32_t *prev, const int32_t *next, int32_t *tgt);
+void idwt_rev_ver_hp_step_i32_avx512(int32_t n, const int32_t *prev, const int32_t *next, int32_t *tgt);
 // Single-row reversible (5/3) FDWT vertical lifting steps.
 void fdwt_rev_ver_hp_step_avx512(int32_t n, const float *prev, const float *next, float *tgt);
 void fdwt_rev_ver_lp_step_avx512(int32_t n, const float *prev, const float *next, float *tgt);
@@ -284,6 +331,9 @@ void idwt_irrev_ver_step_fixed_neon(int32_t n, float *prev, float *next, float *
 // Single-row reversible (5/3) vertical lifting steps.
 void idwt_rev_ver_lp_step_neon(int32_t n, const float *prev, const float *next, float *tgt);
 void idwt_rev_ver_hp_step_neon(int32_t n, const float *prev, const float *next, float *tgt);
+void idwt_1d_filtr_rev53_i32_neon(int32_t *X, int32_t left, int32_t u_i0, int32_t u_i1);
+void idwt_rev_ver_lp_step_i32_neon(int32_t n, const int32_t *prev, const int32_t *next, int32_t *tgt);
+void idwt_rev_ver_hp_step_i32_neon(int32_t n, const int32_t *prev, const int32_t *next, int32_t *tgt);
 #elif defined(OPENHTJ2K_ENABLE_AVX2)
 void idwt_1d_filtr_rev53_fixed_avx2(sprec_t *X, int32_t left, int32_t u_i0, int32_t u_i1);
 void idwt_1d_filtr_irrev97_fixed_avx2(sprec_t *X, int32_t left, int32_t u_i0, int32_t u_i1);
@@ -300,6 +350,9 @@ void idwt_irrev_ver_step_fixed_avx2(int32_t n, float *prev, float *next, float *
 // Single-row reversible (5/3) vertical lifting steps.
 void idwt_rev_ver_lp_step_avx2(int32_t n, const float *prev, const float *next, float *tgt);
 void idwt_rev_ver_hp_step_avx2(int32_t n, const float *prev, const float *next, float *tgt);
+void idwt_1d_filtr_rev53_i32_avx2(int32_t *X, int32_t left, int32_t u_i0, int32_t u_i1);
+void idwt_rev_ver_lp_step_i32_avx2(int32_t n, const int32_t *prev, const int32_t *next, int32_t *tgt);
+void idwt_rev_ver_hp_step_i32_avx2(int32_t n, const int32_t *prev, const int32_t *next, int32_t *tgt);
 #else
 void idwt_1d_filtr_rev53_fixed(sprec_t *X, int32_t left, int32_t u_i0, int32_t u_i1);
 void idwt_1d_filtr_irrev97_fixed(sprec_t *X, int32_t left, int32_t u_i0, int32_t u_i1);
@@ -327,6 +380,9 @@ void idwt_rev_ver_sr_fixed_wasm(sprec_t *in, int32_t u0, int32_t u1, int32_t v0,
 void idwt_irrev_ver_step_fixed_wasm(int32_t n, float *prev, float *next, float *tgt, float coeff);
 void idwt_rev_ver_lp_step_wasm(int32_t n, const float *prev, const float *next, float *tgt);
 void idwt_rev_ver_hp_step_wasm(int32_t n, const float *prev, const float *next, float *tgt);
+void idwt_1d_filtr_rev53_i32_wasm(int32_t *X, int32_t left, int32_t u_i0, int32_t u_i1);
+void idwt_rev_ver_lp_step_i32_wasm(int32_t n, const int32_t *prev, const int32_t *next, int32_t *tgt);
+void idwt_rev_ver_hp_step_i32_wasm(int32_t n, const int32_t *prev, const int32_t *next, int32_t *tgt);
 // single-row vertical step (for streaming fdwt_2d_state)
 void fdwt_rev_ver_hp_step_wasm(int32_t n, const float *prev, const float *next, float *tgt);
 void fdwt_rev_ver_lp_step_wasm(int32_t n, const float *prev, const float *next, float *tgt);
@@ -356,6 +412,8 @@ void idwt_vert_only_sr_fixed(sprec_t *nextLL, const sprec_t *LL, const sprec_t *
 // left and right are precomputed PSE counts (function of u0%2, u1%2, and transformation).
 void idwt_1d_row_inplace(sprec_t *row, int32_t left, int32_t right,
                          int32_t u0, int32_t u1, uint8_t transformation);
+void idwt_1d_row_inplace_i32(int32_t *row, int32_t left, int32_t right,
+                             int32_t u0, int32_t u1);
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Streaming 2D IDWT — produces one output row per call via pull_row().
@@ -391,14 +449,15 @@ struct idwt_2d_state {
   int32_t slot_stride;     // IDWT_RING_PSE_LEFT + round_up(u1-u0+SIMD_PADDING, SIMD_PADDING)
   uint8_t transformation;  // 0 = irrev 9/7, 1 = rev 5/3, 2+ = ATK irrev
   dwt_type dir;            // DWT_BIDIR (full 2D), DWT_HORZ (horizontal only), DWT_NO (passthrough)
+  bool    use_i32;         // when true, ring/PSE buffers hold int32_t (reinterpret_cast'd from sprec_t*)
   int8_t  top_pse;         // PSE rows above v0  (3 or 4 for 9/7; 1 or 2 for 5/3 / ATK)
   int8_t  bottom_pse;      // PSE rows below v1-1
 
   // ── PSE scratch (separate from the ring, BIDIR only) ──────────────────────
   // top_pse_buf[0] ↔ physical row v0-1, [1] ↔ v0-2, …
   // bot_pse_buf[0] ↔ physical row v1,   [1] ↔ v1+1, …
-  sprec_t *top_pse_buf;        // top_pse    × stride sprec_t (SIMD-aligned); nullptr for HORZ/NO
-  sprec_t *bot_pse_buf;        // bottom_pse × stride sprec_t; nullptr for HORZ/NO
+  void *top_pse_buf;           // top_pse    × stride sprec_t (SIMD-aligned); nullptr for HORZ/NO
+  void *bot_pse_buf;           // bottom_pse × stride sprec_t; nullptr for HORZ/NO
   int8_t   top_dlevel[4];      // d_level per top-PSE slot (-1 = unfilled)
   int8_t   bot_dlevel[4];      // d_level per bot-PSE slot (-1 = unfilled)
 
@@ -407,14 +466,14 @@ struct idwt_2d_state {
   // Each ring slot is slot_stride floats wide; the data portion (post-horizontal-IDWT)
   // starts at offset IDWT_RING_PSE_LEFT within the slot, providing scratch space
   // for the in-place horizontal PSE fill and filter (no separate ext_buf needed).
-  sprec_t *ring_buf;                           // IDWT_STATE_RING_DEPTH × slot_stride; nullptr for HORZ/NO
+  void *ring_buf;                              // IDWT_STATE_RING_DEPTH × slot_stride; nullptr for HORZ/NO
   int32_t  ring_origin;                         // abs row mapped to slot 0
   int8_t   d_level[IDWT_STATE_RING_DEPTH];     // 0=raw, 1=step1, 2=step2, -1=unused
 
   // ── single-row output buffer (HORZ and NO only) ───────────────────────────
   // Allocated with IDWT_RING_PSE_LEFT prefix for in-place horizontal IDWT.
   // Data area starts at horz_out_buf + IDWT_RING_PSE_LEFT.
-  sprec_t *horz_out_buf;   // nullptr for BIDIR
+  void *horz_out_buf;      // nullptr for BIDIR
 
   // ── zero-row tracking (Phase 4 IDWT skip for absent JPIP precincts) ──────
   // When a fetched source row is entirely zero (absent precinct), the zero
@@ -460,7 +519,8 @@ struct idwt_2d_state {
 void idwt_2d_state_init(idwt_2d_state *s,
                         int32_t u0, int32_t u1, int32_t v0, int32_t v1,
                         uint8_t transformation, dwt_type dir,
-                        idwt_row_src_fn src_fn, void *src_ctx);
+                        idwt_row_src_fn src_fn, void *src_ctx,
+                        bool use_i32 = false);
 
 // Free buffers allocated by idwt_2d_state_init.
 void idwt_2d_state_free(idwt_2d_state *s);
@@ -514,11 +574,12 @@ sprec_t *idwt_2d_state_pull_row_ref(idwt_2d_state *s);
 // Pointer to the row buffer for physical row r (ring, top-PSE, or bot-PSE).
 static inline sprec_t *idwt_rptr(const idwt_2d_state *s, int32_t r) {
   if (r >= s->v0 && r < s->v1)
-    return s->ring_buf + static_cast<ptrdiff_t>(r & (IDWT_STATE_RING_DEPTH - 1)) * s->slot_stride
+    return static_cast<sprec_t *>(s->ring_buf)
+           + static_cast<ptrdiff_t>(r & (IDWT_STATE_RING_DEPTH - 1)) * s->slot_stride
            + IDWT_RING_PSE_LEFT;
   if (r < s->v0)
-    return s->top_pse_buf + static_cast<ptrdiff_t>(s->v0 - 1 - r) * s->stride;
-  return s->bot_pse_buf + static_cast<ptrdiff_t>(r - s->v1) * s->stride;
+    return static_cast<sprec_t *>(s->top_pse_buf) + static_cast<ptrdiff_t>(s->v0 - 1 - r) * s->stride;
+  return static_cast<sprec_t *>(s->bot_pse_buf) + static_cast<ptrdiff_t>(r - s->v1) * s->stride;
 }
 
 // d_level for physical row r (-1 = unfilled / out of range).
@@ -598,19 +659,19 @@ struct fdwt_2d_state {
   bool    use_i32;
 
   // ── PSE scratch ───────────────────────────────────────────────────────────
-  sprec_t *top_pse_buf;      // top_pse    × stride sprec_t (or int32_t if use_i32)
-  sprec_t *bot_pse_buf;      // bottom_pse × stride sprec_t (or int32_t if use_i32)
+  void *top_pse_buf;         // top_pse    × stride sprec_t (or int32_t if use_i32)
+  void *bot_pse_buf;         // bottom_pse × stride sprec_t (or int32_t if use_i32)
   int8_t   top_dlevel[4];    // d_level per top-PSE slot (-1 = unfilled)
   int8_t   bot_dlevel[4];    // d_level per bot-PSE slot (-1 = unfilled)
 
   // ── sliding ring ──────────────────────────────────────────────────────────
-  sprec_t *ring_buf;                          // FDWT_STATE_RING_DEPTH × stride
+  void *ring_buf;                             // FDWT_STATE_RING_DEPTH × stride
   int32_t  ring_origin;
   int8_t   d_level[FDWT_STATE_RING_DEPTH];   // 0=raw, 1=step1, 2=step2, -1=unused
 
   // ── horizontal-DWT temp buffer ────────────────────────────────────────────
   // Size: horiz_left + stride + horiz_right + SIMD_PADDING
-  sprec_t *horiz_tmp;
+  void *horiz_tmp;
 
   // ── cursors ───────────────────────────────────────────────────────────────
   int32_t next_in;    // next row to accept via push_row() [v0, v1]

--- a/source/core/transform/fdwt.cpp
+++ b/source/core/transform/fdwt.cpp
@@ -783,10 +783,10 @@ static inline int32_t pse_src_fdwt(int32_t p, int32_t v0, int32_t v1) {
 // Pointer to ring / PSE row buffer for physical row r.
 static sprec_t *rptr_f(const fdwt_2d_state *s, int32_t r) {
   if (r >= s->v0 && r < s->v1)
-    return s->ring_buf + static_cast<ptrdiff_t>(r % FDWT_STATE_RING_DEPTH) * s->stride;
+    return static_cast<sprec_t *>(s->ring_buf) + static_cast<ptrdiff_t>(r % FDWT_STATE_RING_DEPTH) * s->stride;
   if (r < s->v0)
-    return s->top_pse_buf + static_cast<ptrdiff_t>(s->v0 - 1 - r) * s->stride;
-  return s->bot_pse_buf + static_cast<ptrdiff_t>(r - s->v1) * s->stride;
+    return static_cast<sprec_t *>(s->top_pse_buf) + static_cast<ptrdiff_t>(s->v0 - 1 - r) * s->stride;
+  return static_cast<sprec_t *>(s->bot_pse_buf) + static_cast<ptrdiff_t>(r - s->v1) * s->stride;
 }
 
 static int8_t get_dl_f(const fdwt_2d_state *s, int32_t r) {
@@ -875,13 +875,13 @@ static void fill_pse_f(fdwt_2d_state *s, int32_t r) {
   const sprec_t *src = rptr_f(s, r);
   for (int8_t i = 1; i <= s->top_pse; ++i) {
     if (s->top_dlevel[i - 1] < 0 && pse_src_fdwt(s->v0 - i, s->v0, s->v1) == r) {
-      memcpy(s->top_pse_buf + static_cast<ptrdiff_t>(i - 1) * s->stride, src, nb);
+      memcpy(static_cast<sprec_t *>(s->top_pse_buf) + static_cast<ptrdiff_t>(i - 1) * s->stride, src, nb);
       s->top_dlevel[i - 1] = 0;
     }
   }
   for (int8_t i = 0; i < s->bottom_pse; ++i) {
     if (s->bot_dlevel[i] < 0 && pse_src_fdwt(s->v1 + i, s->v0, s->v1) == r) {
-      memcpy(s->bot_pse_buf + static_cast<ptrdiff_t>(i) * s->stride, src, nb);
+      memcpy(static_cast<sprec_t *>(s->bot_pse_buf) + static_cast<ptrdiff_t>(i) * s->stride, src, nb);
       s->bot_dlevel[i] = 0;
     }
   }
@@ -950,30 +950,30 @@ static void emit_ready_f(fdwt_2d_state *s) {
       // Single-column: skip PSE/filter (PSEo has UB for length-1 signals).
       // Match fdwt_hor_sr_fixed: LP even u0 → no-op; HP odd u0 → *2 for 5/3.
       if (s->use_i32) {
-        int32_t *out = reinterpret_cast<int32_t *>(s->horiz_tmp) + s->horiz_left;
+        int32_t *out = static_cast<int32_t *>(s->horiz_tmp) + s->horiz_left;
         out[0] = reinterpret_cast<const int32_t *>(ring_row)[0];
         if (s->u0 % 2 != 0) out[0] <<= 1;  // floor(x*2.0) for an integer == x<<1
       } else {
-        sprec_t *out = s->horiz_tmp + s->horiz_left;
+        sprec_t *out = static_cast<sprec_t *>(s->horiz_tmp) + s->horiz_left;
         out[0] = ring_row[0];
         if (s->transformation == 1 && (s->u0 % 2 != 0)) out[0] = floorf(out[0] * 2.0f);
       }
     } else if (s->use_i32) {
       // int32 lossless path
-      int32_t       *htmp_i = reinterpret_cast<int32_t *>(s->horiz_tmp);
+      int32_t       *htmp_i = static_cast<int32_t *>(s->horiz_tmp);
       int32_t       *row_i  = const_cast<int32_t *>(reinterpret_cast<const int32_t *>(ring_row));
       dwt_1d_extr_fixed<int32_t>(htmp_i, row_i, s->horiz_left, s->horiz_right, s->u0, s->u1);
       fdwt_1d_filtr_rev53_i32_fn(htmp_i, s->horiz_left, s->u0, s->u1);
     } else {
-      dwt_1d_extr_fixed(s->horiz_tmp, const_cast<sprec_t *>(ring_row),
+      dwt_1d_extr_fixed(static_cast<sprec_t *>(s->horiz_tmp), const_cast<sprec_t *>(ring_row),
                         s->horiz_left, s->horiz_right, s->u0, s->u1);
       if (s->transformation < 2)
-        fdwt_1d_filtr_fixed[s->transformation](s->horiz_tmp, s->horiz_left, s->u0, s->u1);
+        fdwt_1d_filtr_fixed[s->transformation](static_cast<sprec_t *>(s->horiz_tmp), s->horiz_left, s->u0, s->u1);
       else
-        fdwt_1d_filtr_irrev53_fixed(s->horiz_tmp, s->horiz_left, s->u0, s->u1);
+        fdwt_1d_filtr_irrev53_fixed(static_cast<sprec_t *>(s->horiz_tmp), s->horiz_left, s->u0, s->u1);
     }
 
-    s->put_row(s->sink_ctx, is_hp, r, s->horiz_tmp + s->horiz_left);
+    s->put_row(s->sink_ctx, is_hp, r, static_cast<sprec_t *>(s->horiz_tmp) + s->horiz_left);
     ++s->next_emit;
 
     // Reclaim ring slots that are at least 4 rows behind next_emit (safe look-back).
@@ -1005,13 +1005,13 @@ void fdwt_2d_state_init(fdwt_2d_state *s,
   s->horiz_right   = kHorizRight[u1 % 2][cls];
 
   const size_t row_bytes = sizeof(sprec_t) * static_cast<size_t>(s->stride);
-  s->ring_buf    = static_cast<sprec_t *>(aligned_mem_alloc(FDWT_STATE_RING_DEPTH * row_bytes, 32));
-  s->top_pse_buf = (s->top_pse    > 0) ? static_cast<sprec_t *>(aligned_mem_alloc(static_cast<size_t>(s->top_pse)    * row_bytes, 32)) : nullptr;
-  s->bot_pse_buf = (s->bottom_pse > 0) ? static_cast<sprec_t *>(aligned_mem_alloc(static_cast<size_t>(s->bottom_pse) * row_bytes, 32)) : nullptr;
+  s->ring_buf    = aligned_mem_alloc(FDWT_STATE_RING_DEPTH * row_bytes, 32);
+  s->top_pse_buf = (s->top_pse    > 0) ? aligned_mem_alloc(static_cast<size_t>(s->top_pse)    * row_bytes, 32) : nullptr;
+  s->bot_pse_buf = (s->bottom_pse > 0) ? aligned_mem_alloc(static_cast<size_t>(s->bottom_pse) * row_bytes, 32) : nullptr;
 
   const size_t htmp_bytes = sizeof(sprec_t) *
       static_cast<size_t>(s->horiz_left + s->stride + s->horiz_right + SIMD_PADDING);
-  s->horiz_tmp = static_cast<sprec_t *>(aligned_mem_alloc(htmp_bytes, 32));
+  s->horiz_tmp = aligned_mem_alloc(htmp_bytes, 32);
 
   s->ring_origin = v0;
   for (int32_t i = 0; i < FDWT_STATE_RING_DEPTH; ++i) s->d_level[i]    = -1;
@@ -1038,7 +1038,7 @@ void fdwt_2d_state_push_row(fdwt_2d_state *s, const sprec_t *in) {
   if (s->v1 == s->v0 + 1) {
     // Still store the row in ring_buf so flush() can read it.
     const int32_t slot = s->next_in % FDWT_STATE_RING_DEPTH;
-    memcpy(s->ring_buf + static_cast<ptrdiff_t>(slot) * s->stride, in,
+    memcpy(static_cast<sprec_t *>(s->ring_buf) + static_cast<ptrdiff_t>(slot) * s->stride, in,
            sizeof(sprec_t) * static_cast<size_t>(s->u1 - s->u0));
     ++s->next_in;
     return;
@@ -1047,7 +1047,7 @@ void fdwt_2d_state_push_row(fdwt_2d_state *s, const sprec_t *in) {
   const int32_t r    = s->next_in;
   const int32_t slot = r % FDWT_STATE_RING_DEPTH;
 
-  memcpy(s->ring_buf + static_cast<ptrdiff_t>(slot) * s->stride, in,
+  memcpy(static_cast<sprec_t *>(s->ring_buf) + static_cast<ptrdiff_t>(slot) * s->stride, in,
          sizeof(sprec_t) * static_cast<size_t>(s->u1 - s->u0));
   s->d_level[slot] = 0;
   ++s->next_in;
@@ -1063,8 +1063,8 @@ void fdwt_2d_state_flush(fdwt_2d_state *s) {
     // Single-row: LL-only or HP-only scaling.
     // For 5/3 with v0 odd: HP *= 2; for irrev: no-op.
     const bool is_hp = !is_lp_fdwt(s->v0);
-    const sprec_t *src = s->ring_buf + static_cast<ptrdiff_t>(s->v0 % FDWT_STATE_RING_DEPTH) * s->stride;
-    sprec_t *out = s->horiz_tmp + s->horiz_left;
+    const sprec_t *src = static_cast<sprec_t *>(s->ring_buf) + static_cast<ptrdiff_t>(s->v0 % FDWT_STATE_RING_DEPTH) * s->stride;
+    sprec_t *out = static_cast<sprec_t *>(s->horiz_tmp) + s->horiz_left;
     if (s->u1 == s->u0 + 1) {
       // Single-column: PSEo has UB for length-1 — bypass filter entirely.
       // Match fdwt_hor_sr_fixed: even u0 (LP) → no-op; odd u0 (HP) → *2 for 5/3.
@@ -1083,29 +1083,29 @@ void fdwt_2d_state_flush(fdwt_2d_state *s) {
       }
     } else if (s->use_i32) {
       // int32 path: HP scaling + extract + i32 filter
-      int32_t *ms = reinterpret_cast<int32_t *>(
-          s->ring_buf + static_cast<ptrdiff_t>(s->v0 % FDWT_STATE_RING_DEPTH) * s->stride);
+      int32_t *ms = static_cast<int32_t *>(s->ring_buf)
+          + static_cast<ptrdiff_t>(s->v0 % FDWT_STATE_RING_DEPTH) * s->stride;
       if (is_hp) {
         const int32_t w = s->u1 - s->u0;
         for (int32_t c = 0; c < w; ++c) ms[c] <<= 1;  // x*2 == x<<1 for integers
       }
-      int32_t *htmp_i = reinterpret_cast<int32_t *>(s->horiz_tmp);
+      int32_t *htmp_i = static_cast<int32_t *>(s->horiz_tmp);
       dwt_1d_extr_fixed<int32_t>(htmp_i, ms, s->horiz_left, s->horiz_right, s->u0, s->u1);
       fdwt_1d_filtr_rev53_i32_fn(htmp_i, s->horiz_left, s->u0, s->u1);
     } else {
       // Match fdwt_rev_ver_sr_fixed: scale HP row by 2 BEFORE horizontal DWT.
       // (floorf makes 5/3 non-linear, so order matters.)
       if (s->transformation == 1 && is_hp) {
-        sprec_t *ms = s->ring_buf + static_cast<ptrdiff_t>(s->v0 % FDWT_STATE_RING_DEPTH) * s->stride;
+        sprec_t *ms = static_cast<sprec_t *>(s->ring_buf) + static_cast<ptrdiff_t>(s->v0 % FDWT_STATE_RING_DEPTH) * s->stride;
         const int32_t w = s->u1 - s->u0;
         for (int32_t c = 0; c < w; ++c) ms[c] = floorf(ms[c] * 2.0f);
       }
-      dwt_1d_extr_fixed(s->horiz_tmp, const_cast<sprec_t *>(src),
+      dwt_1d_extr_fixed(static_cast<sprec_t *>(s->horiz_tmp), const_cast<sprec_t *>(src),
                         s->horiz_left, s->horiz_right, s->u0, s->u1);
       if (s->transformation < 2)
-        fdwt_1d_filtr_fixed[s->transformation](s->horiz_tmp, s->horiz_left, s->u0, s->u1);
+        fdwt_1d_filtr_fixed[s->transformation](static_cast<sprec_t *>(s->horiz_tmp), s->horiz_left, s->u0, s->u1);
       else
-        fdwt_1d_filtr_irrev53_fixed(s->horiz_tmp, s->horiz_left, s->u0, s->u1);
+        fdwt_1d_filtr_irrev53_fixed(static_cast<sprec_t *>(s->horiz_tmp), s->horiz_left, s->u0, s->u1);
     }
     s->put_row(s->sink_ctx, is_hp, s->v0, out);
     ++s->next_emit;

--- a/source/core/transform/idwt.cpp
+++ b/source/core/transform/idwt.cpp
@@ -31,6 +31,9 @@
 #include <utility>
 #include "dwt.hpp"
 #include "utils.hpp"
+#if defined(OPENHTJ2K_ENABLE_ARM_NEON)
+  #include <arm_neon.h>
+#endif
 #if defined(OPENHTJ2K_ENABLE_WASM_SIMD)
   #include <wasm_simd128.h>
 #endif
@@ -52,6 +55,11 @@ static adv_irrev_step_fn adv_irrev_ver_step_fn = idwt_irrev_ver_step_fixed_wasm;
 typedef void (*adv_rev_step_fn)(int32_t, const float *, const float *, float *);
 static adv_rev_step_fn adv_rev_ver_lp_step_fn = idwt_rev_ver_lp_step_wasm;
 static adv_rev_step_fn adv_rev_ver_hp_step_fn = idwt_rev_ver_hp_step_wasm;
+typedef void (*idwt_1d_filtr_i32_fn_t)(int32_t *, int32_t, int32_t, int32_t);
+typedef void (*adv_idwt_rev_step_i32_fn_t)(int32_t, const int32_t *, const int32_t *, int32_t *);
+static idwt_1d_filtr_i32_fn_t      idwt_1d_filtr_rev53_i32_fn  = idwt_1d_filtr_rev53_i32_wasm;
+static adv_idwt_rev_step_i32_fn_t  adv_idwt_rev_lp_step_i32_fn = idwt_rev_ver_lp_step_i32_wasm;
+static adv_idwt_rev_step_i32_fn_t  adv_idwt_rev_hp_step_i32_fn = idwt_rev_ver_hp_step_i32_wasm;
 #elif defined(OPENHTJ2K_ENABLE_AVX512)
 static idwt_1d_filtd_func_fixed idwt_1d_filtr_fixed[2] = {idwt_1d_filtr_irrev97_fixed_avx512,
                                                            idwt_1d_filtr_rev53_fixed_avx512};
@@ -64,6 +72,11 @@ static adv_irrev_step_fn adv_irrev_ver_step_fn = idwt_irrev_ver_step_fixed_avx51
 typedef void (*adv_rev_step_fn)(int32_t, const float *, const float *, float *);
 static adv_rev_step_fn adv_rev_ver_lp_step_fn = idwt_rev_ver_lp_step_avx512;
 static adv_rev_step_fn adv_rev_ver_hp_step_fn = idwt_rev_ver_hp_step_avx512;
+typedef void (*idwt_1d_filtr_i32_fn_t)(int32_t *, int32_t, int32_t, int32_t);
+typedef void (*adv_idwt_rev_step_i32_fn_t)(int32_t, const int32_t *, const int32_t *, int32_t *);
+static idwt_1d_filtr_i32_fn_t      idwt_1d_filtr_rev53_i32_fn  = idwt_1d_filtr_rev53_i32_avx512;
+static adv_idwt_rev_step_i32_fn_t  adv_idwt_rev_lp_step_i32_fn = idwt_rev_ver_lp_step_i32_avx512;
+static adv_idwt_rev_step_i32_fn_t  adv_idwt_rev_hp_step_i32_fn = idwt_rev_ver_hp_step_i32_avx512;
 #elif defined(OPENHTJ2K_ENABLE_ARM_NEON)
 static idwt_1d_filtd_func_fixed idwt_1d_filtr_fixed[2] = {idwt_1d_filtr_irrev97_fixed_neon,
                                                           idwt_1d_filtr_rev53_fixed_neon};
@@ -76,6 +89,11 @@ static adv_irrev_step_fn adv_irrev_ver_step_fn = idwt_irrev_ver_step_fixed_neon;
 typedef void (*adv_rev_step_fn)(int32_t, const float *, const float *, float *);
 static adv_rev_step_fn adv_rev_ver_lp_step_fn = idwt_rev_ver_lp_step_neon;
 static adv_rev_step_fn adv_rev_ver_hp_step_fn = idwt_rev_ver_hp_step_neon;
+typedef void (*idwt_1d_filtr_i32_fn_t)(int32_t *, int32_t, int32_t, int32_t);
+typedef void (*adv_idwt_rev_step_i32_fn_t)(int32_t, const int32_t *, const int32_t *, int32_t *);
+static idwt_1d_filtr_i32_fn_t      idwt_1d_filtr_rev53_i32_fn  = idwt_1d_filtr_rev53_i32_neon;
+static adv_idwt_rev_step_i32_fn_t  adv_idwt_rev_lp_step_i32_fn = idwt_rev_ver_lp_step_i32_neon;
+static adv_idwt_rev_step_i32_fn_t  adv_idwt_rev_hp_step_i32_fn = idwt_rev_ver_hp_step_i32_neon;
 #elif defined(OPENHTJ2K_ENABLE_AVX2)
 static idwt_1d_filtd_func_fixed idwt_1d_filtr_fixed[2] = {idwt_1d_filtr_irrev97_fixed_avx2,
                                                           idwt_1d_filtr_rev53_fixed_avx2};
@@ -88,6 +106,11 @@ static adv_irrev_step_fn adv_irrev_ver_step_fn = idwt_irrev_ver_step_fixed_avx2;
 typedef void (*adv_rev_step_fn)(int32_t, const float *, const float *, float *);
 static adv_rev_step_fn adv_rev_ver_lp_step_fn = idwt_rev_ver_lp_step_avx2;
 static adv_rev_step_fn adv_rev_ver_hp_step_fn = idwt_rev_ver_hp_step_avx2;
+typedef void (*idwt_1d_filtr_i32_fn_t)(int32_t *, int32_t, int32_t, int32_t);
+typedef void (*adv_idwt_rev_step_i32_fn_t)(int32_t, const int32_t *, const int32_t *, int32_t *);
+static idwt_1d_filtr_i32_fn_t      idwt_1d_filtr_rev53_i32_fn  = idwt_1d_filtr_rev53_i32_avx2;
+static adv_idwt_rev_step_i32_fn_t  adv_idwt_rev_lp_step_i32_fn = idwt_rev_ver_lp_step_i32_avx2;
+static adv_idwt_rev_step_i32_fn_t  adv_idwt_rev_hp_step_i32_fn = idwt_rev_ver_hp_step_i32_avx2;
 #else
 static idwt_1d_filtd_func_fixed idwt_1d_filtr_fixed[2] = {idwt_1d_filtr_irrev97_fixed,
                                                           idwt_1d_filtr_rev53_fixed};
@@ -108,6 +131,26 @@ static void adv_rev_ver_hp_step_scalar(int32_t n, const float *prev, const float
 typedef void (*adv_rev_step_fn)(int32_t, const float *, const float *, float *);
 static adv_rev_step_fn adv_rev_ver_lp_step_fn = adv_rev_ver_lp_step_scalar;
 static adv_rev_step_fn adv_rev_ver_hp_step_fn = adv_rev_ver_hp_step_scalar;
+typedef void (*idwt_1d_filtr_i32_fn_t)(int32_t *, int32_t, int32_t, int32_t);
+typedef void (*adv_idwt_rev_step_i32_fn_t)(int32_t, const int32_t *, const int32_t *, int32_t *);
+static void idwt_1d_filtr_rev53_i32_scalar(int32_t *X, int32_t left, int32_t u_i0, int32_t u_i1) {
+  const int32_t start  = u_i0 / 2;
+  const int32_t stop   = u_i1 / 2;
+  const int32_t offset = left - u_i0 % 2;
+  for (int32_t n = 0 + offset, i = start; i < stop + 1; ++i, n += 2)
+    X[n] -= (X[n - 1] + X[n + 1] + 2) >> 2;
+  for (int32_t n = 0 + offset, i = start; i < stop; ++i, n += 2)
+    X[n + 1] += (X[n] + X[n + 2]) >> 1;
+}
+static void adv_idwt_rev_lp_step_i32_scalar(int32_t n, const int32_t *prev, const int32_t *next, int32_t *tgt) {
+  for (int32_t i = 0; i < n; ++i) tgt[i] -= (prev[i] + next[i] + 2) >> 2;
+}
+static void adv_idwt_rev_hp_step_i32_scalar(int32_t n, const int32_t *prev, const int32_t *next, int32_t *tgt) {
+  for (int32_t i = 0; i < n; ++i) tgt[i] += (prev[i] + next[i]) >> 1;
+}
+static idwt_1d_filtr_i32_fn_t      idwt_1d_filtr_rev53_i32_fn  = idwt_1d_filtr_rev53_i32_scalar;
+static adv_idwt_rev_step_i32_fn_t  adv_idwt_rev_lp_step_i32_fn = adv_idwt_rev_lp_step_i32_scalar;
+static adv_idwt_rev_step_i32_fn_t  adv_idwt_rev_hp_step_i32_fn = adv_idwt_rev_hp_step_i32_scalar;
 #endif
 
 void idwt_1d_filtr_irrev97_fixed(sprec_t *X, const int32_t left, const int32_t u_i0, const int32_t u_i1) {
@@ -808,6 +851,22 @@ void idwt_1d_row_inplace(sprec_t *row, const int32_t left, const int32_t right,
     idwt_1d_filtr_irrev53_fn(row - left, left, u0, u1);
 }
 
+void idwt_1d_row_inplace_i32(int32_t *row, const int32_t left, const int32_t right,
+                             const int32_t u0, const int32_t u1) {
+  const int32_t width = u1 - u0;
+  // PSE fill using integer intrinsics — avoids strict-aliasing UB from
+  // applying float-typed SIMD to int32_t data.
+  if (width >= 9) {
+    dwt_pse_fill_inplace_i32(row, width);
+  } else {
+    for (int32_t i = 1; i <= left; ++i)
+      row[-i] = row[PSEo(u0 - i, u0, u1)];
+    for (int32_t i = 1; i <= right; ++i)
+      row[width + i - 1] = row[PSEo(u1 - u0 + i - 1 + u0, u0, u1)];
+  }
+  idwt_1d_filtr_rev53_i32_fn(row - left, left, u0, u1);
+}
+
 // Sub-range 9/7 IDWT: runs only the 4-pass lifting on buffer positions
 // [buf_lo, buf_hi] (inclusive) of X.  The kernel's parity / offset logic is
 // inherited from u_i0 unchanged so the LP/HP identity of each column matches
@@ -1003,10 +1062,19 @@ static inline void adv_step(idwt_2d_state *s, int32_t r, int8_t cur) {
     const float coeff = lp ? 0.25f : -0.5f;
     adv_irrev_ver_step_fn(w, prev + col0, next + col0, tgt + col0, coeff);
   } else {  // rev 5/3
-    if (lp) {
-      adv_rev_ver_lp_step_fn(w, prev + col0, next + col0, tgt + col0);
+    if (s->use_i32) {
+      int32_t *tgt_i  = reinterpret_cast<int32_t *>(tgt);
+      const int32_t *prev_i = reinterpret_cast<const int32_t *>(prev);
+      const int32_t *next_i = reinterpret_cast<const int32_t *>(next);
+      if (lp)
+        adv_idwt_rev_lp_step_i32_fn(w, prev_i + col0, next_i + col0, tgt_i + col0);
+      else
+        adv_idwt_rev_hp_step_i32_fn(w, prev_i + col0, next_i + col0, tgt_i + col0);
     } else {
-      adv_rev_ver_hp_step_fn(w, prev + col0, next + col0, tgt + col0);
+      if (lp)
+        adv_rev_ver_lp_step_fn(w, prev + col0, next + col0, tgt + col0);
+      else
+        adv_rev_ver_hp_step_fn(w, prev + col0, next + col0, tgt + col0);
     }
   }
   set_dl(s, r, cur + 1);
@@ -1019,14 +1087,14 @@ static inline void fill_pse(idwt_2d_state *s, int32_t r) {
   const bool z = is_zero(s, r);
   for (int8_t i = 1; i <= s->top_pse; ++i) {
     if (s->top_dlevel[i - 1] < 0 && pse_source(s->v0 - i, s->v0, s->v1) == r) {
-      memcpy(s->top_pse_buf + static_cast<ptrdiff_t>(i - 1) * s->stride, src, nb);
+      memcpy(static_cast<sprec_t *>(s->top_pse_buf) + static_cast<ptrdiff_t>(i - 1) * s->stride, src, nb);
       s->top_dlevel[i - 1] = 0;
       s->top_pse_zero[i - 1] = z;
     }
   }
   for (int8_t i = 0; i < s->bottom_pse; ++i) {
     if (s->bot_dlevel[i] < 0 && pse_source(s->v1 + i, s->v0, s->v1) == r) {
-      memcpy(s->bot_pse_buf + static_cast<ptrdiff_t>(i) * s->stride, src, nb);
+      memcpy(static_cast<sprec_t *>(s->bot_pse_buf) + static_cast<ptrdiff_t>(i) * s->stride, src, nb);
       s->bot_dlevel[i] = 0;
       s->bot_pse_zero[i] = z;
     }
@@ -1154,13 +1222,15 @@ void idwt_2d_state_init(idwt_2d_state *s,
                         const int32_t u0, const int32_t u1,
                         const int32_t v0, const int32_t v1,
                         const uint8_t transformation, const dwt_type dir,
-                        idwt_row_src_fn src_fn, void *src_ctx) {
+                        idwt_row_src_fn src_fn, void *src_ctx,
+                        bool use_i32) {
   s->u0            = u0;  s->u1 = u1;
   s->v0            = v0;  s->v1 = v1;
   s->stride        = round_up(u1 - u0, SIMD_PADDING);
   s->slot_stride   = IDWT_RING_PSE_LEFT + round_up(u1 - u0 + SIMD_PADDING, SIMD_PADDING);
   s->transformation = transformation;
   s->dir           = dir;
+  s->use_i32       = use_i32 && (transformation == 1);
   // ATK (transformation>=2) is a 2-step filter like rev53 — use same PSE counts (eff=1).
   const uint8_t eff = (transformation < 2) ? transformation : 1;
   s->top_pse       = kPseTop[v0 % 2][eff];
@@ -1174,13 +1244,13 @@ void idwt_2d_state_init(idwt_2d_state *s,
   if (dir == DWT_BIDIR) {
     const size_t row_bytes  = sizeof(sprec_t) * static_cast<size_t>(s->stride);
     const size_t slot_bytes = sizeof(sprec_t) * static_cast<size_t>(s->slot_stride);
-    s->ring_buf    = static_cast<sprec_t *>(aligned_mem_alloc(IDWT_STATE_RING_DEPTH * slot_bytes, 32));
-    s->top_pse_buf = (s->top_pse    > 0) ? static_cast<sprec_t *>(aligned_mem_alloc(static_cast<size_t>(s->top_pse)    * row_bytes, 32)) : nullptr;
-    s->bot_pse_buf = (s->bottom_pse > 0) ? static_cast<sprec_t *>(aligned_mem_alloc(static_cast<size_t>(s->bottom_pse) * row_bytes, 32)) : nullptr;
+    s->ring_buf    = aligned_mem_alloc(IDWT_STATE_RING_DEPTH * slot_bytes, 32);
+    s->top_pse_buf = (s->top_pse    > 0) ? aligned_mem_alloc(static_cast<size_t>(s->top_pse)    * row_bytes, 32) : nullptr;
+    s->bot_pse_buf = (s->bottom_pse > 0) ? aligned_mem_alloc(static_cast<size_t>(s->bottom_pse) * row_bytes, 32) : nullptr;
   } else {
     // HORZ or NO: one output row at a time — single scratch buffer with PSE prefix.
     const size_t slot_bytes = sizeof(sprec_t) * static_cast<size_t>(s->slot_stride);
-    s->horz_out_buf = static_cast<sprec_t *>(aligned_mem_alloc(slot_bytes, 32));
+    s->horz_out_buf = aligned_mem_alloc(slot_bytes, 32);
   }
 
   s->ring_origin = v0;
@@ -1253,7 +1323,7 @@ sprec_t *idwt_2d_state_pull_row_ref(idwt_2d_state *s) {
   // The source callback interleaves LL and H and applies the horizontal IDWT.
   // horz_out_buf has IDWT_RING_PSE_LEFT prefix so the callback can fill PSE in-place.
   if (s->dir == DWT_HORZ) {
-    sprec_t *data = s->horz_out_buf + IDWT_RING_PSE_LEFT;
+    sprec_t *data = static_cast<sprec_t *>(s->horz_out_buf) + IDWT_RING_PSE_LEFT;
     s->get_src_row(s->src_ctx, s->next_out, data);
     ++s->next_out;
     return data;
@@ -1261,7 +1331,7 @@ sprec_t *idwt_2d_state_pull_row_ref(idwt_2d_state *s) {
 
   // ── NO_DWT: pure passthrough — source callback copies LL row to scratch ───
   if (s->dir == DWT_NO) {
-    sprec_t *data = s->horz_out_buf + IDWT_RING_PSE_LEFT;
+    sprec_t *data = static_cast<sprec_t *>(s->horz_out_buf) + IDWT_RING_PSE_LEFT;
     s->get_src_row(s->src_ctx, s->next_out, data);
     ++s->next_out;
     return data;
@@ -1277,7 +1347,12 @@ sprec_t *idwt_2d_state_pull_row_ref(idwt_2d_state *s) {
     sprec_t *dst = rptr(s, s->v0);
     s->get_src_row(s->src_ctx, s->v0, dst);
     if (s->transformation == 1 && (s->v0 % 2) == 1) {
-      for (int32_t c = 0; c < s->u1 - s->u0; ++c) dst[c] = floorf(dst[c] * 0.5f);
+      if (s->use_i32) {
+        int32_t *dst_i = reinterpret_cast<int32_t *>(dst);
+        for (int32_t c = 0; c < s->u1 - s->u0; ++c) dst_i[c] >>= 1;
+      } else {
+        for (int32_t c = 0; c < s->u1 - s->u0; ++c) dst[c] = floorf(dst[c] * 0.5f);
+      }
     }
     ++s->next_out;
     return dst;

--- a/source/core/transform/idwt_avx2.cpp
+++ b/source/core/transform/idwt_avx2.cpp
@@ -489,4 +489,92 @@ void idwt_irrev53_ver_sr_fixed_avx2(sprec_t *in, const int32_t u0, const int32_t
     }
   }
 }
+
+void idwt_1d_filtr_rev53_i32_avx2(int32_t *X, const int32_t left, const int32_t i0, const int32_t i1) {
+  const int32_t start  = i0 / 2;
+  const int32_t stop   = i1 / 2;
+  const int32_t offset = left - i0 % 2;
+
+  // step 1 (undo forward LP update): LP -= (HP_left + HP_right + 2) >> 2
+  int32_t simdlen = stop + 1 - start;
+  int32_t i = 0, n = offset;
+  const __m256i vtwo = _mm256_set1_epi32(2);
+  for (; i + 4 < simdlen; i += 8, n += 16) {
+    __m256i xin0a = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(X + n - 1));
+    __m256i xin2a = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(X + n + 1));
+    __m256i xin0b = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(X + n + 7));
+    __m256i xin2b = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(X + n + 9));
+    __m256i xsuma = _mm256_slli_epi64(
+        _mm256_add_epi32(_mm256_add_epi32(xin0a, xin2a), vtwo), 32);
+    __m256i xsumb = _mm256_slli_epi64(
+        _mm256_add_epi32(_mm256_add_epi32(xin0b, xin2b), vtwo), 32);
+    xsuma = _mm256_srai_epi32(xsuma, 2);
+    xsumb = _mm256_srai_epi32(xsumb, 2);
+    xin0a = _mm256_sub_epi32(xin0a, xsuma);
+    xin0b = _mm256_sub_epi32(xin0b, xsumb);
+    _mm256_storeu_si256(reinterpret_cast<__m256i *>(X + n - 1), xin0a);
+    _mm256_storeu_si256(reinterpret_cast<__m256i *>(X + n + 7), xin0b);
+  }
+  for (; i < simdlen; i += 4, n += 8) {
+    __m256i xin0 = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(X + n - 1));
+    __m256i xin2 = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(X + n + 1));
+    __m256i xsum = _mm256_slli_epi64(
+        _mm256_add_epi32(_mm256_add_epi32(xin0, xin2), vtwo), 32);
+    xsum = _mm256_srai_epi32(xsum, 2);
+    xin0 = _mm256_sub_epi32(xin0, xsum);
+    _mm256_storeu_si256(reinterpret_cast<__m256i *>(X + n - 1), xin0);
+  }
+
+  // step 2 (undo forward HP predict): HP += (LP_left + LP_right) >> 1
+  simdlen = stop - start;
+  i = 0; n = offset;
+  for (; i + 4 < simdlen; i += 8, n += 16) {
+    __m256i xin0a = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(X + n));
+    __m256i xin2a = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(X + n + 2));
+    __m256i xin0b = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(X + n + 8));
+    __m256i xin2b = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(X + n + 10));
+    __m256i xsuma = _mm256_slli_epi64(_mm256_add_epi32(xin0a, xin2a), 32);
+    __m256i xsumb = _mm256_slli_epi64(_mm256_add_epi32(xin0b, xin2b), 32);
+    xsuma = _mm256_srai_epi32(xsuma, 1);
+    xsumb = _mm256_srai_epi32(xsumb, 1);
+    xin0a = _mm256_add_epi32(xin0a, xsuma);
+    xin0b = _mm256_add_epi32(xin0b, xsumb);
+    _mm256_storeu_si256(reinterpret_cast<__m256i *>(X + n), xin0a);
+    _mm256_storeu_si256(reinterpret_cast<__m256i *>(X + n + 8), xin0b);
+  }
+  for (; i < simdlen; i += 4, n += 8) {
+    __m256i xin0 = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(X + n));
+    __m256i xin2 = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(X + n + 2));
+    __m256i xsum = _mm256_slli_epi64(_mm256_add_epi32(xin0, xin2), 32);
+    xsum = _mm256_srai_epi32(xsum, 1);
+    xin0 = _mm256_add_epi32(xin0, xsum);
+    _mm256_storeu_si256(reinterpret_cast<__m256i *>(X + n), xin0);
+  }
+}
+
+void idwt_rev_ver_lp_step_i32_avx2(int32_t n, const int32_t *prev, const int32_t *next, int32_t *tgt) {
+  const __m256i vtwo = _mm256_set1_epi32(2);
+  int32_t i = 0;
+  for (; i + 8 <= n; i += 8) {
+    __m256i a = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(prev + i));
+    __m256i b = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(next + i));
+    __m256i t = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(tgt  + i));
+    t = _mm256_sub_epi32(t,
+        _mm256_srai_epi32(_mm256_add_epi32(_mm256_add_epi32(a, b), vtwo), 2));
+    _mm256_storeu_si256(reinterpret_cast<__m256i *>(tgt + i), t);
+  }
+  for (; i < n; ++i) tgt[i] -= (prev[i] + next[i] + 2) >> 2;
+}
+
+void idwt_rev_ver_hp_step_i32_avx2(int32_t n, const int32_t *prev, const int32_t *next, int32_t *tgt) {
+  int32_t i = 0;
+  for (; i + 8 <= n; i += 8) {
+    __m256i a = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(prev + i));
+    __m256i b = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(next + i));
+    __m256i t = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(tgt  + i));
+    t = _mm256_add_epi32(t, _mm256_srai_epi32(_mm256_add_epi32(a, b), 1));
+    _mm256_storeu_si256(reinterpret_cast<__m256i *>(tgt + i), t);
+  }
+  for (; i < n; ++i) tgt[i] += (prev[i] + next[i]) >> 1;
+}
 #endif

--- a/source/core/transform/idwt_avx512.cpp
+++ b/source/core/transform/idwt_avx512.cpp
@@ -525,4 +525,107 @@ void idwt_irrev53_ver_sr_fixed_avx512(sprec_t *in, const int32_t u0, const int32
   }
 }
 
+void idwt_1d_filtr_rev53_i32_avx512(int32_t *X, const int32_t left, const int32_t i0, const int32_t i1) {
+  const int32_t start  = i0 / 2;
+  const int32_t stop   = i1 / 2;
+  const int32_t offset = left - i0 % 2;
+
+  // step 1 (undo forward LP update): LP -= (HP_left + HP_right + 2) >> 2
+  int32_t simdlen = stop + 1 - start;
+  int32_t i = 0, n = offset;
+  const __m512i vtwo = _mm512_set1_epi32(2);
+  for (; i + 8 < simdlen; i += 16, n += 32) {
+    __m512i xin0a = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(X + n - 1));
+    __m512i xin2a = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(X + n + 1));
+    __m512i xin0b = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(X + n + 15));
+    __m512i xin2b = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(X + n + 17));
+    __m512i xsuma = _mm512_slli_epi64(
+        _mm512_add_epi32(_mm512_add_epi32(xin0a, xin2a), vtwo), 32);
+    __m512i xsumb = _mm512_slli_epi64(
+        _mm512_add_epi32(_mm512_add_epi32(xin0b, xin2b), vtwo), 32);
+    xsuma = _mm512_srai_epi32(xsuma, 2);
+    xsumb = _mm512_srai_epi32(xsumb, 2);
+    xin0a = _mm512_sub_epi32(xin0a, xsuma);
+    xin0b = _mm512_sub_epi32(xin0b, xsumb);
+    _mm512_storeu_si512(reinterpret_cast<__m512i *>(X + n - 1), xin0a);
+    _mm512_storeu_si512(reinterpret_cast<__m512i *>(X + n + 15), xin0b);
+  }
+  for (; i < simdlen; i += 8, n += 16) {
+    __m512i xin0 = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(X + n - 1));
+    __m512i xin2 = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(X + n + 1));
+    __m512i xsum = _mm512_slli_epi64(
+        _mm512_add_epi32(_mm512_add_epi32(xin0, xin2), vtwo), 32);
+    xsum = _mm512_srai_epi32(xsum, 2);
+    xin0 = _mm512_sub_epi32(xin0, xsum);
+    _mm512_storeu_si512(reinterpret_cast<__m512i *>(X + n - 1), xin0);
+  }
+
+  // step 2 (undo forward HP predict): HP += (LP_left + LP_right) >> 1
+  simdlen = stop - start;
+  i = 0; n = offset;
+  for (; i + 8 < simdlen; i += 16, n += 32) {
+    __m512i xin0a = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(X + n));
+    __m512i xin2a = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(X + n + 2));
+    __m512i xin0b = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(X + n + 16));
+    __m512i xin2b = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(X + n + 18));
+    __m512i xsuma = _mm512_slli_epi64(_mm512_add_epi32(xin0a, xin2a), 32);
+    __m512i xsumb = _mm512_slli_epi64(_mm512_add_epi32(xin0b, xin2b), 32);
+    xsuma = _mm512_srai_epi32(xsuma, 1);
+    xsumb = _mm512_srai_epi32(xsumb, 1);
+    xin0a = _mm512_add_epi32(xin0a, xsuma);
+    xin0b = _mm512_add_epi32(xin0b, xsumb);
+    _mm512_storeu_si512(reinterpret_cast<__m512i *>(X + n), xin0a);
+    _mm512_storeu_si512(reinterpret_cast<__m512i *>(X + n + 16), xin0b);
+  }
+  for (; i < simdlen; i += 8, n += 16) {
+    __m512i xin0 = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(X + n));
+    __m512i xin2 = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(X + n + 2));
+    __m512i xsum = _mm512_slli_epi64(_mm512_add_epi32(xin0, xin2), 32);
+    xsum = _mm512_srai_epi32(xsum, 1);
+    xin0 = _mm512_add_epi32(xin0, xsum);
+    _mm512_storeu_si512(reinterpret_cast<__m512i *>(X + n), xin0);
+  }
+}
+
+void idwt_rev_ver_lp_step_i32_avx512(int32_t n, const int32_t *prev, const int32_t *next, int32_t *tgt) {
+  const __m512i vtwo = _mm512_set1_epi32(2);
+  int32_t i = 0;
+  for (; i + 16 <= n; i += 16) {
+    __m512i a = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(prev + i));
+    __m512i b = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(next + i));
+    __m512i t = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(tgt  + i));
+    t = _mm512_sub_epi32(t,
+        _mm512_srai_epi32(_mm512_add_epi32(_mm512_add_epi32(a, b), vtwo), 2));
+    _mm512_storeu_si512(reinterpret_cast<__m512i *>(tgt + i), t);
+  }
+  if (i < n) {
+    __mmask16 mask = static_cast<__mmask16>((1U << (n - i)) - 1U);
+    __m512i a = _mm512_maskz_loadu_epi32(mask, prev + i);
+    __m512i b = _mm512_maskz_loadu_epi32(mask, next + i);
+    __m512i t = _mm512_maskz_loadu_epi32(mask, tgt  + i);
+    t = _mm512_sub_epi32(t,
+        _mm512_srai_epi32(_mm512_add_epi32(_mm512_add_epi32(a, b), vtwo), 2));
+    _mm512_mask_storeu_epi32(tgt + i, mask, t);
+  }
+}
+
+void idwt_rev_ver_hp_step_i32_avx512(int32_t n, const int32_t *prev, const int32_t *next, int32_t *tgt) {
+  int32_t i = 0;
+  for (; i + 16 <= n; i += 16) {
+    __m512i a = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(prev + i));
+    __m512i b = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(next + i));
+    __m512i t = _mm512_loadu_si512(reinterpret_cast<const __m512i *>(tgt  + i));
+    t = _mm512_add_epi32(t, _mm512_srai_epi32(_mm512_add_epi32(a, b), 1));
+    _mm512_storeu_si512(reinterpret_cast<__m512i *>(tgt + i), t);
+  }
+  if (i < n) {
+    __mmask16 mask = static_cast<__mmask16>((1U << (n - i)) - 1U);
+    __m512i a = _mm512_maskz_loadu_epi32(mask, prev + i);
+    __m512i b = _mm512_maskz_loadu_epi32(mask, next + i);
+    __m512i t = _mm512_maskz_loadu_epi32(mask, tgt  + i);
+    t = _mm512_add_epi32(t, _mm512_srai_epi32(_mm512_add_epi32(a, b), 1));
+    _mm512_mask_storeu_epi32(tgt + i, mask, t);
+  }
+}
+
 #endif  // OPENHTJ2K_TRY_AVX2 && __AVX512F__

--- a/source/core/transform/idwt_neon.cpp
+++ b/source/core/transform/idwt_neon.cpp
@@ -636,4 +636,109 @@ void idwt_irrev53_ver_sr_fixed_neon(sprec_t *in, const int32_t u0, const int32_t
   }
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Int32 reversible 5/3 IDWT primitives — exact inverse of the FDWT int32 path.
+// Uses arithmetic right shift instead of float floor/multiply.
+// ─────────────────────────────────────────────────────────────────────────────
+
+void idwt_1d_filtr_rev53_i32_neon(int32_t *X, const int32_t left, const int32_t i0, const int32_t i1) {
+  const int32_t start  = i0 / 2;
+  const int32_t stop   = i1 / 2;
+  const int32_t offset = left - i0 % 2;
+
+  // step 1 (undo forward LP update): LP -= (HP_left + HP_right + 2) >> 2
+  const int32_t base1 = offset;
+  int32_t simdlen     = stop + 1 - start;
+  const int32x4_t vtwo = vdupq_n_s32(2);
+  int32_t k = 0;
+  for (; k + 8 <= simdlen; k += 8) {
+    int32_t *sp = X + base1 + k * 2;
+    int32x4x2_t xl0a = vld2q_s32(sp - 1);
+    int32x4x2_t xl1a = vld2q_s32(sp + 1);
+    int32x4x2_t xl0b = vld2q_s32(sp + 7);
+    int32x4x2_t xl1b = vld2q_s32(sp + 9);
+    xl0a.val[1] = vsubq_s32(xl0a.val[1],
+        vshrq_n_s32(vaddq_s32(vaddq_s32(xl0a.val[0], xl1a.val[0]), vtwo), 2));
+    xl0b.val[1] = vsubq_s32(xl0b.val[1],
+        vshrq_n_s32(vaddq_s32(vaddq_s32(xl0b.val[0], xl1b.val[0]), vtwo), 2));
+    vst2q_s32(sp - 1, xl0a);
+    vst2q_s32(sp + 7, xl0b);
+  }
+  for (; k < simdlen; k += 4) {
+    int32_t *sp = X + base1 + k * 2;
+    int32x4x2_t xl0 = vld2q_s32(sp - 1);
+    int32x4x2_t xl1 = vld2q_s32(sp + 1);
+    xl0.val[1] = vsubq_s32(xl0.val[1],
+        vshrq_n_s32(vaddq_s32(vaddq_s32(xl0.val[0], xl1.val[0]), vtwo), 2));
+    vst2q_s32(sp - 1, xl0);
+  }
+
+  // step 2 (undo forward HP predict): HP += (LP_mod_left + LP_mod_right) >> 1
+  const int32_t base2 = offset;
+  simdlen = stop - start;
+  k = 0;
+  for (; k + 8 <= simdlen; k += 8) {
+    int32_t *sp = X + base2 + k * 2;
+    int32x4x2_t xl0a = vld2q_s32(sp);
+    int32x4x2_t xl1a = vld2q_s32(sp + 2);
+    int32x4x2_t xl0b = vld2q_s32(sp + 8);
+    int32x4x2_t xl1b = vld2q_s32(sp + 10);
+    xl0a.val[1] = vaddq_s32(xl0a.val[1],
+        vshrq_n_s32(vaddq_s32(xl0a.val[0], xl1a.val[0]), 1));
+    xl0b.val[1] = vaddq_s32(xl0b.val[1],
+        vshrq_n_s32(vaddq_s32(xl0b.val[0], xl1b.val[0]), 1));
+    vst2q_s32(sp, xl0a);
+    vst2q_s32(sp + 8, xl0b);
+  }
+  for (; k < simdlen; k += 4) {
+    int32_t *sp = X + base2 + k * 2;
+    int32x4x2_t xl0 = vld2q_s32(sp);
+    int32x4x2_t xl1 = vld2q_s32(sp + 2);
+    xl0.val[1] = vaddq_s32(xl0.val[1],
+        vshrq_n_s32(vaddq_s32(xl0.val[0], xl1.val[0]), 1));
+    vst2q_s32(sp, xl0);
+  }
+}
+
+void idwt_rev_ver_lp_step_i32_neon(int32_t n, const int32_t *prev, const int32_t *next, int32_t *tgt) {
+  const int32x4_t vtwo = vdupq_n_s32(2);
+  int32_t i = 0;
+  for (; i + 8 <= n; i += 8) {
+    int32x4_t a0 = vld1q_s32(prev + i);     int32x4_t b0 = vld1q_s32(next + i);     int32x4_t t0 = vld1q_s32(tgt + i);
+    int32x4_t a1 = vld1q_s32(prev + i + 4); int32x4_t b1 = vld1q_s32(next + i + 4); int32x4_t t1 = vld1q_s32(tgt + i + 4);
+    t0 = vsubq_s32(t0, vshrq_n_s32(vaddq_s32(vaddq_s32(a0, b0), vtwo), 2));
+    t1 = vsubq_s32(t1, vshrq_n_s32(vaddq_s32(vaddq_s32(a1, b1), vtwo), 2));
+    vst1q_s32(tgt + i, t0);
+    vst1q_s32(tgt + i + 4, t1);
+  }
+  for (; i + 4 <= n; i += 4) {
+    int32x4_t a = vld1q_s32(prev + i);
+    int32x4_t b = vld1q_s32(next + i);
+    int32x4_t t = vld1q_s32(tgt  + i);
+    t = vsubq_s32(t, vshrq_n_s32(vaddq_s32(vaddq_s32(a, b), vtwo), 2));
+    vst1q_s32(tgt + i, t);
+  }
+  for (; i < n; ++i) tgt[i] -= (prev[i] + next[i] + 2) >> 2;
+}
+
+void idwt_rev_ver_hp_step_i32_neon(int32_t n, const int32_t *prev, const int32_t *next, int32_t *tgt) {
+  int32_t i = 0;
+  for (; i + 8 <= n; i += 8) {
+    int32x4_t a0 = vld1q_s32(prev + i);     int32x4_t b0 = vld1q_s32(next + i);     int32x4_t t0 = vld1q_s32(tgt + i);
+    int32x4_t a1 = vld1q_s32(prev + i + 4); int32x4_t b1 = vld1q_s32(next + i + 4); int32x4_t t1 = vld1q_s32(tgt + i + 4);
+    t0 = vaddq_s32(t0, vshrq_n_s32(vaddq_s32(a0, b0), 1));
+    t1 = vaddq_s32(t1, vshrq_n_s32(vaddq_s32(a1, b1), 1));
+    vst1q_s32(tgt + i, t0);
+    vst1q_s32(tgt + i + 4, t1);
+  }
+  for (; i + 4 <= n; i += 4) {
+    int32x4_t a = vld1q_s32(prev + i);
+    int32x4_t b = vld1q_s32(next + i);
+    int32x4_t t = vld1q_s32(tgt  + i);
+    t = vaddq_s32(t, vshrq_n_s32(vaddq_s32(a, b), 1));
+    vst1q_s32(tgt + i, t);
+  }
+  for (; i < n; ++i) tgt[i] += (prev[i] + next[i]) >> 1;
+}
+
 #endif

--- a/source/core/transform/idwt_wasm.cpp
+++ b/source/core/transform/idwt_wasm.cpp
@@ -428,4 +428,120 @@ void idwt_rev_ver_sr_fixed_wasm(sprec_t *in, const int32_t u0, const int32_t u1,
   }
 }
 
+struct i32x4x2_idwt {
+  v128_t val[2];
+};
+
+static inline i32x4x2_idwt vld2q_i32_idwt(const int32_t *ptr) {
+  v128_t lo = wasm_v128_load(ptr);
+  v128_t hi = wasm_v128_load(ptr + 4);
+  i32x4x2_idwt r;
+  r.val[0] = wasm_i32x4_shuffle(lo, hi, 0, 2, 4, 6);
+  r.val[1] = wasm_i32x4_shuffle(lo, hi, 1, 3, 5, 7);
+  return r;
+}
+
+static inline void vst2q_i32_idwt(int32_t *ptr, i32x4x2_idwt x) {
+  v128_t lo = wasm_i32x4_shuffle(x.val[0], x.val[1], 0, 4, 1, 5);
+  v128_t hi = wasm_i32x4_shuffle(x.val[0], x.val[1], 2, 6, 3, 7);
+  wasm_v128_store(ptr, lo);
+  wasm_v128_store(ptr + 4, hi);
+}
+
+void idwt_1d_filtr_rev53_i32_wasm(int32_t *X, const int32_t left, const int32_t i0, const int32_t i1) {
+  const int32_t start  = i0 / 2;
+  const int32_t stop   = i1 / 2;
+  const int32_t offset = left - i0 % 2;
+
+  // step 1 (undo forward LP update): LP -= (HP_left + HP_right + 2) >> 2
+  int32_t simdlen = stop + 1 - start;
+  const v128_t vtwo = wasm_i32x4_splat(2);
+  int32_t n = offset, i = 0;
+  for (; i + 8 <= simdlen; i += 8, n += 16) {
+    i32x4x2_idwt xl0a = vld2q_i32_idwt(X + n - 1);
+    i32x4x2_idwt xl1a = vld2q_i32_idwt(X + n + 1);
+    i32x4x2_idwt xl0b = vld2q_i32_idwt(X + n + 7);
+    i32x4x2_idwt xl1b = vld2q_i32_idwt(X + n + 9);
+    xl0a.val[1] = wasm_i32x4_sub(xl0a.val[1],
+        wasm_i32x4_shr(wasm_i32x4_add(wasm_i32x4_add(xl0a.val[0], xl1a.val[0]), vtwo), 2));
+    xl0b.val[1] = wasm_i32x4_sub(xl0b.val[1],
+        wasm_i32x4_shr(wasm_i32x4_add(wasm_i32x4_add(xl0b.val[0], xl1b.val[0]), vtwo), 2));
+    vst2q_i32_idwt(X + n - 1, xl0a);
+    vst2q_i32_idwt(X + n + 7, xl0b);
+  }
+  for (; i < simdlen; i += 4, n += 8) {
+    i32x4x2_idwt xl0 = vld2q_i32_idwt(X + n - 1);
+    i32x4x2_idwt xl1 = vld2q_i32_idwt(X + n + 1);
+    xl0.val[1] = wasm_i32x4_sub(xl0.val[1],
+        wasm_i32x4_shr(wasm_i32x4_add(wasm_i32x4_add(xl0.val[0], xl1.val[0]), vtwo), 2));
+    vst2q_i32_idwt(X + n - 1, xl0);
+  }
+
+  // step 2 (undo forward HP predict): HP += (LP_left + LP_right) >> 1
+  simdlen = stop - start;
+  n = offset; i = 0;
+  for (; i + 8 <= simdlen; i += 8, n += 16) {
+    i32x4x2_idwt xl0a = vld2q_i32_idwt(X + n);
+    i32x4x2_idwt xl1a = vld2q_i32_idwt(X + n + 2);
+    i32x4x2_idwt xl0b = vld2q_i32_idwt(X + n + 8);
+    i32x4x2_idwt xl1b = vld2q_i32_idwt(X + n + 10);
+    xl0a.val[1] = wasm_i32x4_add(xl0a.val[1],
+        wasm_i32x4_shr(wasm_i32x4_add(xl0a.val[0], xl1a.val[0]), 1));
+    xl0b.val[1] = wasm_i32x4_add(xl0b.val[1],
+        wasm_i32x4_shr(wasm_i32x4_add(xl0b.val[0], xl1b.val[0]), 1));
+    vst2q_i32_idwt(X + n, xl0a);
+    vst2q_i32_idwt(X + n + 8, xl0b);
+  }
+  for (; i < simdlen; i += 4, n += 8) {
+    i32x4x2_idwt xl0 = vld2q_i32_idwt(X + n);
+    i32x4x2_idwt xl1 = vld2q_i32_idwt(X + n + 2);
+    xl0.val[1] = wasm_i32x4_add(xl0.val[1],
+        wasm_i32x4_shr(wasm_i32x4_add(xl0.val[0], xl1.val[0]), 1));
+    vst2q_i32_idwt(X + n, xl0);
+  }
+}
+
+void idwt_rev_ver_lp_step_i32_wasm(int32_t n, const int32_t *prev, const int32_t *next, int32_t *tgt) {
+  const v128_t vtwo = wasm_i32x4_splat(2);
+  int32_t i = 0;
+  for (; i + 8 <= n; i += 8) {
+    v128_t a0 = wasm_v128_load(prev + i);     v128_t b0 = wasm_v128_load(next + i);     v128_t t0 = wasm_v128_load(tgt + i);
+    v128_t a1 = wasm_v128_load(prev + i + 4); v128_t b1 = wasm_v128_load(next + i + 4); v128_t t1 = wasm_v128_load(tgt + i + 4);
+    t0 = wasm_i32x4_sub(t0,
+         wasm_i32x4_shr(wasm_i32x4_add(wasm_i32x4_add(a0, b0), vtwo), 2));
+    t1 = wasm_i32x4_sub(t1,
+         wasm_i32x4_shr(wasm_i32x4_add(wasm_i32x4_add(a1, b1), vtwo), 2));
+    wasm_v128_store(tgt + i,     t0);
+    wasm_v128_store(tgt + i + 4, t1);
+  }
+  for (; i + 4 <= n; i += 4) {
+    v128_t a = wasm_v128_load(prev + i);
+    v128_t b = wasm_v128_load(next + i);
+    v128_t t = wasm_v128_load(tgt  + i);
+    t = wasm_i32x4_sub(t, wasm_i32x4_shr(wasm_i32x4_add(wasm_i32x4_add(a, b), vtwo), 2));
+    wasm_v128_store(tgt + i, t);
+  }
+  for (; i < n; ++i) tgt[i] -= (prev[i] + next[i] + 2) >> 2;
+}
+
+void idwt_rev_ver_hp_step_i32_wasm(int32_t n, const int32_t *prev, const int32_t *next, int32_t *tgt) {
+  int32_t i = 0;
+  for (; i + 8 <= n; i += 8) {
+    v128_t a0 = wasm_v128_load(prev + i);     v128_t b0 = wasm_v128_load(next + i);     v128_t t0 = wasm_v128_load(tgt + i);
+    v128_t a1 = wasm_v128_load(prev + i + 4); v128_t b1 = wasm_v128_load(next + i + 4); v128_t t1 = wasm_v128_load(tgt + i + 4);
+    t0 = wasm_i32x4_add(t0, wasm_i32x4_shr(wasm_i32x4_add(a0, b0), 1));
+    t1 = wasm_i32x4_add(t1, wasm_i32x4_shr(wasm_i32x4_add(a1, b1), 1));
+    wasm_v128_store(tgt + i,     t0);
+    wasm_v128_store(tgt + i + 4, t1);
+  }
+  for (; i + 4 <= n; i += 4) {
+    v128_t a = wasm_v128_load(prev + i);
+    v128_t b = wasm_v128_load(next + i);
+    v128_t t = wasm_v128_load(tgt  + i);
+    t = wasm_i32x4_add(t, wasm_i32x4_shr(wasm_i32x4_add(a, b), 1));
+    wasm_v128_store(tgt + i, t);
+  }
+  for (; i < n; ++i) tgt[i] += (prev[i] + next[i]) >> 1;
+}
+
 #endif  // OPENHTJ2K_ENABLE_WASM_SIMD


### PR DESCRIPTION
## Summary

- **NEON emitFlat encoder**: port the AVX2 deferred MagSgn drain pattern to NEON — accumulates (v_corr, m) pairs into flat arrays and drains once per line-pair instead of calling `emitBits()` per quad. **25% single-threaded lossless encode speedup** on 4K 12-bit (183 ms → 138 ms).
- **Int32 reversible 5/3 IDWT pipeline**: adds int32 IDWT primitives across all backends (NEON, AVX2, AVX-512, WASM SIMD, scalar) that match the int32 FDWT encoder, fixing the lossless encode→decode round-trip. The fused dequant inside `ht_cleanup_decode` and standalone `dequantize()` use a `template<bool StoreI32>` approach (`if constexpr`) for zero inner-loop branching. The finalize step reads int32 directly from the ring buffer to avoid in-place corruption of the IDWT vertical lifting neighbors.

## Benchmarks (4K ElephantDream 4096x2160, Zen 5)

| | main | patched | delta |
|---|---|---|---|
| Lossless encode | 59 ms | 58 ms | -1.7% |
| Lossless decode | 48 ms | 47 ms | -2.1% |
| Lossy encode | 54 ms | 53 ms | -1.9% |
| Lossy decode | 40 ms | 39 ms | -2.5% |

## Test plan

- [x] 9/9 CI jobs pass (ubuntu gcc/clang, macOS ARM/Intel, Windows x86/ARM, ubuntu ARM gcc/clang, WASM)
- [x] Lossless round-trip: PAE = 0 (both even and odd dimensions)
- [x] All 137 WASM conformance tests pass
- [x] All 266 native conformance tests pass
- [x] No decode throughput regression on any path
- [x] Codestreams bitwise identical (emitFlat produces same output)