### PR TITLE
perf(decoder): planar LP/HP horizontal IDWT lifting on AVX2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,14 @@
   kernel keep the interleave + in-place path unchanged. Measured on an 8K
   12-bit image (M3 Max, single thread, 30-iteration mean): lossy decode
   ~5% faster, lossless ~2.5%.
+- The same planar horizontal IDWT lifting on AVX2 (one unaligned load per
+  plane, fused single-pass 9/7 pipeline, interleave-on-store), replacing
+  the interleave pass plus four half-idle in-place lifting passes. The
+  AVX2 kernels also serve AVX-512 hosts; WASM and scalar keep the
+  fallback. Output is bit-identical (conformance suite plus 8K `cmp`
+  against a main-baseline decoder, even and odd image sizes). Measured on
+  an 8K 12-bit image (Ryzen 9 9950X, single thread, 30-iteration mean):
+  lossy decode ~4% faster, lossless ~0.5%.
 
 ## Fixed
 

--- a/docs/planar_idwt_porting.md
+++ b/docs/planar_idwt_porting.md
@@ -1,17 +1,25 @@
 # Porting the planar horizontal IDWT to AVX2 / AVX-512 / WASM
 
-Status as of PR #406 (June 2026): the streaming horizontal IDWT lifts directly
-from the planar LP/HP subband rows **on NEON only** (9/7 float and int32 5/3).
-All other platforms — AVX2, AVX-512, WASM, scalar — go through a bit-identical
-fallback that interleaves into the ring slot and runs the historical in-place
-kernels, at unchanged cost. This document is the map for converting those
-platforms. It assumes no access to the NEON machine; everything needed is in
-the tree.
+Status: the streaming horizontal IDWT lifts directly from the planar LP/HP
+subband rows on **NEON** (PR #406) and **AVX2** (9/7 float and int32 5/3 on
+both).  The AVX2 kernels also serve AVX-512 hosts (`OPENHTJ2K_ENABLE_AVX2` is
+defined there too); a dedicated 16-lane AVX-512 variant (§5.2) and the WASM
+port (§5.3) remain open.  WASM and scalar go through a bit-identical fallback
+that interleaves into the ring slot and runs the historical in-place kernels,
+at unchanged cost.  This document is the map for the remaining platforms.
 
-Measured upside on NEON (8K 12-bit, M3 Max, single thread, 30-iter mean):
-lossy 9/7 **−5.5%**, lossless 5/3 i32 **−2.5%** end-to-end decode. On AVX2 the
-upside is plausibly larger (see §5.1): the current in-place kernels waste half
-their lanes on pass-through elements, which the planar formulation does not.
+Measured upside (8K 12-bit, single thread, 30-iter mean, end-to-end decode):
+
+| Platform | lossy 9/7 | lossless 5/3 i32 |
+|---|---|---|
+| NEON (M3 Max) | −5.5% | −2.5% |
+| AVX2 (Ryzen 9 9950X, AVX-512 host) | −3.8% | −0.5% |
+
+The AVX2 gain is smaller than NEON's despite §5.1's lane-utilisation argument
+because on an AVX-512 host the displaced in-place kernels are the 16-lane
+`_avx512` variants — the 8-lane planar kernel's own time roughly matches
+interleave + in-place; the net win comes from the deleted pass over the row.
+That is also why a dedicated AVX-512 planar variant is a plausible follow-up.
 
 ---
 
@@ -23,7 +31,7 @@ idwt_level_src_fn (coding_units.cpp)          ← selects lp_ptr/hp_ptr, zero sc
         ▼
 idwt_1d_row_from_planar (idwt.cpp)            ← THE dispatcher; the only place
         │                                        that decides planar vs fallback
-        ├─ planar kernel        (NEON today)  ← lp/hp planes → natural row in
+        ├─ planar kernel        (NEON, AVX2)  ← lp/hp planes → natural row in
         │                                        the ring slot; no interleave
         └─ fallback: interleave_row_planes()  ← LP at u0%2, HP at 1-u0%2, then
            + idwt_1d_row_inplace[_range|_i32]    in-place PSE fill + lifting
@@ -37,16 +45,17 @@ zero-row tracking, PSE row copies, `pull_row_ref`, and the whole batch path
 
 The port therefore adds, per platform:
 
