### PR TITLE
perf(decoder): planar LP/HP horizontal IDWT lifting on WASM SIMD

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,15 @@
   against a main-baseline decoder, even and odd image sizes). Measured on
   an 8K 12-bit image (Ryzen 9 9950X, single thread, 30-iteration mean):
   lossy decode ~4% faster, lossless ~0.5%.
+- The same planar horizontal IDWT lifting on WASM SIMD, completing the
+  SIMD platforms (only scalar builds keep the interleave + in-place
+  fallback). The 9/7 kernel matches the in-place WASM rounding
+  (separately-rounded mul+sub — SIMD128 has no FMA), so output stays
+  bit-identical on this platform (verified by whole-image `cmp` against
+  a main-baseline WASM decoder under Node.js at 8K, even and odd image
+  sizes, lossless and lossy). Measured on an 8K 12-bit image (Node 24,
+  Ryzen 9 9950X, single thread, 30-iteration mean): lossy decode ~5.5%
+  faster, lossless unchanged.
 
 ## Fixed
 

--- a/docs/planar_idwt_porting.md
+++ b/docs/planar_idwt_porting.md
@@ -1,12 +1,12 @@
 # Porting the planar horizontal IDWT to AVX2 / AVX-512 / WASM
 
 Status: the streaming horizontal IDWT lifts directly from the planar LP/HP
