### PR TITLE
perf(decoder): planar LP/HP horizontal IDWT lifting on NEON

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,17 @@
 # [Unreleased]
 
+## Performance
+
+### Decoder
+- Streaming horizontal IDWT lifts directly from the planar LP/HP subband
+  rows on NEON (9/7 float and int32 5/3): the per-row interleave pass into
+  the ring slot is gone and the kernels' interleaved `vld2q` input loads
+  become one `vld1q` per plane. Output is bit-identical (verified against
+  the conformance suite and an 8K `cmp`); platforms without a planar
+  kernel keep the interleave + in-place path unchanged. Measured on an 8K
+  12-bit image (M3 Max, single thread, 30-iteration mean): lossy decode
+  ~5% faster, lossless ~2.5%.
+
 ## Fixed
 
 - The HT SigProp bit reader rejected valid codestreams whose refinement

--- a/docs/planar_idwt_porting.md
+++ b/docs/planar_idwt_porting.md
@@ -1,0 +1,271 @@
+# Porting the planar horizontal IDWT to AVX2 / AVX-512 / WASM
+
+Status as of PR #406 (June 2026): the streaming horizontal IDWT lifts directly
+from the planar LP/HP subband rows **on NEON only** (9/7 float and int32 5/3).
+All other platforms — AVX2, AVX-512, WASM, scalar — go through a bit-identical
+fallback that interleaves into the ring slot and runs the historical in-place
+kernels, at unchanged cost. This document is the map for converting those
+platforms. It assumes no access to the NEON machine; everything needed is in
+the tree.
+
+Measured upside on NEON (8K 12-bit, M3 Max, single thread, 30-iter mean):
+lossy 9/7 **−5.5%**, lossless 5/3 i32 **−2.5%** end-to-end decode. On AVX2 the
+upside is plausibly larger (see §5.1): the current in-place kernels waste half
+their lanes on pass-through elements, which the planar formulation does not.
+
+---
+
+## 1. Architecture after PR #406
+
+```
+idwt_level_src_fn (coding_units.cpp)          ← selects lp_ptr/hp_ptr, zero scan
+        │
+        ▼
+idwt_1d_row_from_planar (idwt.cpp)            ← THE dispatcher; the only place
+        │                                        that decides planar vs fallback
+        ├─ planar kernel        (NEON today)  ← lp/hp planes → natural row in
+        │                                        the ring slot; no interleave
+        └─ fallback: interleave_row_planes()  ← LP at u0%2, HP at 1-u0%2, then
+           + idwt_1d_row_inplace[_range|_i32]    in-place PSE fill + lifting
+```
+
+Key property that keeps the port contained: **ring-buffer rows hold
+natural-domain rows**. The interleaved format only ever existed between the
+source callback and the horizontal kernel. Vertical lifting, the cascade,
+zero-row tracking, PSE row copies, `pull_row_ref`, and the whole batch path
+(`idwt_2d_sr_fixed`) are untouched and must stay untouched.
+
+The port therefore adds, per platform:
+
+1. Two kernels in `idwt_avx2.cpp` / `idwt_wasm.cpp` (and later `idwt_avx512.cpp`):
+   - `idwt_1d_filtr_irrev97_planar_<isa>(sprec_t *out, const sprec_t *lp, const sprec_t *hp, int32_t u0, int32_t u1)`
+   - `idwt_1d_filtr_rev53_planar_i32_<isa>(int32_t *out, const int32_t *lp, const int32_t *hp, int32_t u0, int32_t u1)`
+2. Declarations in the matching `#elif` block of `dwt.hpp`.
+3. An `#elif` branch in the planar fast path of `idwt_1d_row_from_planar`
+   (idwt.cpp), which today reads `#if defined(OPENHTJ2K_ENABLE_ARM_NEON)`.
+   Note `OPENHTJ2K_ENABLE_AVX2` is also defined on AVX-512 builds, so an AVX2
+   planar kernel automatically serves AVX-512 hosts until a dedicated
+   `_avx512` variant exists (the in-place dispatch tables prefer AVX-512; the
+   planar dispatch can start with AVX2 only).
+
+Nothing else changes. `coding_units.cpp` already calls the dispatcher.
+
+## 2. Dispatcher contract (do not relax without re-deriving §3)
+
+The planar fast path runs only when **all** of these hold; everything else
+falls back (and must keep falling back):
+
+| Guard | Why |
+|---|---|
+| `(u0 & 1) == 0` | keeps `E[j] = lp[j]`, `O[j] = hp[j]` index-aligned; odd u0 shifts the LP plane by one and is rare (odd tile/precinct origins) |
+| `N = u1/2 - u0/2 >= 12` | the kernels' SIMD warmup loads blocks j=0..7 unconditionally; short rows go through the fallback's scalar-friendly path |
+| 9/7 float: `col_lo <= u0 && col_hi >= u1` | narrow JPIP column ranges use the scalar sub-range lifter on the interleaved row; not worth porting |
+| 5/3: `use_i32 == true` | the float-5/3 streaming path is cold (lossless decode is i32); i32 ignores the column range by design, matching `idwt_1d_row_inplace_i32` |
+
+Buffer contract the dispatcher guarantees to the kernel:
+
+- `out` is a ring-slot (or `horz_out_buf`) data pointer: **8 writable floats
+  before index 0** (`IDWT_RING_PSE_LEFT`) and **≥ 32 after index width-1**
+  (`SIMD_PADDING` in `slot_stride`). The kernels write `out[-2]`, `out[-1]`
+  (the "final E[-1]/O[-1]" the in-place kernel also produced) and up to
+  `out[2N+2]` past the data end — all within that slack.
+- `lp` has `ceil(u1/2) - u0/2` valid samples (= N or N+1), `hp` has exactly N.
+  **There are no PSE margins on the planes** — never load past those counts
+  (see §3 loop bounds). Plane sources are codeblock band rows, the child
+  state's ring row, or the zeroed `lp_tmp`; over-reading band rows is not
+  covered by any allocation guarantee at these widths.
+- `out` never aliases `lp`/`hp`.
+
+## 3. The math (identical on every platform)
+
+### 3.1 Recurrences
+
+With `E[j] = lp[j]`, `O[j] = hp[j]`, `N = u1/2 - u0/2` (u0 even — guard above):
+
+9/7 synthesis, fused single pass (same scheme as the in-place fused kernel):
+
+```
+S1[j] = E[j]  - fD*(O[j-1]  + O[j])     j ∈ [-1, N+1]
+S2[j] = O[j]  - fC*(S1[j]   + S1[j+1])  j ∈ [-1, N]
+S3[j] = S1[j] - fB*(S2[j-1] + S2[j])    j ∈ [ 0, N]
+S4[j] = S2[j] - fA*(S3[j]   + S3[j+1])  j ∈ [ 0, N-1]
+out:  E[-1]=S1[-1], O[-1]=S2[-1], E[j]=S3[j], O[j]=S4[j], O[N]=S2[N], E[N+1]=S1[N+1]
+```
+
+int32 5/3 synthesis:
+
+```
+S1[j] = E[j] - ((O[j-1] + O[j] + 2) >> 2)   j ∈ [0, N]
+S2[j] = O[j] + ((S1[j]  + S1[j+1]) >> 1)    j ∈ [0, N)
+out:  E[j]=S1[j] (→ out[2j]), O[j]=S2[j] (→ out[2j+1])
+```
+
+### 3.2 Boundary taps — mirror within the plane
+
+Whole-sample symmetric extension preserves parity: positions `u0-k` and
+`u0+k` are both even or both odd, so **extension never crosses planes**. Any
+raw `E[j]`/`O[j]` outside the valid range maps to an in-range plane index via
+`PSEo` on the absolute position:
+
+```cpp
+auto E = [&](int32_t j) -> float { return lp[PSEo(u0 + 2 * j,     u0, u1) >> 1]; };
+auto O = [&](int32_t j) -> float { return hp[PSEo(u0 + 2 * j + 1, u0, u1) >> 1]; };
+```
+
+These return *exactly* the values the in-place kernels found in their
+PSE-filled margins (that is the bit-exactness argument for the boundaries; do
+not hand-derive per-parity mirror formulas, just use `PSEo`). They are used
+only in the scalar warmup/drain — a dozen taps per row.
+
+### 3.3 Loop bounds (the one place planar differs from in-place)
+
+The in-place fused NEON kernel ran its SIMD loop to `4n+3 <= N+1` because the
+interleaved row had PSE-filled margins to read. The planes do not, so the
+planar SIMD loop stops at **`4n+3 <= N-1`** (NEON, 4-lane; for 8-lane AVX2 the
+analogous bound keeps every plane load ≤ index N-1) and the scalar drain
+covers the remaining j with the mirrored accessors. Same for the 5/3 i32 main
+loop: `j + 4 <= N - 1`, because the `s1_next` lookahead reads `lp[j+4]` /
+`hp[j+4]`.
+
+### 3.4 Bit-exactness mandate
+
+`lbs_*` tests enforce batch == line-based bit-exact, and the dispatcher's
+fallback must equal the planar path. So a planar kernel must reproduce **the
+same single-rounded operation sequence per element as the same platform's
+in-place kernel**:
+
+- 9/7: one fused multiply-add per stage. NEON uses `vfmsq_f32` / `std::fmaf`;
+  the existing AVX2 in-place kernel uses `_mm256_fnmadd_ps` — also
+  single-rounded, and `fnmadd(sum, coeff, x) == fmaf(-coeff, sum, x)`, so the
+  NEON pipeline math transfers as-is. Keep `std::fmaf` in the scalar
+  warmup/drain on every platform. The neighbor sum is always
+  `(left + right)` in that order, then the FMA.
+- 5/3 i32: integer adds/shifts — exact regardless of structure.
+- 5/3 float (if ever ported): `floorf((a+b+2)*0.25f)` / `floorf((a+b)*0.5f)`
+  with `_mm256_floor_ps` / `wasm_f32x4_floor`; mul+floor, **not** FMA.
+
+Verify against the conformance suite *and* a whole-image `cmp` (§6) — the
+tests alone don't cover 8K-scale row widths.
+
+## 4. The NEON reference implementations
+
+Read these first; they are the template (`source/core/transform/idwt_neon.cpp`,
+bottom of the file):
+
+- `idwt_1d_filtr_irrev97_planar_neon` — warmup (scalar j=-1 taps + S1 of
+  blocks 0/1 + S2/S3 of block 0), steady state (a depth-2 software pipeline:
+  iteration n loads E/O block n with one `vld1q` per plane and stores finished
+  natural-row block n-2 with one `vst2q`), drain (scalar, ≤ 12 elements,
+  mirror accessors). The cross-element shifts (`O[j-1]`, `S1[j+1]`, `S2[j-1]`,
+  `S3[j+1]`) are `vextq_f32` register shuffles between the previous and
+  current block's vectors.
+- `idwt_1d_filtr_rev53_planar_i32_neon` — single loop, no pipeline depth: the
+  one cross-block lane `S1[j+4]` is computed scalar from raw memory
+  (`s1_next`) and `vextq`-ed in. Scalar tail of ≤ 5 elements.
+
+Output-side note: the `vst2q` (interleave-on-store) is **irreducible** — the
+natural-domain row *is* alternating E/O. The win is on the input side (one
+plain load per plane instead of deinterleaving loads) plus the deleted
+interleave pass in the caller.
+
+## 5. Platform notes
+
+### 5.1 AVX2 (do this one first)
+
+The current in-place AVX2 kernels (`idwt_avx2.cpp`) do **not** deinterleave:
+each pass loads overlapping unaligned vectors over the interleaved row and
+updates only every other element, using a `_mm256_slli_epi64(…, 32)` trick to
+zero the pass-through lanes. Net effect: 4 useful results per 8-lane op, four
+passes over the row, plus the caller's interleave pass. A planar kernel gets 8
+useful results per op and one pass — which is why the expected gain here
+exceeds NEON's.
+
+Porting the NEON pipeline to 8 lanes, the only non-mechanical part is the
+cross-element shift of *computed* vectors (raw `O[j-1]` can simply be an
+unaligned reload from `hp + 4n - 1` in steady state, where j-1 ≥ 0 — cheaper
+than shuffling on x86). For the pipeline-internal values use the standard
+two-instruction idiom (no AVX-512 needed):
+
+```cpp
+// y = [a1..a7, b0]   (shift left by one element, carry-in from next vector b)
+__m256 t = _mm256_permute2f128_ps(a, b, 0x21);          // [a4..a7, b0..b3]
+__m256 y = _mm256_castsi256_ps(_mm256_alignr_epi8(
+             _mm256_castps_si256(t), _mm256_castps_si256(a), 4));
+
+// z = [p7, a0..a6]   (shift right by one element, carry-in from previous p)
+__m256 t = _mm256_permute2f128_ps(p, a, 0x21);          // [p4..p7, a0..a3]
+__m256 z = _mm256_castsi256_ps(_mm256_alignr_epi8(
+             _mm256_castps_si256(a), _mm256_castps_si256(t), 12));
+```
+
+Interleaved store: `unpacklo/hi_ps` + `permute2f128` (the inverse of the
+pattern in `interleave_row_planes`, idwt.cpp).
+
+A lower-effort fallback if the full pipeline proves fiddly: keep the four-pass
+in-place structure but fuse the interleave into pass 1 (read `lp`/`hp`, write
+the S1-updated interleaved row). That removes only the caller's interleave
+pass (~half the win) but is a small, low-risk diff. Measure before settling.
+
+Warmup/drain: reuse the NEON scalar code verbatim (`std::fmaf`, mirror
+accessors) — it is platform-independent. With 8-lane blocks the drain spans up
+to ~20 elements; size the `s1t/s2t/s3t` staging arrays accordingly (NEON uses
+16 for 4-lane blocks; 8-lane needs 32 — re-derive from the loop-exit bound the
+way the NEON drain comment does, don't guess).
+
+### 5.2 AVX-512
+
+`idwt_avx512.cpp` exists for IDWT only. Don't start here: ship the AVX2
+planar kernels first (they run on AVX-512 hosts via `OPENHTJ2K_ENABLE_AVX2`),
+then evaluate whether 16-lane + `vpermt2ps` (single-instruction cross-lane
+shifts) pays for a dedicated variant. Keep the dispatch precedence consistent
+with the in-place tables (AVX-512 before AVX2) when adding it.
+
+### 5.3 WASM
+
+`idwt_wasm.cpp` currently emulates `vld2q/vst2q` with paired loads +
+`wasm_i32x4_shuffle` (helpers at the top of the file). The planar port is a
+near line-for-line transcription of the NEON kernels at the same 4-lane width:
+
+- `vextq_f32(a, b, k)` → `wasm_i32x4_shuffle(a, b, k, k+1, k+2, k+3)`
+- **Rounding differs from NEON/AVX2 — this is the one place the NEON code
+  cannot be transcribed blindly.** The in-place WASM 9/7 kernel uses
+  `wasm_f32x4_sub(x, wasm_f32x4_mul(sum, coeff))` — separately-rounded
+  mul+sub, not a fused op (SIMD128 has none). The planar kernel must match:
+  mul+sub in vectors, and plain `x - coeff*(a+b)` float expressions in the
+  scalar warmup/drain — NOT `std::fmaf`. (Plain scalar expressions are safe
+  on WASM: there is no scalar FMA instruction for clang to contract into, so
+  they compile to f32.mul + f32.sub, matching the vector lanes.) The 5/3 i32
+  kernel has no such concern.
+- store: `wasm_i32x4_shuffle` zip pair + two `wasm_v128_store` (same as the
+  existing `vst2q` emulation).
+
+Build/test: `subprojects/` (emcmake) where checked out; minimum bar without a
+browser harness is `emcc -fsyntax-only -msimd128 -DOPENHTJ2K_ENABLE_WASM_SIMD`
+on the touched files plus the native test suite (the WASM guards compile to
+nothing natively, so native ctest only proves you didn't break the others).
+
+## 6. Verification protocol (per platform, no shortcuts)
+
+1. **ctest**: full Release suite (407 tests at time of writing) + Debug.
+2. **Whole-image bit-exactness** vs `main` at 8K scale, lossless and lossy:
+   ```
+   open_htj2k_enc -i u01_Books_8k_12bit.ppm -o 8k_lossless.j2c Creversible=yes
+   open_htj2k_enc -i u01_Books_8k_12bit.ppm -o 8k_lossy.j2c    Creversible=no Qfactor=85
+   <baseline_bin>/open_htj2k_dec -i 8k_<x>.j2c -o base.ppm -num_threads 1
+   <new_bin>/open_htj2k_dec      -i 8k_<x>.j2c -o new.ppm  -num_threads 1
+   cmp base.ppm new.ppm     # must be identical, both streams
+   ```
+3. **A/B benchmark**: snapshotted `bin/` dirs (baseline = a worktree of main,
+   built once), interleaved runs, `-iter 30 -num_threads 1`, ≥ 3 repetitions
+   per config, both streams. Don't trust a single pair of runs.
+4. **lb_compare** on at least one stream (`lb_compare <codestream>`) — directly
+   exercises batch-vs-streaming equality, which is exactly the fallback-vs-
+   planar boundary.
+
+## 7. Encoder mirror (separate work, not this port)
+
+`fdwt_level_sink_fn` (coding_units.cpp) still deinterleaves the FDWT
+horizontal output before quantizing (NEON `vld2q` + fused quantize). The
+symmetric change — FDWT horizontal kernels writing LP/HP planes with plain
+stores, sink quantizing planes directly — is unstarted on every platform.
+There the *input*-side `ld2` of the natural row is the irreducible half.

--- a/source/core/coding/coding_units.cpp
+++ b/source/core/coding/coding_units.cpp
@@ -229,7 +229,7 @@ static void idwt_level_src_fn(void *ctx, int32_t abs_row, sprec_t *out) {
     return;
   }
 
-  // ── DWT_HORZ: all rows are LP-style — interleave LL+H then horizontal IDWT ─
+  // ── DWT_HORZ: all rows are LP-style — horizontal IDWT from LL+H planes ────
   // For HORZ levels, there is no vertical split: abs_row maps 1:1 to subband rows.
   if (c->dir == DWT_HORZ) {
     const int32_t sub_idx = abs_row - c->v0;  // direct row index (no /2)
@@ -252,47 +252,11 @@ static void idwt_level_src_fn(void *ctx, int32_t abs_row, sprec_t *out) {
       memset(out, 0, sizeof(sprec_t) * static_cast<size_t>(width));
       return;
     }
-    // Fall through to shared interleave + horizontal IDWT code below.
-    // Interleave: LP at u0%2, HP at 1-u0%2.
-    const int32_t u_off = c->u0 & 1;
-    const int32_t min_w = std::min(c->lp_width, c->hp_width);
-    if (c->use_i32) {
-      // int32 data stored in sprec_t (float) buffers — use int32 assignment
-      // to avoid strict-aliasing UB from float-typed loads/stores.
-      int32_t *out_i       = reinterpret_cast<int32_t *>(out);
-      const int32_t *lp_i  = reinterpret_cast<const int32_t *>(lp_ptr);
-      const int32_t *hp_i  = reinterpret_cast<const int32_t *>(hp_ptr);
-      if (u_off == 0) {
-        for (int32_t j = 0; j < c->lp_width; ++j) out_i[2 * j] = lp_i[j];
-        for (int32_t j = 0; j < c->hp_width; ++j) out_i[2 * j + 1] = hp_i[j];
-      } else {
-        for (int32_t j = 0; j < c->hp_width; ++j) out_i[2 * j] = hp_i[j];
-        for (int32_t j = 0; j < c->lp_width; ++j) out_i[2 * j + 1] = lp_i[j];
-      }
-    } else {
-      if (u_off == 0) {
-        for (int32_t j = 0; j < c->lp_width; ++j) out[2 * j] = lp_ptr[j];
-        for (int32_t j = 0; j < c->hp_width; ++j) out[2 * j + 1] = hp_ptr[j];
-      } else {
-        for (int32_t j = 0; j < c->hp_width; ++j) out[2 * j] = hp_ptr[j];
-        for (int32_t j = 0; j < c->lp_width; ++j) out[2 * j + 1] = lp_ptr[j];
-      }
-    }
-    (void)min_w;  // suppress unused-variable warning (used in BIDIR path below)
-    if (width == 1) {
-      if ((c->u0 % 2 != 0) && (c->transformation == 1)) {
-        if (c->use_i32)
-          reinterpret_cast<int32_t *>(out)[0] >>= 1;
-        else
-          out[0] /= 2.0f;
-      }
-      return;
-    }
-    if (c->use_i32)
-      idwt_1d_row_inplace_i32(reinterpret_cast<int32_t *>(out), c->h_pse_left, c->h_pse_right, c->u0, c->u1);
-    else
-      idwt_1d_row_inplace_range(out, c->h_pse_left, c->h_pse_right, c->u0, c->u1, c->transformation,
-                                c->col_lo, c->col_hi);
+    // Horizontal synthesis straight from the planar subband rows (planar
+    // kernel where available, interleave + in-place kernels otherwise).
+    idwt_1d_row_from_planar(out, lp_ptr, hp_ptr, c->lp_width, c->hp_width, c->u0, c->u1,
+                            c->transformation, c->use_i32, c->h_pse_left, c->h_pse_right, c->col_lo,
+                            c->col_hi);
     return;
   }
 
@@ -339,225 +303,11 @@ static void idwt_level_src_fn(void *ctx, int32_t abs_row, sprec_t *out) {
     }
   }
 
-  // Interleave: LP always at u0%2 column-offset, HP at 1-u0%2.
-  const int32_t u_off = c->u0 & 1;
-  const int32_t min_w = std::min(c->lp_width, c->hp_width);
-#if defined(OPENHTJ2K_TRY_AVX2) && defined(__AVX2__)
-  if (c->use_i32) {
-    // AVX2 int32 interleave — avoids strict-aliasing UB from float-typed
-    // SIMD on int32_t data.  Same algorithm as the float path below.
-    const int32_t *a_ptr = reinterpret_cast<const int32_t *>((u_off == 0) ? lp_ptr : hp_ptr);
-    const int32_t *b_ptr = reinterpret_cast<const int32_t *>((u_off == 0) ? hp_ptr : lp_ptr);
-    int32_t *out_i       = reinterpret_cast<int32_t *>(out);
-    int32_t i            = 0;
-    for (; i + 8 <= min_w; i += 8) {
-      __m256i va = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(a_ptr + i));
-      __m256i vb = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(b_ptr + i));
-      __m256i lo = _mm256_unpacklo_epi32(va, vb);
-      __m256i hi = _mm256_unpackhi_epi32(va, vb);
-      __m256i r0 = _mm256_permute2x128_si256(lo, hi, 0x20);
-      __m256i r1 = _mm256_permute2x128_si256(lo, hi, 0x31);
-      _mm256_storeu_si256(reinterpret_cast<__m256i *>(out_i + 2 * i), r0);
-      _mm256_storeu_si256(reinterpret_cast<__m256i *>(out_i + 2 * i + 8), r1);
-    }
-    const int32_t *lp_i = reinterpret_cast<const int32_t *>(lp_ptr);
-    const int32_t *hp_i = reinterpret_cast<const int32_t *>(hp_ptr);
-    if (u_off == 0) {
-      for (int32_t j = i; j < c->lp_width; ++j) out_i[2 * j] = lp_i[j];
-      for (int32_t j = i; j < c->hp_width; ++j) out_i[2 * j + 1] = hp_i[j];
-    } else {
-      for (int32_t j = i; j < c->hp_width; ++j) out_i[2 * j] = hp_i[j];
-      for (int32_t j = i; j < c->lp_width; ++j) out_i[2 * j + 1] = lp_i[j];
-    }
-  } else {
-    // AVX2: process 8 LP + 8 HP → 16 interleaved floats per iteration.
-    // _mm256_unpacklo/hi_ps interleave lanes, permute2f128 reorders 128-bit halves.
-    const sprec_t *a_ptr = (u_off == 0) ? lp_ptr : hp_ptr;  // → even slots
-    const sprec_t *b_ptr = (u_off == 0) ? hp_ptr : lp_ptr;  // → odd slots
-    int32_t i            = 0;
-    for (; i + 8 <= min_w; i += 8) {
-      __m256 va = _mm256_loadu_ps(a_ptr + i);
-      __m256 vb = _mm256_loadu_ps(b_ptr + i);
-      __m256 lo = _mm256_unpacklo_ps(va, vb);            // a0,b0,a1,b1, a4,b4,a5,b5
-      __m256 hi = _mm256_unpackhi_ps(va, vb);            // a2,b2,a3,b3, a6,b6,a7,b7
-      __m256 r0 = _mm256_permute2f128_ps(lo, hi, 0x20);  // a0..b3
-      __m256 r1 = _mm256_permute2f128_ps(lo, hi, 0x31);  // a4..b7
-      _mm256_storeu_ps(out + 2 * i, r0);
-      _mm256_storeu_ps(out + 2 * i + 8, r1);
-    }
-    // Two independent scalar tails starting from i (independent loop variables).
-    if (u_off == 0) {
-      for (int32_t j = i; j < c->lp_width; ++j) out[2 * j] = lp_ptr[j];
-      for (int32_t j = i; j < c->hp_width; ++j) out[2 * j + 1] = hp_ptr[j];
-    } else {
-      for (int32_t j = i; j < c->hp_width; ++j) out[2 * j] = hp_ptr[j];
-      for (int32_t j = i; j < c->lp_width; ++j) out[2 * j + 1] = lp_ptr[j];
-    }
-  }
-#elif defined(OPENHTJ2K_ENABLE_WASM_SIMD)
-  {
-    // WASM SIMD: wasm_v128_load / wasm_i8x16_shuffle / wasm_v128_store are
-    // type-agnostic (operate on v128_t), so the SIMD loop is shared.  Only
-    // the scalar tail needs separate int32 / float assignment.
-    const sprec_t *a_ptr = (u_off == 0) ? lp_ptr : hp_ptr;
-    const sprec_t *b_ptr = (u_off == 0) ? hp_ptr : lp_ptr;
-    int32_t i            = 0;
-    for (; i + 4 <= min_w; i += 4) {
-      v128_t va = wasm_v128_load(a_ptr + i);
-      v128_t vb = wasm_v128_load(b_ptr + i);
-      v128_t lo = wasm_i8x16_shuffle(va, vb, 0, 1, 2, 3, 16, 17, 18, 19, 4, 5, 6, 7, 20, 21, 22, 23);
-      v128_t hi = wasm_i8x16_shuffle(va, vb, 8, 9, 10, 11, 24, 25, 26, 27, 12, 13, 14, 15, 28, 29, 30, 31);
-      wasm_v128_store(out + 2 * i, lo);
-      wasm_v128_store(out + 2 * i + 4, hi);
-    }
-    if (c->use_i32) {
-      int32_t *out_i       = reinterpret_cast<int32_t *>(out);
-      const int32_t *lp_i  = reinterpret_cast<const int32_t *>(lp_ptr);
-      const int32_t *hp_i  = reinterpret_cast<const int32_t *>(hp_ptr);
-      if (u_off == 0) {
-        for (int32_t j = i; j < c->lp_width; ++j) out_i[2 * j] = lp_i[j];
-        for (int32_t j = i; j < c->hp_width; ++j) out_i[2 * j + 1] = hp_i[j];
-      } else {
-        for (int32_t j = i; j < c->hp_width; ++j) out_i[2 * j] = hp_i[j];
-        for (int32_t j = i; j < c->lp_width; ++j) out_i[2 * j + 1] = lp_i[j];
-      }
-    } else {
-      if (u_off == 0) {
-        for (int32_t j = i; j < c->lp_width; ++j) out[2 * j] = lp_ptr[j];
-        for (int32_t j = i; j < c->hp_width; ++j) out[2 * j + 1] = hp_ptr[j];
-      } else {
-        for (int32_t j = i; j < c->hp_width; ++j) out[2 * j] = hp_ptr[j];
-        for (int32_t j = i; j < c->lp_width; ++j) out[2 * j + 1] = lp_ptr[j];
-      }
-    }
-  }
-#elif defined(OPENHTJ2K_ENABLE_ARM_NEON)
-  if (c->use_i32) {
-    // NEON int32 interleave — avoids strict-aliasing UB from float-typed
-    // vzipq_f32 on int32_t data.  Same structure as the float path below.
-    const int32_t *a_ptr = reinterpret_cast<const int32_t *>((u_off == 0) ? lp_ptr : hp_ptr);
-    const int32_t *b_ptr = reinterpret_cast<const int32_t *>((u_off == 0) ? hp_ptr : lp_ptr);
-    int32_t *out_i       = reinterpret_cast<int32_t *>(out);
-    int32_t i            = 0;
-    for (; i + 16 <= min_w; i += 16) {
-      int32x4x2_t z0 = vzipq_s32(vld1q_s32(a_ptr + i), vld1q_s32(b_ptr + i));
-      int32x4x2_t z1 = vzipq_s32(vld1q_s32(a_ptr + i + 4), vld1q_s32(b_ptr + i + 4));
-      int32x4x2_t z2 = vzipq_s32(vld1q_s32(a_ptr + i + 8), vld1q_s32(b_ptr + i + 8));
-      int32x4x2_t z3 = vzipq_s32(vld1q_s32(a_ptr + i + 12), vld1q_s32(b_ptr + i + 12));
-      vst1q_s32(out_i + 2 * i, z0.val[0]);
-      vst1q_s32(out_i + 2 * i + 4, z0.val[1]);
-      vst1q_s32(out_i + 2 * i + 8, z1.val[0]);
-      vst1q_s32(out_i + 2 * i + 12, z1.val[1]);
-      vst1q_s32(out_i + 2 * i + 16, z2.val[0]);
-      vst1q_s32(out_i + 2 * i + 20, z2.val[1]);
-      vst1q_s32(out_i + 2 * i + 24, z3.val[0]);
-      vst1q_s32(out_i + 2 * i + 28, z3.val[1]);
-    }
-    for (; i + 8 <= min_w; i += 8) {
-      int32x4x2_t z0 = vzipq_s32(vld1q_s32(a_ptr + i), vld1q_s32(b_ptr + i));
-      int32x4x2_t z1 = vzipq_s32(vld1q_s32(a_ptr + i + 4), vld1q_s32(b_ptr + i + 4));
-      vst1q_s32(out_i + 2 * i, z0.val[0]);
-      vst1q_s32(out_i + 2 * i + 4, z0.val[1]);
-      vst1q_s32(out_i + 2 * i + 8, z1.val[0]);
-      vst1q_s32(out_i + 2 * i + 12, z1.val[1]);
-    }
-    for (; i + 4 <= min_w; i += 4) {
-      int32x4x2_t zipped = vzipq_s32(vld1q_s32(a_ptr + i), vld1q_s32(b_ptr + i));
-      vst1q_s32(out_i + 2 * i, zipped.val[0]);
-      vst1q_s32(out_i + 2 * i + 4, zipped.val[1]);
-    }
-    const int32_t *lp_i = reinterpret_cast<const int32_t *>(lp_ptr);
-    const int32_t *hp_i = reinterpret_cast<const int32_t *>(hp_ptr);
-    if (u_off == 0) {
-      for (int32_t j = i; j < c->lp_width; ++j) out_i[2 * j] = lp_i[j];
-      for (int32_t j = i; j < c->hp_width; ++j) out_i[2 * j + 1] = hp_i[j];
-    } else {
-      for (int32_t j = i; j < c->hp_width; ++j) out_i[2 * j] = hp_i[j];
-      for (int32_t j = i; j < c->lp_width; ++j) out_i[2 * j + 1] = lp_i[j];
-    }
-  } else {
-    // NEON: vzipq_f32 interleaves two float32x4 vectors. 4x unrolled to process 16 pairs/iter.
-    const sprec_t *a_ptr = (u_off == 0) ? lp_ptr : hp_ptr;
-    const sprec_t *b_ptr = (u_off == 0) ? hp_ptr : lp_ptr;
-    int32_t i            = 0;
-    for (; i + 16 <= min_w; i += 16) {
-      float32x4x2_t z0 = vzipq_f32(vld1q_f32(a_ptr + i), vld1q_f32(b_ptr + i));
-      float32x4x2_t z1 = vzipq_f32(vld1q_f32(a_ptr + i + 4), vld1q_f32(b_ptr + i + 4));
-      float32x4x2_t z2 = vzipq_f32(vld1q_f32(a_ptr + i + 8), vld1q_f32(b_ptr + i + 8));
-      float32x4x2_t z3 = vzipq_f32(vld1q_f32(a_ptr + i + 12), vld1q_f32(b_ptr + i + 12));
-      vst1q_f32(out + 2 * i, z0.val[0]);
-      vst1q_f32(out + 2 * i + 4, z0.val[1]);
-      vst1q_f32(out + 2 * i + 8, z1.val[0]);
-      vst1q_f32(out + 2 * i + 12, z1.val[1]);
-      vst1q_f32(out + 2 * i + 16, z2.val[0]);
-      vst1q_f32(out + 2 * i + 20, z2.val[1]);
-      vst1q_f32(out + 2 * i + 24, z3.val[0]);
-      vst1q_f32(out + 2 * i + 28, z3.val[1]);
-    }
-    for (; i + 8 <= min_w; i += 8) {
-      float32x4x2_t z0 = vzipq_f32(vld1q_f32(a_ptr + i), vld1q_f32(b_ptr + i));
-      float32x4x2_t z1 = vzipq_f32(vld1q_f32(a_ptr + i + 4), vld1q_f32(b_ptr + i + 4));
-      vst1q_f32(out + 2 * i, z0.val[0]);
-      vst1q_f32(out + 2 * i + 4, z0.val[1]);
-      vst1q_f32(out + 2 * i + 8, z1.val[0]);
-      vst1q_f32(out + 2 * i + 12, z1.val[1]);
-    }
-    for (; i + 4 <= min_w; i += 4) {
-      float32x4x2_t zipped = vzipq_f32(vld1q_f32(a_ptr + i), vld1q_f32(b_ptr + i));
-      vst1q_f32(out + 2 * i, zipped.val[0]);
-      vst1q_f32(out + 2 * i + 4, zipped.val[1]);
-    }
-    if (u_off == 0) {
-      for (int32_t j = i; j < c->lp_width; ++j) out[2 * j] = lp_ptr[j];
-      for (int32_t j = i; j < c->hp_width; ++j) out[2 * j + 1] = hp_ptr[j];
-    } else {
-      for (int32_t j = i; j < c->hp_width; ++j) out[2 * j] = hp_ptr[j];
-      for (int32_t j = i; j < c->lp_width; ++j) out[2 * j + 1] = lp_ptr[j];
-    }
-  }
-#else
-  if (c->use_i32) {
-    int32_t *out_i       = reinterpret_cast<int32_t *>(out);
-    const int32_t *lp_i  = reinterpret_cast<const int32_t *>(lp_ptr);
-    const int32_t *hp_i  = reinterpret_cast<const int32_t *>(hp_ptr);
-    if (u_off == 0) {
-      for (int32_t i = 0; i < c->lp_width; ++i) out_i[2 * i] = lp_i[i];
-      for (int32_t i = 0; i < c->hp_width; ++i) out_i[2 * i + 1] = hp_i[i];
-    } else {
-      for (int32_t i = 0; i < c->hp_width; ++i) out_i[2 * i] = hp_i[i];
-      for (int32_t i = 0; i < c->lp_width; ++i) out_i[2 * i + 1] = lp_i[i];
-    }
-  } else {
-    if (u_off == 0) {
-      for (int32_t i = 0; i < c->lp_width; ++i) out[2 * i] = lp_ptr[i];
-      for (int32_t i = 0; i < c->hp_width; ++i) out[2 * i + 1] = hp_ptr[i];
-    } else {
-      for (int32_t i = 0; i < c->hp_width; ++i) out[2 * i] = hp_ptr[i];
-      for (int32_t i = 0; i < c->lp_width; ++i) out[2 * i + 1] = lp_ptr[i];
-    }
-  }
-  (void)min_w;
-#endif
-
-  // In-place horizontal IDWT: the ring buffer slot has IDWT_RING_PSE_LEFT scratch floats
-  // before out[0], so we can fill PSE directly into out[-left..-1] and out[width..width+right-1]
-  // then filter in-place — no ext_buf copy needed.
-  const int32_t width = c->u1 - c->u0;
-  if (width <= 0) return;
-  if (width == 1) {
-    if ((c->u0 % 2 != 0) && (c->transformation == 1)) {
-      if (c->use_i32)
-        reinterpret_cast<int32_t *>(out)[0] >>= 1;
-      else
-        out[0] /= 2.0f;
-    }
-    return;
-  }
-  if (c->use_i32)
-    idwt_1d_row_inplace_i32(reinterpret_cast<int32_t *>(out), c->h_pse_left, c->h_pse_right, c->u0, c->u1);
-  else
-    idwt_1d_row_inplace_range(out, c->h_pse_left, c->h_pse_right, c->u0, c->u1, c->transformation, c->col_lo,
-                              c->col_hi);
+  // Horizontal synthesis straight from the planar subband rows (planar
+  // kernel where available, interleave + in-place kernels otherwise).
+  idwt_1d_row_from_planar(out, lp_ptr, hp_ptr, c->lp_width, c->hp_width, c->u0, c->u1,
+                          c->transformation, c->use_i32, c->h_pse_left, c->h_pse_right, c->col_lo,
+                          c->col_hi);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/source/core/transform/dwt.hpp
+++ b/source/core/transform/dwt.hpp
@@ -319,6 +319,17 @@ void fdwt_rev_ver_lp_step_i32_avx512(int32_t n, const int32_t *prev, const int32
 void idwt_1d_filtr_rev53_fixed_neon(sprec_t *X, int32_t left, int32_t u_i0, int32_t u_i1);
 void idwt_1d_filtr_irrev97_fixed_neon(sprec_t *X, int32_t left, int32_t u_i0, int32_t u_i1);
 void idwt_1d_filtr_irrev53_fixed_neon(sprec_t *X, int32_t left, int32_t u_i0, int32_t u_i1);
+// Planar-input horizontal synthesis: read the LP plane (E[j] = lp[j]) and HP
+// plane (O[j] = hp[j]) directly and write the synthesised natural-domain row
+// to out[0..u1-u0-1] — no interleave pass, vld1q instead of vld2q.  Same fused
+// lifting pipeline and single-rounded ops as the interleaved kernels, so the
+// output is bit-identical.  Dispatched from idwt_1d_row_from_planar, which
+// guarantees: u0 even, u1/2 - u0/2 >= 12, out with >= IDWT_RING_PSE_LEFT
+// writable floats before index 0 and >= 8 after index u1-u0-1.
+void idwt_1d_filtr_irrev97_planar_neon(sprec_t *out, const sprec_t *lp, const sprec_t *hp, int32_t u0,
+                                       int32_t u1);
+void idwt_1d_filtr_rev53_planar_i32_neon(int32_t *out, const int32_t *lp, const int32_t *hp, int32_t u0,
+                                         int32_t u1);
 void idwt_irrev_ver_sr_fixed_neon(sprec_t *in, int32_t u0, int32_t u1, int32_t v0, int32_t v1,
                                   int32_t stride, sprec_t *pse_scratch, sprec_t **buf_scratch);
 void idwt_rev_ver_sr_fixed_neon(sprec_t *in, int32_t u0, int32_t u1, int32_t v0, int32_t v1,
@@ -414,6 +425,22 @@ void idwt_1d_row_inplace(sprec_t *row, int32_t left, int32_t right,
                          int32_t u0, int32_t u1, uint8_t transformation);
 void idwt_1d_row_inplace_i32(int32_t *row, int32_t left, int32_t right,
                              int32_t u0, int32_t u1);
+
+// Horizontal synthesis of one streaming row from planar LP/HP subband rows.
+// Writes the synthesised natural-domain row to out[0..u1-u0-1].  `out` must be
+// a ring-slot data pointer (IDWT_RING_PSE_LEFT writable floats before index 0,
+// >= SIMD_PADDING after index u1-u0-1) and must not alias lp/hp.  On platforms
+// with a planar kernel (NEON) and a supported geometry the LP/HP planes are
+// lifted directly — no interleave pass; otherwise the planes are interleaved
+// into `out` and the existing in-place kernels run.  Both paths produce
+// bit-identical rows.  For use_i32 the column range is ignored (full-width
+// lifting), matching the historical idwt_1d_row_inplace_i32 behaviour;
+// lp/hp/out are then reinterpret_cast'd int32_t buffers.
+void idwt_1d_row_from_planar(sprec_t *out, const sprec_t *lp, const sprec_t *hp,
+                             int32_t lp_width, int32_t hp_width,
+                             int32_t u0, int32_t u1, uint8_t transformation, bool use_i32,
+                             int32_t h_pse_left, int32_t h_pse_right,
+                             int32_t col_lo, int32_t col_hi);
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Streaming 2D IDWT — produces one output row per call via pull_row().

--- a/source/core/transform/idwt.cpp
+++ b/source/core/transform/idwt.cpp
@@ -992,6 +992,156 @@ void idwt_1d_row_inplace_range(sprec_t *row, const int32_t left, const int32_t r
   }
 }
 
+// Interleave two planar subband rows into out: plane `a` lands at even offsets,
+// plane `b` at odd offsets (the caller resolves u0-parity by choosing which of
+// LP/HP is `a`).  a_width/b_width may differ by one (odd row width).
+static void interleave_row_planes(sprec_t *out, const sprec_t *a_ptr, const sprec_t *b_ptr,
+                                  const int32_t a_width, const int32_t b_width, const bool use_i32) {
+  [[maybe_unused]] const int32_t min_w = a_width < b_width ? a_width : b_width;
+  int32_t i                            = 0;
+#if defined(OPENHTJ2K_ENABLE_AVX2)
+  if (use_i32) {
+    // AVX2 int32 interleave — avoids strict-aliasing UB from float-typed
+    // SIMD on int32_t data.  Same algorithm as the float path below.
+    const int32_t *a_i = reinterpret_cast<const int32_t *>(a_ptr);
+    const int32_t *b_i = reinterpret_cast<const int32_t *>(b_ptr);
+    int32_t *out_i     = reinterpret_cast<int32_t *>(out);
+    for (; i + 8 <= min_w; i += 8) {
+      __m256i va = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(a_i + i));
+      __m256i vb = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(b_i + i));
+      __m256i lo = _mm256_unpacklo_epi32(va, vb);
+      __m256i hi = _mm256_unpackhi_epi32(va, vb);
+      __m256i r0 = _mm256_permute2x128_si256(lo, hi, 0x20);
+      __m256i r1 = _mm256_permute2x128_si256(lo, hi, 0x31);
+      _mm256_storeu_si256(reinterpret_cast<__m256i *>(out_i + 2 * i), r0);
+      _mm256_storeu_si256(reinterpret_cast<__m256i *>(out_i + 2 * i + 8), r1);
+    }
+  } else {
+    // AVX2: process 8 even + 8 odd → 16 interleaved floats per iteration.
+    for (; i + 8 <= min_w; i += 8) {
+      __m256 va = _mm256_loadu_ps(a_ptr + i);
+      __m256 vb = _mm256_loadu_ps(b_ptr + i);
+      __m256 lo = _mm256_unpacklo_ps(va, vb);            // a0,b0,a1,b1, a4,b4,a5,b5
+      __m256 hi = _mm256_unpackhi_ps(va, vb);            // a2,b2,a3,b3, a6,b6,a7,b7
+      __m256 r0 = _mm256_permute2f128_ps(lo, hi, 0x20);  // a0..b3
+      __m256 r1 = _mm256_permute2f128_ps(lo, hi, 0x31);  // a4..b7
+      _mm256_storeu_ps(out + 2 * i, r0);
+      _mm256_storeu_ps(out + 2 * i + 8, r1);
+    }
+  }
+#elif defined(OPENHTJ2K_ENABLE_WASM_SIMD)
+  // WASM SIMD: the byte shuffle is type-agnostic, so the loop is shared
+  // between the int32 and float layouts.
+  for (; i + 4 <= min_w; i += 4) {
+    v128_t va = wasm_v128_load(a_ptr + i);
+    v128_t vb = wasm_v128_load(b_ptr + i);
+    v128_t lo = wasm_i8x16_shuffle(va, vb, 0, 1, 2, 3, 16, 17, 18, 19, 4, 5, 6, 7, 20, 21, 22, 23);
+    v128_t hi = wasm_i8x16_shuffle(va, vb, 8, 9, 10, 11, 24, 25, 26, 27, 12, 13, 14, 15, 28, 29, 30, 31);
+    wasm_v128_store(out + 2 * i, lo);
+    wasm_v128_store(out + 2 * i + 4, hi);
+  }
+#elif defined(OPENHTJ2K_ENABLE_ARM_NEON)
+  if (use_i32) {
+    // NEON int32 interleave — avoids strict-aliasing UB from float-typed
+    // vzipq_f32 on int32_t data.  Same structure as the float path below.
+    const int32_t *a_i = reinterpret_cast<const int32_t *>(a_ptr);
+    const int32_t *b_i = reinterpret_cast<const int32_t *>(b_ptr);
+    int32_t *out_i     = reinterpret_cast<int32_t *>(out);
+    for (; i + 8 <= min_w; i += 8) {
+      int32x4x2_t z0 = vzipq_s32(vld1q_s32(a_i + i), vld1q_s32(b_i + i));
+      int32x4x2_t z1 = vzipq_s32(vld1q_s32(a_i + i + 4), vld1q_s32(b_i + i + 4));
+      vst1q_s32(out_i + 2 * i, z0.val[0]);
+      vst1q_s32(out_i + 2 * i + 4, z0.val[1]);
+      vst1q_s32(out_i + 2 * i + 8, z1.val[0]);
+      vst1q_s32(out_i + 2 * i + 12, z1.val[1]);
+    }
+    for (; i + 4 <= min_w; i += 4) {
+      int32x4x2_t z = vzipq_s32(vld1q_s32(a_i + i), vld1q_s32(b_i + i));
+      vst1q_s32(out_i + 2 * i, z.val[0]);
+      vst1q_s32(out_i + 2 * i + 4, z.val[1]);
+    }
+  } else {
+    for (; i + 8 <= min_w; i += 8) {
+      float32x4x2_t z0 = vzipq_f32(vld1q_f32(a_ptr + i), vld1q_f32(b_ptr + i));
+      float32x4x2_t z1 = vzipq_f32(vld1q_f32(a_ptr + i + 4), vld1q_f32(b_ptr + i + 4));
+      vst1q_f32(out + 2 * i, z0.val[0]);
+      vst1q_f32(out + 2 * i + 4, z0.val[1]);
+      vst1q_f32(out + 2 * i + 8, z1.val[0]);
+      vst1q_f32(out + 2 * i + 12, z1.val[1]);
+    }
+    for (; i + 4 <= min_w; i += 4) {
+      float32x4x2_t z = vzipq_f32(vld1q_f32(a_ptr + i), vld1q_f32(b_ptr + i));
+      vst1q_f32(out + 2 * i, z.val[0]);
+      vst1q_f32(out + 2 * i + 4, z.val[1]);
+    }
+  }
+#endif
+  // Scalar tail (and the whole row on scalar builds).
+  if (use_i32) {
+    const int32_t *a_i = reinterpret_cast<const int32_t *>(a_ptr);
+    const int32_t *b_i = reinterpret_cast<const int32_t *>(b_ptr);
+    int32_t *out_i     = reinterpret_cast<int32_t *>(out);
+    for (int32_t k = i; k < a_width; ++k) out_i[2 * k] = a_i[k];
+    for (int32_t k = i; k < b_width; ++k) out_i[2 * k + 1] = b_i[k];
+  } else {
+    for (int32_t k = i; k < a_width; ++k) out[2 * k] = a_ptr[k];
+    for (int32_t k = i; k < b_width; ++k) out[2 * k + 1] = b_ptr[k];
+  }
+}
+
+void idwt_1d_row_from_planar(sprec_t *out, const sprec_t *lp, const sprec_t *hp,
+                             const int32_t lp_width, const int32_t hp_width,
+                             const int32_t u0, const int32_t u1, const uint8_t transformation,
+                             const bool use_i32, const int32_t h_pse_left, const int32_t h_pse_right,
+                             const int32_t col_lo, const int32_t col_hi) {
+  const int32_t width = u1 - u0;
+  if (width <= 0) return;
+  if (width == 1) {
+    // Single-column row: the lone sample is LP for even u0, HP for odd u0;
+    // odd-parity rev 5/3 rows carry a doubled sample.
+    if (use_i32) {
+      const int32_t v = reinterpret_cast<const int32_t *>((u0 & 1) == 0 ? lp : hp)[0];
+      reinterpret_cast<int32_t *>(out)[0] = ((u0 & 1) != 0 && transformation == 1) ? (v >> 1) : v;
+    } else {
+      const sprec_t v = ((u0 & 1) == 0 ? lp : hp)[0];
+      out[0]          = ((u0 & 1) != 0 && transformation == 1) ? v / 2.0f : v;
+    }
+    return;
+  }
+
+#if defined(OPENHTJ2K_ENABLE_ARM_NEON)
+  // Planar fast path: lift straight from the subband planes — no interleave
+  // pass, vld1q instead of vld2q.  Geometry guards: even u0 keeps E[j]=lp[j] /
+  // O[j]=hp[j] aligned; N >= 12 guarantees the kernels' SIMD warmup reads are
+  // in range (short rows go through the fallback's scalar-friendly kernels).
+  const int32_t N = u1 / 2 - u0 / 2;
+  if ((u0 & 1) == 0 && N >= 12) {
+    if (transformation == 1 && use_i32) {
+      // i32 rev 5/3 has no sub-range variant — always full-width (see below).
+      idwt_1d_filtr_rev53_planar_i32_neon(reinterpret_cast<int32_t *>(out),
+                                          reinterpret_cast<const int32_t *>(lp),
+                                          reinterpret_cast<const int32_t *>(hp), u0, u1);
+      return;
+    }
+    if (transformation == 0 && !use_i32 && col_lo <= u0 && col_hi >= u1) {
+      idwt_1d_filtr_irrev97_planar_neon(out, lp, hp, u0, u1);
+      return;
+    }
+  }
+#endif
+
+  // Fallback: interleave into the ring slot (LP at u0%2, HP at 1-u0%2), then
+  // the existing in-place kernels — identical to the historical path.
+  if ((u0 & 1) == 0)
+    interleave_row_planes(out, lp, hp, lp_width, hp_width, use_i32);
+  else
+    interleave_row_planes(out, hp, lp, hp_width, lp_width, use_i32);
+  if (use_i32)
+    idwt_1d_row_inplace_i32(reinterpret_cast<int32_t *>(out), h_pse_left, h_pse_right, u0, u1);
+  else
+    idwt_1d_row_inplace_range(out, h_pse_left, h_pse_right, u0, u1, transformation, col_lo, col_hi);
+}
+
 // =============================================================================
 // Streaming 2D IDWT — idwt_2d_state
 // =============================================================================