-1. Two kernels in `idwt_avx2.cpp` / `idwt_wasm.cpp` (and later `idwt_avx512.cpp`):
+1. Two kernels in `idwt_wasm.cpp` (and later `idwt_avx512.cpp`):
    - `idwt_1d_filtr_irrev97_planar_<isa>(sprec_t *out, const sprec_t *lp, const sprec_t *hp, int32_t u0, int32_t u1)`
    - `idwt_1d_filtr_rev53_planar_i32_<isa>(int32_t *out, const int32_t *lp, const int32_t *hp, int32_t u0, int32_t u1)`
-2. Declarations in the matching `#elif` block of `dwt.hpp`.
+2. Declarations in `dwt.hpp`.  Note the AVX2 planar declarations live in a
+   standalone `#if defined(OPENHTJ2K_ENABLE_AVX2)` block *outside* the
+   AVX-512/NEON/AVX2 `#elif` chain: `OPENHTJ2K_ENABLE_AVX2` is also defined on
+   AVX-512 builds, so the AVX2 planar kernels serve AVX-512 hosts until a
+   dedicated `_avx512` variant exists (the in-place dispatch tables prefer
+   AVX-512; the planar dispatch starts with AVX2 only).
 3. An `#elif` branch in the planar fast path of `idwt_1d_row_from_planar`
-   (idwt.cpp), which today reads `#if defined(OPENHTJ2K_ENABLE_ARM_NEON)`.
-   Note `OPENHTJ2K_ENABLE_AVX2` is also defined on AVX-512 builds, so an AVX2
-   planar kernel automatically serves AVX-512 hosts until a dedicated
-   `_avx512` variant exists (the in-place dispatch tables prefer AVX-512; the
-   planar dispatch can start with AVX2 only).
+   (idwt.cpp), after the existing NEON and AVX2 branches.
 
 Nothing else changes. `coding_units.cpp` already calls the dispatcher.
 
@@ -58,7 +67,7 @@ falls back (and must keep falling back):
 | Guard | Why |
 |---|---|
 | `(u0 & 1) == 0` | keeps `E[j] = lp[j]`, `O[j] = hp[j]` index-aligned; odd u0 shifts the LP plane by one and is rare (odd tile/precinct origins) |
-| `N = u1/2 - u0/2 >= 12` | the kernels' SIMD warmup loads blocks j=0..7 unconditionally; short rows go through the fallback's scalar-friendly path |
+| `N = u1/2 - u0/2 >= 12` (NEON) / `>= 16` (AVX2) | the SIMD warmup loads blocks 0/1 unconditionally — j=0..7 at 4 lanes, j=0..15 at 8 lanes; short rows go through the fallback's scalar-friendly path |
 | 9/7 float: `col_lo <= u0 && col_hi >= u1` | narrow JPIP column ranges use the scalar sub-range lifter on the interleaved row; not worth porting |
 | 5/3: `use_i32 == true` | the float-5/3 streaming path is cold (lossless decode is i32); i32 ignores the column range by design, matching `idwt_1d_row_inplace_i32` |
 
@@ -129,8 +138,8 @@ loop: `j + 4 <= N - 1`, because the `s1_next` lookahead reads `lp[j+4]` /
 
 ### 3.4 Bit-exactness mandate
 
-`lbs_*` tests enforce batch == line-based bit-exact, and the dispatcher's
-fallback must equal the planar path. So a planar kernel must reproduce **the
+The `*_lb_*` conformance tests enforce line-based decode correctness, and the
+dispatcher's fallback must equal the planar path. So a planar kernel must reproduce **the
 same single-rounded operation sequence per element as the same platform's
 in-place kernel**:
 
@@ -170,7 +179,7 @@ interleave pass in the caller.
 
 ## 5. Platform notes
 
-### 5.1 AVX2 (do this one first)
+### 5.1 AVX2 (shipped — kernels at the bottom of `idwt_avx2.cpp`; notes kept for the AVX-512 port)
 
 The current in-place AVX2 kernels (`idwt_avx2.cpp`) do **not** deinterleave:
 each pass loads overlapping unaligned vectors over the interleaved row and
@@ -258,9 +267,11 @@ nothing natively, so native ctest only proves you didn't break the others).
 3. **A/B benchmark**: snapshotted `bin/` dirs (baseline = a worktree of main,
    built once), interleaved runs, `-iter 30 -num_threads 1`, ≥ 3 repetitions
    per config, both streams. Don't trust a single pair of runs.