-subband rows on **NEON** (PR #406) and **AVX2** (9/7 float and int32 5/3 on
-both).  The AVX2 kernels also serve AVX-512 hosts (`OPENHTJ2K_ENABLE_AVX2` is
-defined there too); a dedicated 16-lane AVX-512 variant (§5.2) and the WASM
-port (§5.3) remain open.  WASM and scalar go through a bit-identical fallback
-that interleaves into the ring slot and runs the historical in-place kernels,
-at unchanged cost.  This document is the map for the remaining platforms.
+subband rows on **NEON** (PR #406), **AVX2** (PR #407), and **WASM SIMD**
+(9/7 float and int32 5/3 on all three).  The AVX2 kernels also serve AVX-512
+hosts (`OPENHTJ2K_ENABLE_AVX2` is defined there too); only a dedicated
+16-lane AVX-512 variant (§5.2) remains open.  Scalar builds keep the
+bit-identical fallback that interleaves into the ring slot and runs the
+historical in-place kernels, at unchanged cost.
 
 Measured upside (8K 12-bit, single thread, 30-iter mean, end-to-end decode):
 
@@ -14,6 +14,7 @@ Measured upside (8K 12-bit, single thread, 30-iter mean, end-to-end decode):
 |---|---|---|
 | NEON (M3 Max) | −5.5% | −2.5% |
 | AVX2 (Ryzen 9 9950X, AVX-512 host) | −3.8% | −0.5% |
+| WASM SIMD (Node 24, same 9950X) | −5.6% | neutral (±, 8 reps) |
 
 The AVX2 gain is smaller than NEON's despite §5.1's lane-utilisation argument
 because on an AVX-512 host the displaced in-place kernels are the 16-lane
@@ -31,7 +32,7 @@ idwt_level_src_fn (coding_units.cpp)          ← selects lp_ptr/hp_ptr, zero sc
         ▼
 idwt_1d_row_from_planar (idwt.cpp)            ← THE dispatcher; the only place
         │                                        that decides planar vs fallback
-        ├─ planar kernel        (NEON, AVX2)  ← lp/hp planes → natural row in
+        ├─ planar kernel  (NEON, AVX2, WASM)  ← lp/hp planes → natural row in
         │                                        the ring slot; no interleave
         └─ fallback: interleave_row_planes()  ← LP at u0%2, HP at 1-u0%2, then
            + idwt_1d_row_inplace[_range|_i32]    in-place PSE fill + lifting
@@ -45,7 +46,7 @@ zero-row tracking, PSE row copies, `pull_row_ref`, and the whole batch path
 
 The port therefore adds, per platform:
 
-1. Two kernels in `idwt_wasm.cpp` (and later `idwt_avx512.cpp`):
+1. Two kernels in `idwt_avx512.cpp`:
    - `idwt_1d_filtr_irrev97_planar_<isa>(sprec_t *out, const sprec_t *lp, const sprec_t *hp, int32_t u0, int32_t u1)`
    - `idwt_1d_filtr_rev53_planar_i32_<isa>(int32_t *out, const int32_t *lp, const int32_t *hp, int32_t u0, int32_t u1)`
 2. Declarations in `dwt.hpp`.  Note the AVX2 planar declarations live in a
@@ -67,7 +68,7 @@ falls back (and must keep falling back):
 | Guard | Why |
 |---|---|
 | `(u0 & 1) == 0` | keeps `E[j] = lp[j]`, `O[j] = hp[j]` index-aligned; odd u0 shifts the LP plane by one and is rare (odd tile/precinct origins) |
-| `N = u1/2 - u0/2 >= 12` (NEON) / `>= 16` (AVX2) | the SIMD warmup loads blocks 0/1 unconditionally — j=0..7 at 4 lanes, j=0..15 at 8 lanes; short rows go through the fallback's scalar-friendly path |
+| `N = u1/2 - u0/2 >= 12` (NEON, WASM) / `>= 16` (AVX2) | the SIMD warmup loads blocks 0/1 unconditionally — j=0..7 at 4 lanes, j=0..15 at 8 lanes; short rows go through the fallback's scalar-friendly path |
 | 9/7 float: `col_lo <= u0 && col_hi >= u1` | narrow JPIP column ranges use the scalar sub-range lifter on the interleaved row; not worth porting |
 | 5/3: `use_i32 == true` | the float-5/3 streaming path is cold (lossless decode is i32); i32 ignores the column range by design, matching `idwt_1d_row_inplace_i32` |
 
@@ -229,7 +230,7 @@ then evaluate whether 16-lane + `vpermt2ps` (single-instruction cross-lane
 shifts) pays for a dedicated variant. Keep the dispatch precedence consistent
 with the in-place tables (AVX-512 before AVX2) when adding it.
 
-### 5.3 WASM
+### 5.3 WASM (shipped — kernels at the bottom of `idwt_wasm.cpp`)
 
 `idwt_wasm.cpp` currently emulates `vld2q/vst2q` with paired loads +
 `wasm_i32x4_shuffle` (helpers at the top of the file). The planar port is a

--- a/source/core/transform/dwt.hpp
+++ b/source/core/transform/dwt.hpp
@@ -410,6 +410,15 @@ void idwt_rev_ver_hp_step_wasm(int32_t n, const float *prev, const float *next, 
 void idwt_1d_filtr_rev53_i32_wasm(int32_t *X, int32_t left, int32_t u_i0, int32_t u_i1);
 void idwt_rev_ver_lp_step_i32_wasm(int32_t n, const int32_t *prev, const int32_t *next, int32_t *tgt);
 void idwt_rev_ver_hp_step_i32_wasm(int32_t n, const int32_t *prev, const int32_t *next, int32_t *tgt);
+// Planar-input horizontal synthesis — 4-lane transcription of the NEON planar
+// kernels (see the NEON declarations above for the full contract; same N >= 12
+// dispatch guard).  The 9/7 kernel uses separately-rounded mul+sub to match
+// the in-place WASM kernel (SIMD128 has no FMA) — bit-identical to the
+// fallback on this platform, not to NEON/AVX2 hosts.
+void idwt_1d_filtr_irrev97_planar_wasm(sprec_t *out, const sprec_t *lp, const sprec_t *hp, int32_t u0,
+                                       int32_t u1);
+void idwt_1d_filtr_rev53_planar_i32_wasm(int32_t *out, const int32_t *lp, const int32_t *hp, int32_t u0,
+                                         int32_t u1);
 // single-row vertical step (for streaming fdwt_2d_state)
 void fdwt_rev_ver_hp_step_wasm(int32_t n, const float *prev, const float *next, float *tgt);
 void fdwt_rev_ver_lp_step_wasm(int32_t n, const float *prev, const float *next, float *tgt);

--- a/source/core/transform/idwt.cpp
+++ b/source/core/transform/idwt.cpp
@@ -1147,6 +1147,24 @@ void idwt_1d_row_from_planar(sprec_t *out, const sprec_t *lp, const sprec_t *hp,
       return;
     }
   }
+#elif defined(OPENHTJ2K_ENABLE_WASM_SIMD)
+  // Planar fast path, 4-lane WASM SIMD — same geometry guards as NEON.  The
+  // 9/7 kernel matches the in-place WASM rounding (mul+sub, no FMA), so both
+  // paths stay bit-identical on this platform.
+  const int32_t N = u1 / 2 - u0 / 2;
+  if ((u0 & 1) == 0 && N >= 12) {
+    if (transformation == 1 && use_i32) {
+      // i32 rev 5/3 has no sub-range variant — always full-width (see below).
+      idwt_1d_filtr_rev53_planar_i32_wasm(reinterpret_cast<int32_t *>(out),
+                                          reinterpret_cast<const int32_t *>(lp),
+                                          reinterpret_cast<const int32_t *>(hp), u0, u1);
+      return;
+    }
+    if (transformation == 0 && !use_i32 && col_lo <= u0 && col_hi >= u1) {
+      idwt_1d_filtr_irrev97_planar_wasm(out, lp, hp, u0, u1);
+      return;
+    }
+  }
 #endif
 
   // Fallback: interleave into the ring slot (LP at u0%2, HP at 1-u0%2), then

--- a/source/core/transform/idwt_wasm.cpp
+++ b/source/core/transform/idwt_wasm.cpp
@@ -544,4 +544,153 @@ void idwt_rev_ver_hp_step_i32_wasm(int32_t n, const int32_t *prev, const int32_t
   for (; i < n; ++i) tgt[i] += (prev[i] + next[i]) >> 1;
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Planar-input horizontal synthesis — the LP and HP subband rows are read
+// directly (E[j] = lp[j], O[j] = hp[j]) and the synthesised natural-domain row
+// is written to out[].  4-lane transcription of the NEON planar kernels
+// (idwt_neon.cpp): vextq_f32(a, b, k) becomes wasm_i32x4_shuffle(a, b, k..k+3)
+// and the vst2q store uses this file's zip helpers.  Boundary taps outside the
+// planes use WSSE mirroring via PSEo() on the absolute position (positions
+// u0-k and u0+k have equal parity, so each plane extends within itself).
+//
+// Rounding: SIMD128 has no FMA, and the in-place WASM 9/7 kernel computes
+// wasm_f32x4_sub(x, wasm_f32x4_mul(sum, coeff)) — separately-rounded mul+sub.
+// The planar kernel must match it per element, so the scalar warmup/drain
+// uses plain  x - coeff*(a + b)  float expressions, NOT std::fmaf (there is
+// no scalar FMA instruction for clang to contract into, so these compile to
+// f32.mul + f32.sub, matching the vector lanes).  The 5/3 i32 kernel is
+// integer adds/shifts — exact regardless of structure.
+//
+// Contract (enforced by idwt_1d_row_from_planar): u0 even, N = u1/2 - u0/2
+// >= 12, lp has ceil(u1/2) - u0/2 valid samples, hp has N, out has >= 2
+// writable floats before index 0 and >= 8 after index u1-u0-1.
+// ─────────────────────────────────────────────────────────────────────────────
+
+void idwt_1d_filtr_irrev97_planar_wasm(sprec_t *out, const sprec_t *lp, const sprec_t *hp, const int32_t u0,
+                                       const int32_t u1) {
+  const int32_t N = u1 / 2 - u0 / 2;
+  // Mirrored raw-plane accessors (used only for warmup/drain boundary taps).
+  auto E = [&](int32_t j) -> float { return lp[PSEo(u0 + 2 * j, u0, u1) >> 1]; };
+  auto O = [&](int32_t j) -> float { return hp[PSEo(u0 + 2 * j + 1, u0, u1) >> 1]; };
+
+  const v128_t vA = wasm_f32x4_splat(fA), vB = wasm_f32x4_splat(fB);
+  const v128_t vC = wasm_f32x4_splat(fC), vD = wasm_f32x4_splat(fD);
+
+  // Warmup: j = -1 scalars, then S1 of blocks 0 and 1, S2/S3 of block 0.
+  const float om1  = O(-1);
+  const float s1m1 = E(-1) - fD * (O(-2) + om1);  // S1[-1]
+  v128_t O_b0      = wasm_v128_load(hp);
+  v128_t S1_b0     = wasm_f32x4_sub(
+      wasm_v128_load(lp),
+      wasm_f32x4_mul(wasm_f32x4_add(wasm_i32x4_shuffle(wasm_f32x4_splat(om1), O_b0, 3, 4, 5, 6), O_b0),
+                         vD));
+  const float s2m1 = om1 - fC * (s1m1 + wasm_f32x4_extract_lane(S1_b0, 0));  // S2[-1]
+  out[-2]          = s1m1;                                                   // final E[-1]
+  out[-1]          = s2m1;                                                   // final O[-1]
+
+  v128_t O_b1 = wasm_v128_load(hp + 4);
+  v128_t S1_b1 =
+      wasm_f32x4_sub(wasm_v128_load(lp + 4),
+                     wasm_f32x4_mul(wasm_f32x4_add(wasm_i32x4_shuffle(O_b0, O_b1, 3, 4, 5, 6), O_b1), vD));
+  v128_t S2_b0 = wasm_f32x4_sub(
+      O_b0, wasm_f32x4_mul(wasm_f32x4_add(S1_b0, wasm_i32x4_shuffle(S1_b0, S1_b1, 1, 2, 3, 4)), vC));
+  v128_t S3_b0 = wasm_f32x4_sub(
+      S1_b0, wasm_f32x4_mul(
+                 wasm_f32x4_add(wasm_i32x4_shuffle(wasm_f32x4_splat(s2m1), S2_b0, 3, 4, 5, 6), S2_b0), vB));
+
+  // Steady state: iteration n loads input block n (j = 4n..4n+3) with one
+  // plain load per plane and emits finished block n-2 with one zip store.
+  // The bound is 4n+3 <= N-1 because the planes have no PSE-filled margins
+  // to read past — the drain covers the rest scalar.
+  v128_t O_nm1 = O_b1, S1_nm1 = S1_b1, S2_nm2 = S2_b0, S3_nm2 = S3_b0;
+  int32_t n = 2;
+  for (; 4 * n + 3 <= N - 1; ++n) {
+    v128_t O_n = wasm_v128_load(hp + 4 * n);
+    v128_t S1_n =
+        wasm_f32x4_sub(wasm_v128_load(lp + 4 * n),
+                       wasm_f32x4_mul(wasm_f32x4_add(wasm_i32x4_shuffle(O_nm1, O_n, 3, 4, 5, 6), O_n), vD));
+    v128_t S2_nm1 = wasm_f32x4_sub(
+        O_nm1, wasm_f32x4_mul(wasm_f32x4_add(S1_nm1, wasm_i32x4_shuffle(S1_nm1, S1_n, 1, 2, 3, 4)), vC));
+    v128_t S3_nm1 = wasm_f32x4_sub(
+        S1_nm1, wasm_f32x4_mul(wasm_f32x4_add(wasm_i32x4_shuffle(S2_nm2, S2_nm1, 3, 4, 5, 6), S2_nm1), vB));
+    f32x4x2 o;
+    o.val[0] = S3_nm2;
+    o.val[1] = wasm_f32x4_sub(
+        S2_nm2, wasm_f32x4_mul(wasm_f32x4_add(S3_nm2, wasm_i32x4_shuffle(S3_nm2, S3_nm1, 1, 2, 3, 4)), vA));
+    vst2q(out + 8 * (n - 2), o);
+    O_nm1  = O_n;
+    S1_nm1 = S1_n;
+    S2_nm2 = S2_nm1;
+    S3_nm2 = S3_nm1;
+  }
+
+  // Drain: scalar finish for blocks n-2, n-1 (still in registers) and the
+  // ragged tail.  Loop exit bounds m = 4n to [N-3, N], so with base = m-8
+  // every stage index j-base fits in 16.  s1t/s2t/s3t[i] hold S1/S2/S3[base+i];
+  // s1t[0..3] are unused (block n-2's S1 was consumed).
+  {
+    const int32_t m    = 4 * n;
+    const int32_t base = m - 8;
+    float s1t[16], s2t[16], s3t[16];
+    wasm_v128_store(s1t + 4, S1_nm1);  // S1[m-4..m-1]
+    wasm_v128_store(s2t, S2_nm2);      // S2[m-8..m-5]
+    wasm_v128_store(s3t, S3_nm2);      // S3[m-8..m-5]
+    for (int32_t j = m; j <= N + 1; ++j) s1t[j - base] = E(j) - fD * (O(j - 1) + O(j));
+    for (int32_t j = m - 4; j <= N; ++j) s2t[j - base] = O(j) - fC * (s1t[j - base] + s1t[j - base + 1]);
+    for (int32_t j = m - 4; j <= N; ++j)
+      s3t[j - base] = s1t[j - base] - fB * (s2t[j - base - 1] + s2t[j - base]);
+    // Final row: E[j] = S3[j], O[j] = S4[j]; then O[N] = S2[N], E[N+1] = S1[N+1].
+    for (int32_t j = base; j <= N - 1; ++j) {
+      out[2 * j]     = s3t[j - base];
+      out[2 * j + 1] = s2t[j - base] - fA * (s3t[j - base] + s3t[j - base + 1]);
+    }
+    out[2 * N]       = s3t[N - base];
+    out[2 * N + 1]   = s2t[N - base];
+    out[2 * (N + 1)] = s1t[N + 1 - base];
+  }
+}
+
+void idwt_1d_filtr_rev53_planar_i32_wasm(int32_t *out, const int32_t *lp, const int32_t *hp,
+                                         const int32_t u0, const int32_t u1) {
+  const int32_t N = u1 / 2 - u0 / 2;
+  auto E          = [&](int32_t j) -> int32_t { return lp[PSEo(u0 + 2 * j, u0, u1) >> 1]; };
+  auto O          = [&](int32_t j) -> int32_t { return hp[PSEo(u0 + 2 * j + 1, u0, u1) >> 1]; };
+
+  //   S1[j] = E[j] - ((O[j-1] + O[j] + 2) >> 2)   for j in [0, N]   (undo LP update)
+  //   S2[j] = O[j] + ((S1[j] + S1[j+1]) >> 1)     for j in [0, N)   (undo HP predict)
+  // Integer ops are exact, so this matches idwt_1d_filtr_rev53_i32_wasm bit
+  // for bit.  Loop bound j+4 <= N-1 keeps every plane read in range (the
+  // s1_next lookahead reads lp[j+4] / hp[j+4]); the scalar tail mirrors.
+  const v128_t vtwo = wasm_i32x4_splat(2);
+  int32_t j         = 0;
+  int32_t o_carry   = O(-1);  // raw O[j-1] entering the current position
+  for (; j + 4 <= N - 1; j += 4) {
+    v128_t Ob   = wasm_v128_load(hp + j);
+    v128_t Ojm1 = wasm_i32x4_shuffle(wasm_i32x4_splat(o_carry), Ob, 3, 4, 5, 6);  // O[j-1..j+2]
+    v128_t S1b  = wasm_i32x4_sub(wasm_v128_load(lp + j),
+                                 wasm_i32x4_shr(wasm_i32x4_add(wasm_i32x4_add(Ojm1, Ob), vtwo), 2));
+    // S1[j+4] from raw memory (those positions are not yet written this pass)
+    const int32_t o3      = wasm_i32x4_extract_lane(Ob, 3);  // raw O[j+3]
+    const int32_t s1_next = lp[j + 4] - ((o3 + hp[j + 4] + 2) >> 2);
+    v128_t S1n            = wasm_i32x4_shuffle(S1b, wasm_i32x4_splat(s1_next), 1, 2, 3, 4);  // S1[j+1..j+4]
+    i32x4x2_idwt o;
+    o.val[0] = S1b;
+    o.val[1] = wasm_i32x4_add(Ob, wasm_i32x4_shr(wasm_i32x4_add(S1b, S1n), 1));
+    vst2q_i32_idwt(out + 2 * j, o);
+    o_carry = o3;
+  }
+  // Scalar tail (at most 5 S1 values: loop exits with N - j <= 4).
+  {
+    int32_t s1t[8];
+    int32_t o_prev = o_carry;
+    for (int32_t t = j; t <= N; ++t) {
+      const int32_t o = O(t);
+      s1t[t - j]      = E(t) - ((o_prev + o + 2) >> 2);
+      o_prev          = o;
+    }
+    for (int32_t t = j; t <= N; ++t) out[2 * t] = s1t[t - j];
+    for (int32_t t = j; t < N; ++t) out[2 * t + 1] = O(t) + ((s1t[t - j] + s1t[t - j + 1]) >> 1);
+  }
+}
+
 #endif  // OPENHTJ2K_ENABLE_WASM_SIMD


### PR DESCRIPTION
## Summary

Ports the planar horizontal IDWT kernels (NEON in #406, AVX2 in #407) to WASM SIMD, completing the SIMD platforms — only scalar builds keep the interleave + in-place fallback. The streaming horizontal synthesis lifts directly from the planar LP/HP subband rows: one plain `wasm_v128_load` per plane feeds the fused single-pass 9/7 lifting pipeline, the natural-domain row is written with the file's existing zip-store helpers, and the caller's per-row interleave pass disappears.

- `idwt_1d_filtr_irrev97_planar_wasm` — near line-for-line 4-lane transcription of the NEON kernel: `vextq_f32(a, b, k)` becomes `wasm_i32x4_shuffle(a, b, k..k+3)`, same depth-2 software pipeline, same warmup/drain structure and `N >= 12` dispatch guard.
- `idwt_1d_filtr_rev53_planar_i32_wasm` — integer single-loop kernel with the scalar `S1[j+4]` lookahead.

**Rounding caveat (the one place the NEON code could not be transcribed blindly):** SIMD128 has no FMA, and the in-place WASM 9/7 kernel computes `wasm_f32x4_sub(x, wasm_f32x4_mul(sum, coeff))` — separately-rounded mul+sub. The planar kernel matches that per element, including plain `x - coeff*(a+b)` float expressions in the scalar warmup/drain instead of `std::fmaf` (WASM has no scalar FMA instruction for clang to contract into, so these compile to `f32.mul` + `f32.sub`, matching the vector lanes). Output is therefore bit-identical to this platform's fallback — not to NEON/AVX2 hosts, same as before this change.

Also updates `docs/planar_idwt_porting.md` (WASM marked shipped with measured numbers; only the dedicated 16-lane AVX-512 variant remains open) and the CHANGELOG.

## Verification

- Native conformance suite: 407/407 (the WASM guards compile to nothing natively, so this proves the shared `idwt.cpp`/`dwt.hpp` changes don't disturb other platforms).
- `emcc -fsyntax-only -msimd128 -DOPENHTJ2K_ENABLE_WASM_SIMD` on the touched files.
- Whole-image `cmp` of the `simd` WASM variant against a main-baseline WASM build, both decoded under Node.js via `open_htj2k_dec.mjs`: 8K (u01_Books 12-bit) lossless and lossy (Qfactor=85), at 7680×4320 and an odd-geometry 7679×4319 crop — all four bit-identical. The lossless WASM output is also byte-equal to the source image.

## Performance

8K 12-bit single-tile, `wasm_bench.mjs --variant simd --threads 1 --iters 30`, Node 24 on Ryzen 9 9950X, interleaved A/B runs:

| Stream | main | this PR | Δ |
|---|---|---|---|
| lossy 9/7 (3 reps) | 272.7 ms | 257.4 ms | **−5.6%** |
| lossless 5/3 i32 (8 reps) | 601.4 ms | 600.1 ms | neutral (new faster in 5/8 reps) |

The lossy gain mirrors NEON's (−5.5%): both displace 4-lane in-place kernels whose input loads deinterleave on every pass. The 5/3 i32 result is a wash within run-to-run variance — the planar kernel trades the fallback's interleave pass for a per-block scalar lookahead, and the lossless decode is dominated by HT block decoding anyway; it ships for platform parity and the simpler unified dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)