### PR TITLE
fix(decoder): use direct float dequantization in the scalar HT fallback path

### DIFF
--- a/source/core/coding/ht_block_decoding.cpp
+++ b/source/core/coding/ht_block_decoding.cpp
@@ -1014,16 +1014,15 @@ void j2k_codeblock::dequantize(uint8_t ROIshift) const {
   const uint32_t mask = UINT32_MAX >> (M_b + 1);
   // reconstruction parameter defined in E.1.1.2 of the spec
 
-  float fscale = this->stepsize;
-  fscale *= (1 << FRACBITS);
+  // Direct float scale factor: decoded magnitude is in Q(31-M_b) fixed-point;
+  // the result must be in Q(FRACBITS).
+  float fscale_direct = this->stepsize;
+  fscale_direct *= static_cast<float>(1 << FRACBITS);
   if (M_b <= 31) {
-    fscale /= (static_cast<float>(1 << (31 - M_b)));
+    fscale_direct /= (static_cast<float>(1 << (31 - M_b)));
   } else {
-    fscale *= (static_cast<float>(1 << (M_b - 31)));
+    fscale_direct *= (static_cast<float>(1 << (M_b - 31)));
   }
-  constexpr int32_t downshift = 15;
-  fscale *= (float)(1 << 16) * (float)(1 << downshift);
-  const auto scale = (int32_t)(fscale + 0.5);
   if (this->transformation == 1) {
     auto rev_loop = [&](auto store_fn) {
       for (size_t i = 0; i < static_cast<size_t>(this->size.y); i++) {
@@ -1051,13 +1050,33 @@ void j2k_codeblock::dequantize(uint8_t ROIshift) const {
       rev_loop([](sprec_t *d, int32_t v) { *reinterpret_cast<int32_t *>(d) = v; });
     else
       rev_loop([](sprec_t *d, int32_t v) { *d = static_cast<sprec_t>(v); });
-  } else {
-    // lossy path
-    OPENHTJ2K_MAYBE_UNUSED int32_t ROImask = 0;
-    if (ROIshift) {
-      ROImask = static_cast<int32_t>(0xFFFFFFFF);
+  } else if (ROIshift == 0) {
+    // Lossy, no ROI (common case): direct float multiply, matching the fused
+    // dequant path (dequant_store_scalar) and the AVX2/NEON/WASM variants of
+    // this function bit-exactly.  The previous integer fixed-point pipeline
+    // here rounded every sample to an integer in the Q(FRACBITS) domain, so
+    // blocks taking this fallback (multiple HT passes, odd height) were
+    // dequantized with different precision than fused blocks and than SIMD
+    // builds, causing up to ±1 LSB divergence in decoded images.
+    for (size_t i = 0; i < static_cast<size_t>(this->size.y); i++) {
+      int32_t *val = this->sample_buf + i * this->blksampl_stride;
+      sprec_t *dst = this->band_buf + i * this->band_stride;
+      size_t len   = this->size.x;
+      for (; len > 0; --len) {
+        const int32_t sign = *val & INT32_MIN;
+        float f            = static_cast<float>(*val & INT32_MAX) * fscale_direct;
+        if (sign) f = -f;
+        *dst = f;
+        val++;
+        dst++;
+      }
     }
-    //    auto vROIshift = vdupq_n_s32(ROImask);
+  } else {
+    // Lossy ROI path — rarely used; keep the integer-arithmetic approach.
+    constexpr int32_t downshift = 15;
+    float fscale                = fscale_direct;
+    fscale *= static_cast<float>(1 << 16) * static_cast<float>(1 << downshift);
+    const auto scale = static_cast<int32_t>(fscale + 0.5f);
     for (size_t i = 0; i < static_cast<size_t>(this->size.y); i++) {
       int32_t *val = this->sample_buf + i * this->blksampl_stride;
       sprec_t *dst = this->band_buf + i * this->band_stride;
@@ -1067,7 +1086,7 @@ void j2k_codeblock::dequantize(uint8_t ROIshift) const {
         int32_t sign = *val & INT32_MIN;
         *val &= INT32_MAX;
         // detect background region and upshift it
-        if (ROIshift && (((uint32_t)*val & ~mask) == 0)) {
+        if (((uint32_t)*val & ~mask) == 0) {
           *val <<= ROIshift;
         }
         // to prevent overflow, truncate to int16_t


### PR DESCRIPTION
## Bug

`j2k_codeblock::dequantize()` — the non-fused fallback used for codeblocks that cannot take the fused dequant path (more than one HT pass, ROI, or odd block height) — implements the lossy branch with **integer fixed-point arithmetic in the scalar file** (`(mag + 2^15) >> 16`, integer `scale = (int32)(fscale + 0.5)` multiply, `>> 15` with rounding), which quantizes every dequantized sample to an integer in the Q(FRACBITS) domain. The AVX2 / NEON / WASM variants of the same function, and the **fused** dequant path in *all* builds including scalar, use a direct float multiply (`mag * fscale_direct`) at full precision.

Two consequences:

- **Cross-build divergence**: scalar builds (`-DENABLE_AVX2=OFF`, or any platform without SIMD) decode lossy streams containing non-fuseable blocks up to ±1 LSB differently from SIMD builds, spread uniformly over the frame. This was first noticed as a residual PAE-1 scalar-vs-SIMD difference on `ATK_DFS_REV.j2c` while validating #410, but it is not ATK-specific — any lossy HT stream with multi-pass blocks is affected.
- **Intra-build inconsistency**: within a single scalar-build decode, fuseable blocks (float dequant) and non-fuseable blocks (integer dequant) of the same image are reconstructed with different precision.

Diagnosis: row-level binary dumps at the IDWT input showed the first build-vs-build divergence on fresh subband samples at a constant ratio (e.g. 6 vs 6.038086, 26 vs 26.16504 — ratio = the band's scale factor), the fingerprint of integer-rounded vs full-precision dequantization with identical stepsizes.

## Fix

Restructure the scalar fallback's lossy branch to mirror the AVX2 file:

- `ROIshift == 0` (common case): direct float multiply with `fscale_direct` — bit-exact with the SIMD variants (same scale-factor computation, round-to-nearest int→float conversion, single multiply) and with the fused path, and slightly more accurate than the old pipeline (no 16-bit magnitude truncation, no rounding of results to integers).
- `ROIshift != 0` (rare): integer fixed-point retained, as in the AVX2 file.

Reversible (`transformation == 1`) and MQ-coded (`block_dequant*.cpp`) paths are untouched.

## Verification

- Scalar and default (AVX-512) builds now decode `conformance_data/ATK_DFS_REV.j2c` **byte-identically** (all 3 components; previously PAE 1 with ~5–7% of pixels differing).
- Full ctest suite: **407/407** in both build configurations.
- Proof of mechanism: applying only this arithmetic change to the scalar file was already sufficient to make the two builds byte-identical during diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)