--- a/source/core/transform/idwt_neon.cpp
+++ b/source/core/transform/idwt_neon.cpp
@@ -735,6 +735,144 @@ void idwt_1d_filtr_rev53_i32_neon(int32_t *X, const int32_t left, const int32_t 
   }
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Planar-input horizontal synthesis — the LP and HP subband rows are read
+// directly (E[j] = lp[j], O[j] = hp[j]) and the synthesised natural-domain row
+// is written to out[].  Same fused pipelines as the interleaved kernels above,
+// but every vld2q on the input side becomes a vld1q per plane and the caller's
+// interleave pass disappears.  Boundary taps outside the planes use WSSE
+// mirroring: positions u0-k and u0+k have equal parity, so each plane extends
+// within itself; PSEo() yields the mirrored in-range position, whose half is
+// the plane index.  These mirrored reads return exactly the values the
+// in-place kernels found in their PSE-filled margins, and every lifting stage
+// is the same single-rounded op on the same inputs — output is bit-identical.
+//
+// Contract (enforced by idwt_1d_row_from_planar): u0 even, N = u1/2 - u0/2
+// >= 12, lp has ceil(u1/2) - u0/2 valid samples, hp has N, out has >= 2
+// writable floats before index 0 and >= 8 after index u1-u0-1.
+// ─────────────────────────────────────────────────────────────────────────────
+
+OPENHTJ2K_MSVC_ARM64_NOINLINE void idwt_1d_filtr_irrev97_planar_neon(sprec_t *out, const sprec_t *lp,
+                                                                     const sprec_t *hp,
+                                                                     const int32_t u0,
+                                                                     const int32_t u1) {
+  const int32_t N = u1 / 2 - u0 / 2;
+  // Mirrored raw-plane accessors (used only for warmup/drain boundary taps).
+  auto E = [&](int32_t j) -> float { return lp[PSEo(u0 + 2 * j, u0, u1) >> 1]; };
+  auto O = [&](int32_t j) -> float { return hp[PSEo(u0 + 2 * j + 1, u0, u1) >> 1]; };
+
+  const float32x4_t vA = vdupq_n_f32(fA), vB = vdupq_n_f32(fB);
+  const float32x4_t vC = vdupq_n_f32(fC), vD = vdupq_n_f32(fD);
+
+  // Warmup: j = -1 scalars, then S1 of blocks 0 and 1, S2/S3 of block 0.
+  const float om1  = O(-1);
+  const float s1m1 = std::fmaf(-fD, O(-2) + om1, E(-1));  // S1[-1]
+  float32x4_t O_b0 = vld1q_f32(hp);
+  float32x4_t S1_b0 =
+      vfmsq_f32(vld1q_f32(lp), vaddq_f32(vextq_f32(vdupq_n_f32(om1), O_b0, 3), O_b0), vD);
+  const float s2m1 = std::fmaf(-fC, s1m1 + vgetq_lane_f32(S1_b0, 0), om1);  // S2[-1]
+  out[-2]          = s1m1;                                                  // final E[-1]
+  out[-1]          = s2m1;                                                  // final O[-1]
+
+  float32x4_t O_b1 = vld1q_f32(hp + 4);
+  float32x4_t S1_b1 =
+      vfmsq_f32(vld1q_f32(lp + 4), vaddq_f32(vextq_f32(O_b0, O_b1, 3), O_b1), vD);
+  float32x4_t S2_b0 = vfmsq_f32(O_b0, vaddq_f32(S1_b0, vextq_f32(S1_b0, S1_b1, 1)), vC);
+  float32x4_t S3_b0 =
+      vfmsq_f32(S1_b0, vaddq_f32(vextq_f32(vdupq_n_f32(s2m1), S2_b0, 3), S2_b0), vB);
+
+  // Steady state: iteration n loads input block n (j = 4n..4n+3) with one
+  // vld1q per plane and emits finished block n-2 with one vst2q.  The bound
+  // is 4n+3 <= N-1 (vs N+1 for the in-place kernel) because the planes have
+  // no PSE-filled margins to read past — the drain covers the rest scalar.
+  float32x4_t O_nm1 = O_b1, S1_nm1 = S1_b1, S2_nm2 = S2_b0, S3_nm2 = S3_b0;
+  int32_t n = 2;
+  for (; 4 * n + 3 <= N - 1; ++n) {
+    float32x4_t O_n  = vld1q_f32(hp + 4 * n);
+    float32x4_t S1_n = vfmsq_f32(vld1q_f32(lp + 4 * n), vaddq_f32(vextq_f32(O_nm1, O_n, 3), O_n), vD);
+    float32x4_t S2_nm1 = vfmsq_f32(O_nm1, vaddq_f32(S1_nm1, vextq_f32(S1_nm1, S1_n, 1)), vC);
+    float32x4_t S3_nm1 =
+        vfmsq_f32(S1_nm1, vaddq_f32(vextq_f32(S2_nm2, S2_nm1, 3), S2_nm1), vB);
+    float32x4x2_t o;
+    o.val[0] = S3_nm2;
+    o.val[1] = vfmsq_f32(S2_nm2, vaddq_f32(S3_nm2, vextq_f32(S3_nm2, S3_nm1, 1)), vA);
+    vst2q_f32(out + 8 * (n - 2), o);
+    O_nm1  = O_n;
+    S1_nm1 = S1_n;
+    S2_nm2 = S2_nm1;
+    S3_nm2 = S3_nm1;
+  }
+
+  // Drain: scalar finish for blocks n-2, n-1 (still in registers) and the
+  // ragged tail.  Loop exit bounds m = 4n to [N-3, N], so with base = m-8
+  // every stage index j-base fits in 16.  s1t/s2t/s3t[i] hold S1/S2/S3[base+i];
+  // s1t[0..3] are unused (block n-2's S1 was consumed).
+  {
+    const int32_t m    = 4 * n;
+    const int32_t base = m - 8;
+    float s1t[16], s2t[16], s3t[16];
+    vst1q_f32(s1t + 4, S1_nm1);  // S1[m-4..m-1]
+    vst1q_f32(s2t, S2_nm2);      // S2[m-8..m-5]
+    vst1q_f32(s3t, S3_nm2);      // S3[m-8..m-5]
+    for (int32_t j = m; j <= N + 1; ++j)
+      s1t[j - base] = std::fmaf(-fD, O(j - 1) + O(j), E(j));
+    for (int32_t j = m - 4; j <= N; ++j)
+      s2t[j - base] = std::fmaf(-fC, s1t[j - base] + s1t[j - base + 1], O(j));
+    for (int32_t j = m - 4; j <= N; ++j)
+      s3t[j - base] = std::fmaf(-fB, s2t[j - base - 1] + s2t[j - base], s1t[j - base]);
+    // Final row: E[j] = S3[j], O[j] = S4[j]; then O[N] = S2[N], E[N+1] = S1[N+1].
+    for (int32_t j = base; j <= N - 1; ++j) {
+      out[2 * j]     = s3t[j - base];
+      out[2 * j + 1] = std::fmaf(-fA, s3t[j - base] + s3t[j - base + 1], s2t[j - base]);
+    }
+    out[2 * N]       = s3t[N - base];
+    out[2 * N + 1]   = s2t[N - base];
+    out[2 * (N + 1)] = s1t[N + 1 - base];
+  }
+}
+
+void idwt_1d_filtr_rev53_planar_i32_neon(int32_t *out, const int32_t *lp, const int32_t *hp,
+                                         const int32_t u0, const int32_t u1) {
+  const int32_t N = u1 / 2 - u0 / 2;
+  auto E = [&](int32_t j) -> int32_t { return lp[PSEo(u0 + 2 * j, u0, u1) >> 1]; };
+  auto O = [&](int32_t j) -> int32_t { return hp[PSEo(u0 + 2 * j + 1, u0, u1) >> 1]; };
+
+  //   S1[j] = E[j] - ((O[j-1] + O[j] + 2) >> 2)   for j in [0, N]   (undo LP update)
+  //   S2[j] = O[j] + ((S1[j] + S1[j+1]) >> 1)     for j in [0, N)   (undo HP predict)
+  // Integer ops are exact, so this matches idwt_1d_filtr_rev53_i32_neon bit
+  // for bit.  Loop bound j+4 <= N-1 keeps every plane read in range (the
+  // s1_next lookahead reads lp[j+4] / hp[j+4]); the scalar tail mirrors.
+  const int32x4_t vtwo = vdupq_n_s32(2);
+  int32_t j       = 0;
+  int32_t o_carry = O(-1);  // raw O[j-1] entering the current position
+  for (; j + 4 <= N - 1; j += 4) {
+    int32x4_t Ob   = vld1q_s32(hp + j);
+    int32x4_t Ojm1 = vextq_s32(vdupq_n_s32(o_carry), Ob, 3);  // O[j-1..j+2]
+    int32x4_t S1b  = vsubq_s32(vld1q_s32(lp + j),
+                               vshrq_n_s32(vaddq_s32(vaddq_s32(Ojm1, Ob), vtwo), 2));
+    const int32_t o3      = vgetq_lane_s32(Ob, 3);  // raw O[j+3]
+    const int32_t s1_next = lp[j + 4] - ((o3 + hp[j + 4] + 2) >> 2);
+    int32x4_t S1n         = vextq_s32(S1b, vdupq_n_s32(s1_next), 1);  // S1[j+1..j+4]
+    int32x4x2_t o;
+    o.val[0] = S1b;
+    o.val[1] = vaddq_s32(Ob, vshrq_n_s32(vaddq_s32(S1b, S1n), 1));
+    vst2q_s32(out + 2 * j, o);
+    o_carry = o3;
+  }
+  // Scalar tail (at most 5 S1 values: loop exits with N - j <= 4).
+  {
+    int32_t s1t[8];
+    int32_t o_prev = o_carry;
+    for (int32_t t = j; t <= N; ++t) {
+      const int32_t o = O(t);
+      s1t[t - j]      = E(t) - ((o_prev + o + 2) >> 2);
+      o_prev          = o;
+    }
+    for (int32_t t = j; t <= N; ++t) out[2 * t] = s1t[t - j];
+    for (int32_t t = j; t < N; ++t) out[2 * t + 1] = O(t) + ((s1t[t - j] + s1t[t - j + 1]) >> 1);
+  }
+}
+
 void idwt_rev_ver_lp_step_i32_neon(int32_t n, const int32_t *prev, const int32_t *next, int32_t *tgt) {
   const int32x4_t vtwo = vdupq_n_s32(2);
   int32_t i = 0;


### PR DESCRIPTION
## Summary

Follow-up to #405. The streaming horizontal IDWT consumed an interleaved row (LP at even offsets, HP at odd) that `idwt_level_src_fn` assembled from the LP/HP subband rows on every fetch — a full extra pass over the row (~5% of single-thread decode on M3) — and the lifting kernels then paid 2-µop `vld2q` loads to split it apart again. This PR lifts directly from the planar subband rows.

- **New `idwt_1d_row_from_planar` dispatcher** (`idwt.cpp`): synthesises one natural-domain row straight from the LP/HP planes into the ring slot. On NEON with even `u0` and `N >= 12` it runs the new planar kernels; otherwise it interleaves into the slot (code moved verbatim from `coding_units.cpp`) and runs the existing in-place kernels — every platform/geometry keeps a working, bit-identical path. The narrow JPIP column-range path and the i32 full-width behaviour are preserved.
- **New NEON kernels** (`idwt_neon.cpp`): planar variants of the fused 9/7 float pipeline and the fused int32 5/3 pass. One `vld1q` per plane replaces each `vld2q`, and the caller's interleave pass disappears. The synthesis-output `vst2q` remains — it *is* the output signal. Boundary taps mirror within each plane via `PSEo` (WSSE preserves parity, so extension never crosses planes) and return exactly the values the in-place kernels found in their PSE-filled margins.
- `idwt_level_src_fn` shrinks to plane-pointer selection + zero scan + one dispatcher call.

The ring rows still hold natural-domain rows — vertical lifting, the cascade, zero-row tracking, and the batch path are untouched. AVX2/AVX-512/WASM go through the (unchanged-cost) fallback; planar kernels for those ISAs can follow separately.

## Correctness

Every lifting stage keeps the same single-rounded op (`vfmsq`/`std::fmaf`, integer shifts) on the same inputs as the in-place kernels, so output is **bit-identical**:

- Full ctest suite: 407/407 pass (Release), 82/82 (Debug)
- 8K 12-bit lossless + lossy decodes `cmp`-identical against `main`
- AVX2 and WASM branches syntax-verified via cross-target compiles

## Performance

8K 12-bit (`u01_Books_8k_12bit`), M3 Max, single thread, `-iter 30`, interleaved A/B vs `main`:

| | main | this PR | delta |
|---|---|---|---|
| lossy (9/7) | 166.6 ms | 157.7 ms | **−5.5%** |
| lossless (5/3 i32) | 321.4 ms | 313.5 ms | **−2.5%** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)