-4. **lb_compare** on at least one stream (`lb_compare <codestream>`) — directly
-   exercises batch-vs-streaming equality, which is exactly the fallback-vs-
-   planar boundary.
+4. **Line-based conformance** (`ctest -R lb`, included in step 1) covers the
+   streaming path the dispatcher serves.  (The standalone `lb_compare` tool
+   and its `lbs_*` batch-vs-streaming tests were removed in 0.19.0 — step 2's
+   whole-image `cmp` against a main-baseline decoder is the replacement check
+   at 8K scale.)
 
 ## 7. Encoder mirror (separate work, not this port)
 

--- a/source/core/transform/dwt.hpp
+++ b/source/core/transform/dwt.hpp
@@ -371,6 +371,22 @@ void idwt_irrev_ver_sr_fixed(sprec_t *in, int32_t u0, int32_t u1, int32_t v0, in
 void idwt_rev_ver_sr_fixed(sprec_t *in, int32_t u0, int32_t u1, int32_t v0, int32_t v1, int32_t stride, sprec_t *pse_scratch, sprec_t **buf_scratch);
 #endif
 
+// Planar-input horizontal synthesis for AVX2 — 8-lane port of the NEON planar
+// kernels (see the NEON declarations above for the full contract).  Declared
+// outside the AVX-512/NEON/AVX2 #elif chain because OPENHTJ2K_ENABLE_AVX2 is
+// also defined on AVX-512 builds, where these kernels serve the planar fast
+// path until a dedicated _avx512 variant exists (the in-place dispatch tables
+// still prefer AVX-512).  Dispatched from idwt_1d_row_from_planar, which
+// guarantees: u0 even, u1/2 - u0/2 >= 16 (the 8-lane warmup loads j = 0..15
+// unconditionally), out with >= IDWT_RING_PSE_LEFT writable floats before
+// index 0 and >= 8 after index u1-u0-1.
+#if defined(OPENHTJ2K_ENABLE_AVX2)
+void idwt_1d_filtr_irrev97_planar_avx2(sprec_t *out, const sprec_t *lp, const sprec_t *hp, int32_t u0,
+                                       int32_t u1);
+void idwt_1d_filtr_rev53_planar_i32_avx2(int32_t *out, const int32_t *lp, const int32_t *hp, int32_t u0,
+                                         int32_t u1);
+#endif
+
 // WASM-SIMD DWT kernels (EMSCRIPTEN builds only, no NEON dependency).
 #if defined(OPENHTJ2K_ENABLE_WASM_SIMD)
 // horizontal

--- a/source/core/transform/idwt.cpp
+++ b/source/core/transform/idwt.cpp
@@ -1128,6 +1128,25 @@ void idwt_1d_row_from_planar(sprec_t *out, const sprec_t *lp, const sprec_t *hp,
       return;
     }
   }
+#elif defined(OPENHTJ2K_ENABLE_AVX2)
+  // Planar fast path, 8-lane AVX2 (also serves AVX-512 hosts, where
+  // OPENHTJ2K_ENABLE_AVX2 is defined too; the in-place fallback below keeps
+  // its AVX-512 dispatch).  Same geometry guards as NEON except N >= 16: the
+  // 8-lane warmup loads blocks 0/1 (j = 0..15) unconditionally.
+  const int32_t N = u1 / 2 - u0 / 2;
+  if ((u0 & 1) == 0 && N >= 16) {
+    if (transformation == 1 && use_i32) {
+      // i32 rev 5/3 has no sub-range variant — always full-width (see below).
+      idwt_1d_filtr_rev53_planar_i32_avx2(reinterpret_cast<int32_t *>(out),
+                                          reinterpret_cast<const int32_t *>(lp),
+                                          reinterpret_cast<const int32_t *>(hp), u0, u1);
+      return;
+    }
+    if (transformation == 0 && !use_i32 && col_lo <= u0 && col_hi >= u1) {
+      idwt_1d_filtr_irrev97_planar_avx2(out, lp, hp, u0, u1);
+      return;
+    }
+  }
 #endif
 
   // Fallback: interleave into the ring slot (LP at u0%2, HP at 1-u0%2), then

