### PR TITLE
fix(decoder): apply LP lifting to PSE positions in ATK irreversible 5/3 synthesis

### DIFF
--- a/source/core/transform/idwt.cpp
+++ b/source/core/transform/idwt.cpp
@@ -209,18 +209,20 @@ void idwt_1d_filtr_rev53_fixed(sprec_t *X, const int32_t left, const int32_t u_i
 // Synthesis (steps in FORWARD order, negated, LP first, then HP using modified LP):
 //   Step 1 (undo step[0]): LP[k] -= 0.25*(HP[k-1]+HP[k])   [modifies LP using original HP]
 //   Step 2 (undo step[1]): HP[k] += 0.5*(LP_mod[k]+LP_mod[k+1])  [modifies HP using modified LP]
-[[maybe_unused]] static void idwt_1d_filtr_irrev53_fixed(sprec_t *X, const int32_t left,
-                                                        const int32_t u_i0, const int32_t u_i1) {
-  const int32_t lp_count  = ceil_int(u_i1, 2) - ceil_int(u_i0, 2);  // LP sample count
-  const int32_t hp_count  = u_i1 / 2 - u_i0 / 2;                    // HP sample count
-  const int32_t offset    = left - u_i0 % 2;                         // base for HP step loop
-  const int32_t lp_offset = offset + (u_i0 % 2) * 2;                // first LP sample position
+// Per 15444-2 lifting with whole-sample symmetric extension, each step acts on the extended
+// signal: the LP pass must also lift the even extension positions adjacent to the data so the
+// HP pass reads post-LP values there.  Same loop bounds as idwt_1d_filtr_rev53_fixed above
+// (LP runs stop+1-start times from offset, one lift landing on the even PSE position when the
+// edge sample is HP).
+[[maybe_unused]] static void idwt_1d_filtr_irrev53_fixed(sprec_t *X, const int32_t left, const int32_t u_i0,
+                                                         const int32_t u_i1) {
+  const int32_t start  = u_i0 / 2;
+  const int32_t stop   = u_i1 / 2;
+  const int32_t offset = left - u_i0 % 2;
   // Step 1: LP -= 0.25*(HP_left + HP_right)  [using original HP values]
-  for (int32_t k = 0, n = lp_offset; k < lp_count; ++k, n += 2)
-    X[n] -= 0.25f * (X[n - 1] + X[n + 1]);
+  for (int32_t n = 0 + offset, i = start; i < stop + 1; ++i, n += 2) X[n] -= 0.25f * (X[n - 1] + X[n + 1]);
   // Step 2: HP += 0.5*(LP_mod_left + LP_mod_right)  [using LP values modified in step 1]
-  for (int32_t k = 0, n = offset; k < hp_count; ++k, n += 2)
-    X[n + 1] += 0.5f * (X[n] + X[n + 2]);
+  for (int32_t n = 0 + offset, i = start; i < stop; ++i, n += 2) X[n + 1] += 0.5f * (X[n] + X[n + 2]);
 }
 
 // In-place 1-D IDWT for all rows.
@@ -449,15 +451,16 @@ static void idwt_irrev53_ver_sr_fixed(sprec_t *in, const int32_t u0, const int32
       memcpy(buf[top + (v1 - v0) + i - 1], &in[PSEo(v1 - v0 + i - 1 + v0, v0, v1) * stride],
              sizeof(sprec_t) * static_cast<size_t>(stride));
     }
-    const int32_t lp_count = ceil_int(v1, 2) - ceil_int(v0, 2);  // LP row count
-    const int32_t hp_count = v1 / 2 - v0 / 2;                    // HP row count
-    const int32_t offset   = top - v0 % 2;                        // base for HP step loop
-    const int32_t lp_n0    = top + v0 % 2;                        // first LP row index
+    // Per-step extension semantics: the LP pass also lifts the even PSE rows adjacent to the
+    // data (same bounds as idwt_rev_ver_sr_fixed above) so the HP pass reads post-LP values.
+    const int32_t lp_count = v1 / 2 - v0 / 2 + 1;  // LP rows incl. even PSE rows at the edges
+    const int32_t hp_count = v1 / 2 - v0 / 2;      // HP row count
+    const int32_t offset   = top - v0 % 2;         // first LP row (may be a PSE row)
     const int32_t width    = u1 - u0;
     for (int32_t cs = 0; cs < width; cs += DWT_VERT_STRIP) {
       const int32_t ce = (cs + DWT_VERT_STRIP < width) ? cs + DWT_VERT_STRIP : width;
       // Step 1: LP -= 0.25*(HP_above + HP_below)  [original HP values]
-      for (int32_t k = 0, n = lp_n0; k < lp_count; ++k, n += 2) {
+      for (int32_t k = 0, n = offset; k < lp_count; ++k, n += 2) {
         for (int32_t col = cs; col < ce; ++col)
           buf[n][col] -= 0.25f * (buf[n - 1][col] + buf[n + 1][col]);
       }

--- a/source/core/transform/idwt_avx2.cpp
+++ b/source/core/transform/idwt_avx2.cpp
@@ -454,16 +454,17 @@ void idwt_irrev53_ver_sr_fixed_avx2(sprec_t *in, const int32_t u0, const int32_t
       memcpy(buf[top + (v1 - v0) + i - 1], &in[PSEo(v1 - v0 + i - 1 + v0, v0, v1) * stride],
              sizeof(sprec_t) * static_cast<size_t>(stride));
     }
-    const int32_t lp_count = ceil_int(v1, 2) - ceil_int(v0, 2);
-    const int32_t hp_count = v1 / 2 - v0 / 2;
-    const int32_t offset   = top - v0 % 2;
-    const int32_t lp_n0    = top + v0 % 2;
+    // Per-step extension semantics: the LP pass also lifts the even PSE rows adjacent to the
+    // data (same bounds as the rev53 vertical kernel) so the HP pass reads post-LP values.
+    const int32_t lp_count = v1 / 2 - v0 / 2 + 1;  // LP rows incl. even PSE rows at the edges
+    const int32_t hp_count = v1 / 2 - v0 / 2;      // HP row count
+    const int32_t offset   = top - v0 % 2;         // first LP row (may be a PSE row)
     const int32_t width    = u1 - u0;
     for (int32_t cs = 0; cs < width; cs += DWT_VERT_STRIP) {
       const int32_t ce        = (cs + DWT_VERT_STRIP < width) ? cs + DWT_VERT_STRIP : width;
       const int32_t simdlen_s = (ce - cs) - (ce - cs) % 8;
       const __m256 x025       = _mm256_set1_ps(0.25f);
-      for (int32_t k = 0, n = lp_n0; k < lp_count; ++k, n += 2) {
+      for (int32_t k = 0, n = offset; k < lp_count; ++k, n += 2) {
         for (int32_t col = 0; col < simdlen_s; col += 8) {
           __m256 x0 = _mm256_load_ps(buf[n - 1] + cs + col);
           __m256 x2 = _mm256_load_ps(buf[n + 1] + cs + col);

--- a/source/core/transform/idwt_avx512.cpp
+++ b/source/core/transform/idwt_avx512.cpp
@@ -488,17 +488,18 @@ void idwt_irrev53_ver_sr_fixed_avx512(sprec_t *in, const int32_t u0, const int32
       memcpy(buf[top + (v1 - v0) + i - 1], &in[PSEo(v1 - v0 + i - 1 + v0, v0, v1) * stride],
              sizeof(sprec_t) * static_cast<size_t>(stride));
     }
-    const int32_t lp_count = ceil_int(v1, 2) - ceil_int(v0, 2);
-    const int32_t hp_count = v1 / 2 - v0 / 2;
-    const int32_t offset   = top - v0 % 2;
-    const int32_t lp_n0    = top + v0 % 2;
+    // Per-step extension semantics: the LP pass also lifts the even PSE rows adjacent to the
+    // data (same bounds as the rev53 vertical kernel) so the HP pass reads post-LP values.
+    const int32_t lp_count = v1 / 2 - v0 / 2 + 1;  // LP rows incl. even PSE rows at the edges
+    const int32_t hp_count = v1 / 2 - v0 / 2;      // HP row count
+    const int32_t offset   = top - v0 % 2;         // first LP row (may be a PSE row)
     const int32_t width    = u1 - u0;
     for (int32_t cs = 0; cs < width; cs += DWT_VERT_STRIP) {
       const int32_t ce        = (cs + DWT_VERT_STRIP < width) ? cs + DWT_VERT_STRIP : width;
       const int32_t simdlen_s = (ce - cs) - (ce - cs) % 16;
       const int32_t tail      = ce - cs - simdlen_s;
       const __m512 x025       = _mm512_set1_ps(0.25f);
-      for (int32_t k = 0, n = lp_n0; k < lp_count; ++k, n += 2) {
+      for (int32_t k = 0, n = offset; k < lp_count; ++k, n += 2) {
         for (int32_t col = 0; col < simdlen_s; col += 16) {
           __m512 x0 = _mm512_loadu_ps(buf[n - 1] + cs + col);
           __m512 x2 = _mm512_loadu_ps(buf[n + 1] + cs + col);

--- a/source/core/transform/idwt_neon.cpp
+++ b/source/core/transform/idwt_neon.cpp
@@ -222,15 +222,16 @@ void idwt_1d_filtr_rev53_fixed_neon(sprec_t *X, const int32_t left, const int32_
 // ATK irreversible 5/3 IDWT (horizontal)
 void idwt_1d_filtr_irrev53_fixed_neon(sprec_t *X, const int32_t left, const int32_t u_i0,
                                       const int32_t u_i1) {
-  const int32_t start    = u_i0 / 2;
-  const int32_t stop     = u_i1 / 2;
-  const int32_t offset   = left - u_i0 % 2;
-  const int32_t lp_offset = offset + (u_i0 % 2) * 2;
+  const int32_t start  = u_i0 / 2;
+  const int32_t stop   = u_i1 / 2;
+  const int32_t offset = left - u_i0 % 2;
 
   // Step 1: LP[k] -= 0.25*(HP[k-1]+HP[k])
+  // Starts at offset (not the first real LP sample): per-step extension semantics require the
+  // LP pass to lift the even PSE positions adjacent to the data, same bounds as the rev53 kernel.
   int32_t simdlen = stop + 1 - start;
   const auto x025 = vdupq_n_f32(0.25f);
-  sprec_t *sp     = X + lp_offset;
+  sprec_t *sp     = X + offset;
   int32_t k       = 0;
   if (k + 4 < simdlen) {
     auto x0a = vld2q_f32(sp - 1);
@@ -618,17 +619,18 @@ void idwt_irrev53_ver_sr_fixed_neon(sprec_t *in, const int32_t u0, const int32_t
       memcpy(buf[top + (v1 - v0) + i - 1], &in[PSEo(v1 - v0 + i - 1 + v0, v0, v1) * stride],
              sizeof(sprec_t) * static_cast<size_t>(stride));
     }
-    const int32_t lp_count = ceil_int(v1, 2) - ceil_int(v0, 2);
-    const int32_t hp_count = v1 / 2 - v0 / 2;
-    const int32_t offset   = top - v0 % 2;
-    const int32_t lp_n0    = top + v0 % 2;
+    // Per-step extension semantics: the LP pass also lifts the even PSE rows adjacent to the
+    // data (same bounds as the rev53 vertical kernel) so the HP pass reads post-LP values.
+    const int32_t lp_count = v1 / 2 - v0 / 2 + 1;  // LP rows incl. even PSE rows at the edges
+    const int32_t hp_count = v1 / 2 - v0 / 2;      // HP row count
+    const int32_t offset   = top - v0 % 2;         // first LP row (may be a PSE row)
     const int32_t width    = u1 - u0;
     for (int32_t cs = 0; cs < width; cs += DWT_VERT_STRIP) {
       const int32_t ce        = (cs + DWT_VERT_STRIP < width) ? cs + DWT_VERT_STRIP : width;
       const int32_t simdlen_s = (ce - cs) - (ce - cs) % 4;
       // Step 1: LP[k] -= 0.25*(HP[k-1]+HP[k])
       const auto x025 = vdupq_n_f32(0.25f);
-      for (int32_t k = 0, n = lp_n0; k < lp_count; ++k, n += 2) {
+      for (int32_t k = 0, n = offset; k < lp_count; ++k, n += 2) {
         int32_t col = 0;
         for (; col + 4 < simdlen_s; col += 8) {
           auto x0a = vld1q_f32(buf[n - 1] + cs + col);


### PR DESCRIPTION
## Bug

The ATK (ISO/IEC 15444-2) irreversible 5/3 synthesis kernels filled the whole-sample symmetric extension once and then ran the LP and HP lifting passes over the real samples only. Per 15444-2 lifting-with-WSE semantics, each lifting step acts on the **extended** signal: the LP pass must also lift the even extension positions adjacent to the data so that the HP pass reads post-LP values there. The Part-1 5/3 kernel in the same file (`idwt_1d_filtr_rev53_fixed`) already implements this by iterating the LP pass `stop + 1 - start` times starting at `offset`, one lift landing on the even PSE position when the edge sample is HP.

Because the ATK kernels skipped that lift, for even-width rows the final HP step consumed a stale pre-update mirror value at the right edge (and the NEON horizontal variant additionally skipped the left extension lift for odd `u_i0`). Errors up to 23/255, concentrated in right-edge columns, appeared in decoded i5x3 ATK codestreams; the existing ATK conformance tolerance (PAE 65) does not expose this, so `comp_p2_dfs_atk*` stays green before and after.

## Fix

Align the ATK kernels' loop bounds with the Part-1 rev53 kernels (same `start`/`stop`/`offset` form, LP pass `stop+1-start` iterations):

| Kernel | State on main | Change |
|---|---|---|
| `idwt_1d_filtr_irrev53_fixed` (scalar horizontal) | LP covered real samples only | rev53-style bounds |
| `idwt_1d_filtr_irrev53_fixed_neon` | LP started at first real LP sample (`lp_offset`) | start at `offset` |
| `idwt_1d_filtr_irrev53_fixed_avx2` / `_avx512` | already corrected bounds | none |
| `idwt_irrev53_ver_sr_fixed` + `_avx2` / `_neon` / `_avx512` (vertical batch) | LP covered real rows only | rev53-style bounds |
| `fdwt.cpp` ATK kernels (encoder) | already transcribe rev53 bounds verbatim | none |
| line-based streaming vertical cascade | lifts PSE row copies through their own steps | none |
| sub-range horizontal fallback | dispatches via the same fn pointer | fixed automatically |

The PSE width precondition is already satisfied: the callers use the rev53 PSE counts for ATK (right = 2 when `u1` is even), so the extra LP lift's reads stay inside the filled extension.

## Verification

- Full ctest suite green (407/407) on both the default SIMD build and `-DENABLE_AVX2=OFF`.
- `conformance_data/ATK_DFS_REV.j2c` (irrev53, idx=2): scalar vs SIMD builds diverged at **PAE 207** on main; after the fix they agree to **PAE 1** with the residual ±1 spread uniformly over the frame (float rounding noise from non-kernel SIMD/scalar differences that pre-exists on main). The 9/7 control (`ATK_DFS_IRV.j2c`) is byte-identical between builds before and after.
- Swapping the fixed scalar kernels into the AVX-512 dispatch slots produces bit-identical output to the intrinsic kernels, i.e. all batch kernel variants now agree exactly.
- On an externally encoded 8-bit i5x3 ATK codestream (~3 bpp, 3840x2160): decoding with main's scalar build shows PAE 11 with every >1 error inside the last 28 right-edge columns; after the fix, both builds decode to PAE 1 (uniform) against an independent reference decode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)