--- a/source/core/transform/idwt_avx2.cpp
+++ b/source/core/transform/idwt_avx2.cpp
@@ -552,6 +552,179 @@ void idwt_1d_filtr_rev53_i32_avx2(int32_t *X, const int32_t left, const int32_t 
   }
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Planar-input horizontal synthesis — the LP and HP subband rows are read
+// directly (E[j] = lp[j], O[j] = hp[j]) and the synthesised natural-domain row
+// is written to out[].  8-lane port of the NEON planar kernels
+// (idwt_neon.cpp): one plain load per plane replaces the in-place kernels'
+// four overlapping passes over the interleaved row (which waste half their
+// lanes on pass-through elements), and the caller's interleave pass
+// disappears.  Boundary taps outside the planes use WSSE mirroring: positions
+// u0-k and u0+k have equal parity, so each plane extends within itself;
+// PSEo() yields the mirrored in-range position, whose half is the plane
+// index.  Every lifting stage is the same single-rounded op on the same
+// inputs as the in-place AVX2 kernels (_mm256_fnmadd_ps(sum, coeff, x) ==
+// fmaf(-coeff, sum, x)) — output is bit-identical.
+//
+// Contract (enforced by idwt_1d_row_from_planar): u0 even, N = u1/2 - u0/2
+// >= 16 (the 8-lane warmup loads blocks 0/1, j = 0..15, unconditionally),
+// lp has ceil(u1/2) - u0/2 valid samples, hp has N, out has >= 2 writable
+// floats before index 0 and >= 8 after index u1-u0-1.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Cross-element shifts with carry-in (the AVX2 equivalent of vextq_f32).
+// shl1: [a1..a7, b0] — shift left one element, carry-in from next vector b.
+static inline __m256 avx2_shl1_ps(__m256 a, __m256 b) {
+  __m256 t = _mm256_permute2f128_ps(a, b, 0x21);  // [a4..a7, b0..b3]
+  return _mm256_castsi256_ps(_mm256_alignr_epi8(_mm256_castps_si256(t), _mm256_castps_si256(a), 4));
+}
+// shr1: [p7, a0..a6] — shift right one element, carry-in from previous vector p.
+static inline __m256 avx2_shr1_ps(__m256 p, __m256 a) {
+  __m256 t = _mm256_permute2f128_ps(p, a, 0x21);  // [p4..p7, a0..a3]
+  return _mm256_castsi256_ps(_mm256_alignr_epi8(_mm256_castps_si256(a), _mm256_castps_si256(t), 12));
+}
+static inline __m256i avx2_shl1_epi32(__m256i a, __m256i b) {
+  __m256i t = _mm256_permute2x128_si256(a, b, 0x21);
+  return _mm256_alignr_epi8(t, a, 4);
+}
+static inline __m256i avx2_shr1_epi32(__m256i p, __m256i a) {
+  __m256i t = _mm256_permute2x128_si256(p, a, 0x21);
+  return _mm256_alignr_epi8(a, t, 12);
+}
+
+// Interleaved store of one finished block: out[2j+0,2,..] = e, out[2j+1,3,..] = o.
+// Inverse of the deinterleave pattern in interleave_row_planes (idwt.cpp).
+static inline void avx2_store_interleaved_ps(float *dst, __m256 e, __m256 o) {
+  __m256 lo = _mm256_unpacklo_ps(e, o);  // e0,o0,e1,o1, e4,o4,e5,o5
+  __m256 hi = _mm256_unpackhi_ps(e, o);  // e2,o2,e3,o3, e6,o6,e7,o7
+  _mm256_storeu_ps(dst, _mm256_permute2f128_ps(lo, hi, 0x20));
+  _mm256_storeu_ps(dst + 8, _mm256_permute2f128_ps(lo, hi, 0x31));
+}
+
+void idwt_1d_filtr_irrev97_planar_avx2(sprec_t *out, const sprec_t *lp, const sprec_t *hp, const int32_t u0,
+                                       const int32_t u1) {
+  const int32_t N = u1 / 2 - u0 / 2;
+  // Mirrored raw-plane accessors (used only for warmup/drain boundary taps).
+  auto E = [&](int32_t j) -> float { return lp[PSEo(u0 + 2 * j, u0, u1) >> 1]; };
+  auto O = [&](int32_t j) -> float { return hp[PSEo(u0 + 2 * j + 1, u0, u1) >> 1]; };
+
+  const __m256 vA = _mm256_set1_ps(fA), vB = _mm256_set1_ps(fB);
+  const __m256 vC = _mm256_set1_ps(fC), vD = _mm256_set1_ps(fD);
+
+  // Warmup: j = -1 scalars, then S1 of blocks 0 and 1, S2/S3 of block 0.
+  const float om1  = O(-1);
+  const float s1m1 = std::fmaf(-fD, O(-2) + om1, E(-1));  // S1[-1]
+  __m256 O_b0      = _mm256_loadu_ps(hp);
+  __m256 S1_b0     = _mm256_fnmadd_ps(_mm256_add_ps(avx2_shr1_ps(_mm256_set1_ps(om1), O_b0), O_b0), vD,
+                                      _mm256_loadu_ps(lp));
+  const float s2m1 = std::fmaf(-fC, s1m1 + _mm256_cvtss_f32(S1_b0), om1);  // S2[-1]
+  out[-2]          = s1m1;                                                 // final E[-1]
+  out[-1]          = s2m1;                                                 // final O[-1]
+
+  __m256 O_b1 = _mm256_loadu_ps(hp + 8);
+  __m256 S1_b1 =
+      _mm256_fnmadd_ps(_mm256_add_ps(_mm256_loadu_ps(hp + 7), O_b1), vD, _mm256_loadu_ps(lp + 8));
+  __m256 S2_b0 = _mm256_fnmadd_ps(_mm256_add_ps(S1_b0, avx2_shl1_ps(S1_b0, S1_b1)), vC, O_b0);
+  __m256 S3_b0 =
+      _mm256_fnmadd_ps(_mm256_add_ps(avx2_shr1_ps(_mm256_set1_ps(s2m1), S2_b0), S2_b0), vB, S1_b0);
+
+  // Steady state: iteration n loads input block n (j = 8n..8n+7) with one
+  // unaligned load per plane and emits finished block n-2 with one interleaved
+  // store.  Raw O[j-1] is an unaligned reload from hp + 8n - 1 (j-1 >= 0 in
+  // steady state — cheaper than shuffling on x86); the pipeline-internal
+  // shifts use avx2_shl1/shr1.  The bound is 8n+7 <= N-1 because the planes
+  // have no PSE-filled margins to read past — the drain covers the rest scalar.
+  __m256 O_nm1 = O_b1, S1_nm1 = S1_b1, S2_nm2 = S2_b0, S3_nm2 = S3_b0;
+  int32_t n = 2;
+  for (; 8 * n + 7 <= N - 1; ++n) {
+    __m256 O_n    = _mm256_loadu_ps(hp + 8 * n);
+    __m256 S1_n   = _mm256_fnmadd_ps(_mm256_add_ps(_mm256_loadu_ps(hp + 8 * n - 1), O_n), vD,
+                                     _mm256_loadu_ps(lp + 8 * n));
+    __m256 S2_nm1 = _mm256_fnmadd_ps(_mm256_add_ps(S1_nm1, avx2_shl1_ps(S1_nm1, S1_n)), vC, O_nm1);
+    __m256 S3_nm1 = _mm256_fnmadd_ps(_mm256_add_ps(avx2_shr1_ps(S2_nm2, S2_nm1), S2_nm1), vB, S1_nm1);
+    __m256 S4_nm2 = _mm256_fnmadd_ps(_mm256_add_ps(S3_nm2, avx2_shl1_ps(S3_nm2, S3_nm1)), vA, S2_nm2);
+    avx2_store_interleaved_ps(out + 16 * (n - 2), S3_nm2, S4_nm2);
+    O_nm1  = O_n;
+    S1_nm1 = S1_n;
+    S2_nm2 = S2_nm1;
+    S3_nm2 = S3_nm1;
+  }
+
+  // Drain: scalar finish for blocks n-2, n-1 (still in registers) and the
+  // ragged tail.  Loop exit bounds m = 8n to [N-7, N], so with base = m-16
+  // every stage index j-base fits in 32 (max N+1-base = N+1-m+16 <= 24).
+  // s1t/s2t/s3t[i] hold S1/S2/S3[base+i]; s1t[0..7] are unused (block n-2's
+  // S1 was consumed).
+  {
+    const int32_t m    = 8 * n;
+    const int32_t base = m - 16;
+    float s1t[32], s2t[32], s3t[32];
+    _mm256_storeu_ps(s1t + 8, S1_nm1);  // S1[m-8..m-1]
+    _mm256_storeu_ps(s2t, S2_nm2);      // S2[m-16..m-9]
+    _mm256_storeu_ps(s3t, S3_nm2);      // S3[m-16..m-9]
+    for (int32_t j = m; j <= N + 1; ++j) s1t[j - base] = std::fmaf(-fD, O(j - 1) + O(j), E(j));
+    for (int32_t j = m - 8; j <= N; ++j)
+      s2t[j - base] = std::fmaf(-fC, s1t[j - base] + s1t[j - base + 1], O(j));
+    for (int32_t j = m - 8; j <= N; ++j)
+      s3t[j - base] = std::fmaf(-fB, s2t[j - base - 1] + s2t[j - base], s1t[j - base]);
+    // Final row: E[j] = S3[j], O[j] = S4[j]; then O[N] = S2[N], E[N+1] = S1[N+1].
+    for (int32_t j = base; j <= N - 1; ++j) {
+      out[2 * j]     = s3t[j - base];
+      out[2 * j + 1] = std::fmaf(-fA, s3t[j - base] + s3t[j - base + 1], s2t[j - base]);
+    }
+    out[2 * N]       = s3t[N - base];
+    out[2 * N + 1]   = s2t[N - base];
+    out[2 * (N + 1)] = s1t[N + 1 - base];
+  }
+}
+
+void idwt_1d_filtr_rev53_planar_i32_avx2(int32_t *out, const int32_t *lp, const int32_t *hp,
+                                         const int32_t u0, const int32_t u1) {
+  const int32_t N = u1 / 2 - u0 / 2;
+  auto E          = [&](int32_t j) -> int32_t { return lp[PSEo(u0 + 2 * j, u0, u1) >> 1]; };
+  auto O          = [&](int32_t j) -> int32_t { return hp[PSEo(u0 + 2 * j + 1, u0, u1) >> 1]; };
+
+  //   S1[j] = E[j] - ((O[j-1] + O[j] + 2) >> 2)   for j in [0, N]   (undo LP update)
+  //   S2[j] = O[j] + ((S1[j] + S1[j+1]) >> 1)     for j in [0, N)   (undo HP predict)
+  // Integer ops are exact, so this matches idwt_1d_filtr_rev53_i32_avx2 bit
+  // for bit.  Loop bound j+8 <= N-1 keeps every plane read in range (the
+  // s1_next lookahead reads lp[j+8] / hp[j+8]); the scalar tail mirrors.
+  const __m256i vtwo = _mm256_set1_epi32(2);
+  const int32_t o_m1 = O(-1);  // mirrored O[-1] for the first block only
+  int32_t j          = 0;
+  for (; j + 8 <= N - 1; j += 8) {
+    __m256i Ob = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(hp + j));
+    // O[j-1..j+6]: lane 0 is the mirrored O(-1) on the first block; later
+    // blocks reload hp + j - 1 (j >= 8, all in range — cheaper than shuffling).
+    __m256i Ojm1 = (j == 0) ? avx2_shr1_epi32(_mm256_set1_epi32(o_m1), Ob)
+                            : _mm256_loadu_si256(reinterpret_cast<const __m256i *>(hp + j - 1));
+    __m256i S1b =
+        _mm256_sub_epi32(_mm256_loadu_si256(reinterpret_cast<const __m256i *>(lp + j)),
+                         _mm256_srai_epi32(_mm256_add_epi32(_mm256_add_epi32(Ojm1, Ob), vtwo), 2));
+    // S1[j+8] from raw memory (those positions are not yet written this pass)
+    const int32_t s1_next = lp[j + 8] - ((hp[j + 7] + hp[j + 8] + 2) >> 2);
+    __m256i S1n           = avx2_shl1_epi32(S1b, _mm256_set1_epi32(s1_next));  // S1[j+1..j+8]
+    __m256i S2b           = _mm256_add_epi32(Ob, _mm256_srai_epi32(_mm256_add_epi32(S1b, S1n), 1));
+    __m256i lo            = _mm256_unpacklo_epi32(S1b, S2b);
+    __m256i hi            = _mm256_unpackhi_epi32(S1b, S2b);
+    _mm256_storeu_si256(reinterpret_cast<__m256i *>(out + 2 * j), _mm256_permute2x128_si256(lo, hi, 0x20));
+    _mm256_storeu_si256(reinterpret_cast<__m256i *>(out + 2 * j + 8),
+                        _mm256_permute2x128_si256(lo, hi, 0x31));
+  }
+  // Scalar tail (at most 9 S1 values: loop exits with N - j <= 8).
+  {
+    int32_t s1t[12];
+    int32_t o_prev = O(j - 1);
+    for (int32_t t = j; t <= N; ++t) {
+      const int32_t o = O(t);
+      s1t[t - j]      = E(t) - ((o_prev + o + 2) >> 2);
+      o_prev          = o;
+    }
+    for (int32_t t = j; t <= N; ++t) out[2 * t] = s1t[t - j];
+    for (int32_t t = j; t < N; ++t) out[2 * t + 1] = O(t) + ((s1t[t - j] + s1t[t - j + 1]) >> 1);
+  }
+}
+
 void idwt_rev_ver_lp_step_i32_avx2(int32_t n, const int32_t *prev, const int32_t *next, int32_t *tgt) {
   const __m256i vtwo = _mm256_set1_epi32(2);
   int32_t i = 0;


### PR DESCRIPTION
## Summary

Ports the planar horizontal IDWT kernels introduced for NEON in #406 to AVX2. The streaming horizontal synthesis now lifts directly from the planar LP/HP subband rows on x86: one unaligned load per plane feeds a fused single-pass 9/7 lifting pipeline that writes the natural-domain row with an interleave-on-store. This replaces the previous fallback, which first interleaved the planes into the ring slot and then ran four in-place lifting passes that waste half their SIMD lanes on pass-through elements.

- `idwt_1d_filtr_irrev97_planar_avx2` — depth-2 software pipeline over 8-lane blocks. Cross-element shifts of computed vectors use the two-instruction `permute2f128` + `alignr` idiom; raw `O[j-1]` neighbors are unaligned reloads from the HP plane.
- `idwt_1d_filtr_rev53_planar_i32_avx2` — single loop with a scalar `S1[j+8]` lookahead, the 8-lane analogue of the NEON int32 kernel.
- Dispatch guard is `N >= 16` on AVX2 (the 8-lane warmup loads blocks 0/1, j = 0..15, unconditionally); shorter rows keep the bit-identical interleave + in-place fallback. Drain staging arrays are 32 entries (loop exit bound m = 8n ∈ [N-7, N], base = m-16, max stage index 24).
- The AVX2 kernels also serve AVX-512 hosts, where `OPENHTJ2K_ENABLE_AVX2` is defined as well — their declarations sit outside the AVX-512/NEON/AVX2 `#elif` chain in `dwt.hpp`. Vertical lifting and the in-place fallback keep their AVX-512 dispatch; a dedicated 16-lane planar variant remains a possible follow-up (see the updated porting guide).

Also refreshes `docs/planar_idwt_porting.md`: AVX2 marked shipped with measured numbers, and stale references to the `lb_compare` tool / `lbs_*` tests (removed in 0.19.0) replaced with the current `*_lb_*` conformance coverage.

## Bit-exactness

Every lifting stage is the same single-rounded operation per element as the in-place AVX2 kernels (`_mm256_fnmadd_ps(sum, coeff, x)` ≡ `fmaf(-coeff, sum, x)`; integer 5/3 ops are exact). Boundary taps mirror within each plane via `PSEo` on the absolute position, reproducing the values the in-place kernels found in their PSE-filled margins.

Verified:
- Full conformance suite: 407/407 in Release and Debug.
- Whole-image `cmp` against a main-baseline decoder at 8K (u01_Books 12-bit), lossless and lossy (Qfactor=85), at 7680×4320 and an odd-geometry 7679×4319 crop — all four bit-identical.
- `perf` confirms the planar kernels carry the horizontal IDWT in both lossy (12.5% self-time) and lossless (5.2%) decodes, with vertical lifting still on its AVX-512 path.

## Performance

8K 12-bit single-tile, Ryzen 9 9950X (AVX-512 host), `-num_threads 1 -iter 30`, interleaved A/B runs:

| Stream | main | this PR | Δ |
|---|---|---|---|
| lossy 9/7 (3 reps) | 128.9 ms | 124.0 ms | **−3.8%** |
| lossless 5/3 i32 (8 reps) | 331.1 ms | 329.5 ms | **−0.5%** |

The gain is smaller than NEON's (−5.5% / −2.5%) because on an AVX-512 host the displaced in-place kernels are the 16-lane `_avx512` variants; the net win comes mainly from deleting the interleave pass over the row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)