### PR TITLE
perf(encoder): planar LP/HP horizontal FDWT lifting on AVX2

### DIFF
--- a/source/core/coding/coding_units.cpp
+++ b/source/core/coding/coding_units.cpp
@@ -728,6 +728,73 @@ static inline void sink_quantize_row_i32(const int32_t *src, int32_t sub_row, in
 // switched at the state level for reversible 5/3); we reinterpret_cast and
 // deinterleave as int32, write int32 into lp_tmp/hp_tmp, and call the int32
 // sink/memcpy/push paths.
+// Planar sink: same routing as the float path of fdwt_level_sink_fn below,
+// but receives the horizontal output as LP/HP planes straight from the planar
+// FDWT kernel — the interleave→deinterleave round trip is skipped entirely.
+static void fdwt_level_sink_planes_fn(void *ctx, bool is_hp, int32_t abs_row, const sprec_t *lp_row,
+                                      const sprec_t *hp_row) {
+  auto *c = static_cast<fdwt_level_sink_ctx *>(ctx);
+
+  // Strip-ring stamp (same contract as in fdwt_level_sink_fn; the equality
+  // guard makes a duplicate stamp from the other leg a no-op).
+  if (c->cb_h > 0 && c->sink_quantize) {
+    const int32_t band_y0 = is_hp ? c->lh_y0 : c->hl_y0;
+    const int32_t sub_row = (abs_row >> 1) - band_y0;
+    const int32_t br_curr = sub_row / c->cb_h;
+    if (br_curr != c->last_stamped_br) {
+      stamp_strip_pointers(c, br_curr);
+      c->last_stamped_br = br_curr;
+    }
+  }
+
+  if (!is_hp) {
+    // LP vertical row: HP-horiz → HL, LP-horiz → child/LL0
+    const int32_t hl_sub = (abs_row >> 1) - c->hl_y0;
+    if (c->sink_quantize)
+      sink_quantize_row(hp_row, hl_sub, 0, c);
+    else
+      memcpy(c->hl_samples + static_cast<ptrdiff_t>(hl_sub) * static_cast<ptrdiff_t>(c->hl_stride), hp_row,
+             static_cast<size_t>(c->hp_width) * sizeof(sprec_t));
+    if (c->has_child) {
+      fdwt_2d_state_push_row(c->child_state, lp_row);
+    } else {
+      const int32_t ll_sub = (abs_row >> 1) - c->ll0_y0;
+      memcpy(c->ll0_samples + static_cast<ptrdiff_t>(ll_sub) * static_cast<ptrdiff_t>(c->ll0_stride),
+             lp_row, static_cast<size_t>(c->lp_width) * sizeof(sprec_t));
+    }
+    if (c->cb_h > 0) {
+      const int32_t br   = hl_sub / c->cb_h;
+      const int32_t last = std::min((br + 1) * c->cb_h, c->hl_h) - 1;
+      if (hl_sub == last) {
+        const uint8_t old =
+            c->cblk_row_done[static_cast<size_t>(br)].fetch_or(1, std::memory_order_acq_rel);
+        if ((old | 1) == 3) enc_overlap_dispatch(c, br);
+      }
+    }
+  } else {
+    // HP vertical row: LP-horiz → LH, HP-horiz → HH
+    const int32_t hp_sub = (abs_row >> 1) - c->lh_y0;
+    if (c->sink_quantize) {
+      sink_quantize_row(lp_row, hp_sub, 1, c);
+      sink_quantize_row(hp_row, hp_sub, 2, c);
+    } else {
+      memcpy(c->lh_samples + static_cast<ptrdiff_t>(hp_sub) * static_cast<ptrdiff_t>(c->lh_stride), lp_row,
+             static_cast<size_t>(c->lp_width) * sizeof(sprec_t));
+      memcpy(c->hh_samples + static_cast<ptrdiff_t>(hp_sub) * static_cast<ptrdiff_t>(c->hh_stride), hp_row,
+             static_cast<size_t>(c->hp_width) * sizeof(sprec_t));
+    }
+    if (c->cb_h > 0) {
+      const int32_t br   = hp_sub / c->cb_h;
+      const int32_t last = std::min((br + 1) * c->cb_h, c->lh_h) - 1;
+      if (hp_sub == last) {
+        const uint8_t old =
+            c->cblk_row_done[static_cast<size_t>(br)].fetch_or(2, std::memory_order_acq_rel);
+        if ((old | 2) == 3) enc_overlap_dispatch(c, br);
+      }
+    }
+  }
+}
+
 static void fdwt_level_sink_fn(void *ctx, bool is_hp, int32_t abs_row, const sprec_t *interleaved_row) {
   auto *c = static_cast<fdwt_level_sink_ctx *>(ctx);
 
@@ -901,54 +968,9 @@ static void fdwt_level_sink_fn(void *ctx, bool is_hp, int32_t abs_row, const spr
   for (int32_t i = 0; i < c->hp_width; ++i) c->hp_tmp[i] = interleaved_row[2 * i + (1 - u_off)];
 #endif
 
-  if (!is_hp) {
-    // LP vertical row: HP-horiz → HL, LP-horiz → child/LL0
-    const int32_t hl_sub = (abs_row >> 1) - c->hl_y0;
-    if (c->sink_quantize)
-      sink_quantize_row(c->hp_tmp, hl_sub, 0, c);
-    else
-      memcpy(c->hl_samples + static_cast<ptrdiff_t>(hl_sub) * static_cast<ptrdiff_t>(c->hl_stride),
-             c->hp_tmp, static_cast<size_t>(c->hp_width) * sizeof(sprec_t));
-    if (c->has_child) {
-      fdwt_2d_state_push_row(c->child_state, c->lp_tmp);
-    } else {
-      const int32_t ll_sub = (abs_row >> 1) - c->ll0_y0;
-      memcpy(c->ll0_samples + static_cast<ptrdiff_t>(ll_sub) * static_cast<ptrdiff_t>(c->ll0_stride),
-             c->lp_tmp, static_cast<size_t>(c->lp_width) * sizeof(sprec_t));
-    }
-    // Overlap: dispatch HT block encoding if this HL row completes codeblock row br.
-    if (c->cb_h > 0) {
-      const int32_t br   = hl_sub / c->cb_h;
-      const int32_t last = std::min((br + 1) * c->cb_h, c->hl_h) - 1;
-      if (hl_sub == last) {
-        const uint8_t old =
-            c->cblk_row_done[static_cast<size_t>(br)].fetch_or(1, std::memory_order_acq_rel);
-        if ((old | 1) == 3) enc_overlap_dispatch(c, br);
-      }
-    }
-  } else {
-    // HP vertical row: LP-horiz → LH, HP-horiz → HH
-    const int32_t hp_sub = (abs_row >> 1) - c->lh_y0;
-    if (c->sink_quantize) {
-      sink_quantize_row(c->lp_tmp, hp_sub, 1, c);
-      sink_quantize_row(c->hp_tmp, hp_sub, 2, c);
-    } else {
-      memcpy(c->lh_samples + static_cast<ptrdiff_t>(hp_sub) * static_cast<ptrdiff_t>(c->lh_stride),
-             c->lp_tmp, static_cast<size_t>(c->lp_width) * sizeof(sprec_t));
-      memcpy(c->hh_samples + static_cast<ptrdiff_t>(hp_sub) * static_cast<ptrdiff_t>(c->hh_stride),
-             c->hp_tmp, static_cast<size_t>(c->hp_width) * sizeof(sprec_t));
-    }
-    // Overlap: dispatch HT block encoding if this LH+HH row completes codeblock row br.
-    if (c->cb_h > 0) {
-      const int32_t br   = hp_sub / c->cb_h;
-      const int32_t last = std::min((br + 1) * c->cb_h, c->lh_h) - 1;
-      if (hp_sub == last) {
-        const uint8_t old =
-            c->cblk_row_done[static_cast<size_t>(br)].fetch_or(2, std::memory_order_acq_rel);
-        if ((old | 2) == 3) enc_overlap_dispatch(c, br);
-      }
-    }
-  }
+  // Route through the planes sink (identical logic; lp_tmp/hp_tmp now hold
+  // the deinterleaved planes).  The duplicate strip stamp is a guarded no-op.
+  fdwt_level_sink_planes_fn(ctx, is_hp, abs_row, c->lp_tmp, c->hp_tmp);
 }
 
 // Per-component line-encode state.
@@ -3354,6 +3376,9 @@ void j2k_tile_component::init_line_encode() {
     // reversible 5/3 components, which is the only place where i_samples-as-
     // float consumers (t1_encode on subbands) are bypassed via sink_quantize.
     fdwt_2d_state_init(&states[i], u0, u1, v0, v1, xform, /*use_i32=*/false, fdwt_level_sink_fn, cx);
+    // Opt in to the planar horizontal fast path (taken only where the state
+    // allocated plane scratch: 9/7 float, even u0, full-warmup width).
+    states[i].put_planes = fdwt_level_sink_planes_fn;
   }
 }
 

--- a/source/core/transform/dwt.hpp
+++ b/source/core/transform/dwt.hpp
@@ -394,6 +394,13 @@ void idwt_1d_filtr_irrev97_planar_avx2(sprec_t *out, const sprec_t *lp, const sp
                                        int32_t u1);
 void idwt_1d_filtr_rev53_planar_i32_avx2(int32_t *out, const int32_t *lp, const int32_t *hp, int32_t u0,
                                          int32_t u1);
+// Encoder mirror: fused 9/7 horizontal FDWT reading the natural-domain row
+// (read-only, no PSE margins — boundary taps mirror within the row) and
+// writing LP/HP planes with plain stores.  Dispatched from emit_ready_f,
+// which guarantees: u0 even, u1/2 - u0/2 >= 16 (the 8-lane warmup loads
+// j = 0..15 unconditionally), lp/hp with >= 8 writable floats of slack past
+// their plane widths.
+void fdwt_1d_filtr_irrev97_planar_avx2(sprec_t *lp, sprec_t *hp, const sprec_t *in, int32_t u0, int32_t u1);
 #endif
 
 // WASM-SIMD DWT kernels (EMSCRIPTEN builds only, no NEON dependency).
@@ -702,6 +709,13 @@ static inline int32_t idwt_pse_source(int32_t p, int32_t v0, int32_t v1) {
 typedef void (*fdwt_row_sink_fn)(void *ctx, bool is_hp, int32_t abs_phys_row,
                                  const sprec_t *interleaved_row);
 
+// Planar variant: receives the horizontally-filtered row as separate LP/HP
+// planes (lp_row[j] = LP sample j, hp_row[j] = HP sample j), skipping the
+// interleave→deinterleave round trip.  Optional — only called when the state
+// owner sets fdwt_2d_state::put_planes and the planar kernel guards hold.
+typedef void (*fdwt_row_sink_planes_fn)(void *ctx, bool is_hp, int32_t abs_phys_row, const sprec_t *lp_row,
+                                        const sprec_t *hp_row);
+
 constexpr int32_t FDWT_STATE_RING_DEPTH = 12;
 
 struct fdwt_2d_state {
@@ -741,6 +755,15 @@ struct fdwt_2d_state {
   // ── sink ──────────────────────────────────────────────────────────────────
   fdwt_row_sink_fn put_row;
   void            *sink_ctx;
+
+  // ── planar horizontal fast path (9/7 float only) ──────────────────────────
+  // put_planes: optional planes sink set by the state owner (nullptr = off).
+  // planar_lp/planar_hp: per-state plane scratch (allocated by init when the
+  // geometry is planar-eligible; views into one allocation).  emit_ready_f
+  // takes the planar path only when put_planes and planar_lp are non-null.
+  fdwt_row_sink_planes_fn put_planes;
+  sprec_t *planar_lp;
+  sprec_t *planar_hp;
 };
 
 // Initialise (allocates ring_buf, PSE buffers, horiz_tmp).

--- a/source/core/transform/fdwt.cpp
+++ b/source/core/transform/fdwt.cpp
@@ -946,6 +946,23 @@ static void emit_ready_f(fdwt_2d_state *s) {
     // still reference r as a vertical-lifting neighbour).
     const sprec_t *ring_row = rptr_f(s, r);
 
+#if defined(OPENHTJ2K_ENABLE_AVX2)
+    // Planar 9/7 fast path: lift straight from the (read-only) ring row into
+    // LP/HP planes — no extension copy, no interleaved stores, and the sink
+    // consumes the planes without deinterleaving.  Eligibility was baked into
+    // the planar_lp allocation at init; put_planes is the owner's opt-in.
+    if (s->put_planes != nullptr && s->planar_lp != nullptr) {
+      fdwt_1d_filtr_irrev97_planar_avx2(s->planar_lp, s->planar_hp, ring_row, s->u0, s->u1);
+      s->put_planes(s->sink_ctx, is_hp, r, s->planar_lp, s->planar_hp);
+      ++s->next_emit;
+      while (s->ring_origin < s->next_emit - 4 && get_dl_f(s, s->ring_origin) >= mxdl) {
+        s->d_level[s->ring_origin % FDWT_STATE_RING_DEPTH] = -1;
+        ++s->ring_origin;
+      }
+      continue;
+    }
+#endif
+
     if (s->u1 == s->u0 + 1) {
       // Single-column: skip PSE/filter (PSEo has UB for length-1 signals).
       // Match fdwt_hor_sr_fixed: LP even u0 → no-op; HP odd u0 → *2 for 5/3.
@@ -1022,6 +1039,21 @@ void fdwt_2d_state_init(fdwt_2d_state *s,
   s->next_emit = v0;
   s->put_row   = sink_fn;
   s->sink_ctx  = sink_ctx;
+
+  // Planar horizontal fast path: plane scratch, allocated only when the
+  // geometry is eligible (9/7 float, even u0, wide enough for the 8-lane
+  // warmup).  put_planes stays null until the state owner opts in.
+  s->put_planes = nullptr;
+  s->planar_lp  = nullptr;
+  s->planar_hp  = nullptr;
+#if defined(OPENHTJ2K_ENABLE_AVX2)
+  if (transformation == 0 && !s->use_i32 && (u0 & 1) == 0 && (u1 / 2 - u0 / 2) >= 16) {
+    const int32_t plane_cap = s->stride / 2 + SIMD_PADDING;  // NL <= stride/2 + 1, + SIMD slack
+    s->planar_lp            = static_cast<sprec_t *>(
+        aligned_mem_alloc(2U * sizeof(sprec_t) * static_cast<size_t>(plane_cap), 32));
+    s->planar_hp = s->planar_lp + plane_cap;
+  }
+#endif
 }
 
 void fdwt_2d_state_free(fdwt_2d_state *s) {
@@ -1029,6 +1061,11 @@ void fdwt_2d_state_free(fdwt_2d_state *s) {
   aligned_mem_free(s->top_pse_buf); s->top_pse_buf = nullptr;
   aligned_mem_free(s->bot_pse_buf); s->bot_pse_buf = nullptr;
   aligned_mem_free(s->horiz_tmp);   s->horiz_tmp   = nullptr;
+  if (s->planar_lp != nullptr) {
+    aligned_mem_free(s->planar_lp);
+    s->planar_lp = nullptr;
+    s->planar_hp = nullptr;
+  }
 }
 
 void fdwt_2d_state_push_row(fdwt_2d_state *s, const sprec_t *in) {

--- a/source/core/transform/fdwt_avx2.cpp
+++ b/source/core/transform/fdwt_avx2.cpp
@@ -438,4 +438,103 @@ void fdwt_rev_ver_lp_step_i32_avx2(int32_t n, const int32_t *prev, const int32_t
   }
   for (; i < n; ++i) tgt[i] += (prev[i] + next[i] + 2) >> 2;
 }
+
+/********************************************************************************
+ * Planar horizontal FDWT — encoder mirror of the planar IDWT kernels.
+ *******************************************************************************/
+// Cross-element shifts with carry-in (same pattern as idwt_avx2.cpp; file-local).
+static inline __m256 fdwt_shl1_ps(__m256 a, __m256 b) {
+  __m256 t = _mm256_permute2f128_ps(a, b, 0x21);  // [a4..a7, b0..b3]
+  return _mm256_castsi256_ps(_mm256_alignr_epi8(_mm256_castps_si256(t), _mm256_castps_si256(a), 4));
+}
+static inline __m256 fdwt_shr1_ps(__m256 p, __m256 a) {
+  __m256 t = _mm256_permute2f128_ps(p, a, 0x21);  // [p4..p7, a0..a3]
+  return _mm256_castsi256_ps(_mm256_alignr_epi8(_mm256_castps_si256(a), _mm256_castps_si256(t), 12));
+}
+// Deinterleaving load of one block: e = even lanes in[2j..], o = odd lanes.
+// Same shuffle pattern as the float deinterleave in fdwt_level_sink_fn.
+static inline void fdwt_load_deint_ps(const float *p, __m256 &e, __m256 &o) {
+  const __m256i perm = _mm256_setr_epi32(0, 1, 4, 5, 2, 3, 6, 7);
+  __m256 a           = _mm256_loadu_ps(p);
+  __m256 b           = _mm256_loadu_ps(p + 8);
+  e                  = _mm256_permutevar8x32_ps(_mm256_shuffle_ps(a, b, 0x88), perm);
+  o                  = _mm256_permutevar8x32_ps(_mm256_shuffle_ps(a, b, 0xDD), perm);
+}
+
+// Fused single-pass 9/7 analysis, planar output.  Stage recurrences (even u0,
+// E[j] = in[2j], O[j] = in[2j+1], NL = ceil(u1/2)-u0/2, NH = u1/2-u0/2):
+//   T1[j] = O[j]  + fA*(E[j]    + E[j+1])   j in [-2, NL]
+//   T2[j] = E[j]  + fB*(T1[j-1] + T1[j])    j in [-1, NL]
+//   T3[j] = T1[j] + fC*(T2[j]   + T2[j+1])  j in [-1, NL-1]
+//   T4[j] = T2[j] + fD*(T3[j-1] + T3[j])    j in [ 0, NL-1]
+//   hp[j] = T3[j] (j < NH),  lp[j] = T4[j] (j < NL)
+// Each stage is the same single-rounded op as the in-place kernels: sum of
+// the two raw neighbors (left + right), then one fmadd — so the planar output
+// is bit-identical to filtering an extended copy with fdwt_1d_filtr_irrev97_*.
+// Boundary taps mirror within the row via PSEo, scalar warmup/drain only.
+// The input row is read-only (a live vertical-lifting ring row) and has no
+// PSE margins: the SIMD loop loads block n only while all raw lanes are in
+// range (8n+7 <= NH-1); the drain covers the rest with mirrored accessors.
+void fdwt_1d_filtr_irrev97_planar_avx2(sprec_t *lp, sprec_t *hp, const sprec_t *in, const int32_t u0,
+                                       const int32_t u1) {
+  const int32_t NH = u1 / 2 - u0 / 2;
+  const int32_t NL = ceil_int(u1, 2) - u0 / 2;
+  auto E           = [&](int32_t j) -> float { return in[PSEo(u0 + 2 * j, u0, u1) - u0]; };
+  auto O           = [&](int32_t j) -> float { return in[PSEo(u0 + 2 * j + 1, u0, u1) - u0]; };
+
+  const __m256 vA = _mm256_set1_ps(fA), vB = _mm256_set1_ps(fB);
+  const __m256 vC = _mm256_set1_ps(fC), vD = _mm256_set1_ps(fD);
+
+  // Warmup: boundary scalars, blocks 0/1 loads, T1/T2 of block 0.
+  const float t1m2 = std::fmaf(fA, E(-2) + E(-1), O(-2));  // T1[-2]
+  const float t1m1 = std::fmaf(fA, E(-1) + E(0), O(-1));   // T1[-1]
+  __m256 E0, O0, E1, O1;
+  fdwt_load_deint_ps(in, E0, O0);
+  fdwt_load_deint_ps(in + 16, E1, O1);
+  __m256 T1_0      = _mm256_fmadd_ps(_mm256_add_ps(E0, fdwt_shl1_ps(E0, E1)), vA, O0);
+  __m256 T2_0      = _mm256_fmadd_ps(_mm256_add_ps(fdwt_shr1_ps(_mm256_set1_ps(t1m1), T1_0), T1_0), vB, E0);
+  const float t2m1 = std::fmaf(fB, t1m2 + t1m1, E(-1));                   // T2[-1]
+  const float t3m1 = std::fmaf(fC, t2m1 + _mm256_cvtss_f32(T2_0), t1m1);  // T3[-1]
+
+  // Steady state: iteration n deinterleave-loads input block n and emits
+  // finished plane block n-2 with two plain stores.
+  __m256 E_nm1 = E1, O_nm1 = O1, T1_nm2 = T1_0, T2_nm2 = T2_0;
+  __m256 T3_nm3 = _mm256_set1_ps(t3m1);  // only its top lane is consumed (shr1)
+  int32_t n     = 2;
+  for (; 8 * n + 7 <= NH - 1; ++n) {
+    __m256 E_n, O_n;
+    fdwt_load_deint_ps(in + 16 * n, E_n, O_n);
+    __m256 T1_nm1 = _mm256_fmadd_ps(_mm256_add_ps(E_nm1, fdwt_shl1_ps(E_nm1, E_n)), vA, O_nm1);
+    __m256 T2_nm1 = _mm256_fmadd_ps(_mm256_add_ps(fdwt_shr1_ps(T1_nm2, T1_nm1), T1_nm1), vB, E_nm1);
+    __m256 T3_nm2 = _mm256_fmadd_ps(_mm256_add_ps(T2_nm2, fdwt_shl1_ps(T2_nm2, T2_nm1)), vC, T1_nm2);
+    __m256 T4_nm2 = _mm256_fmadd_ps(_mm256_add_ps(fdwt_shr1_ps(T3_nm3, T3_nm2), T3_nm2), vD, T2_nm2);
+    _mm256_storeu_ps(hp + 8 * (n - 2), T3_nm2);
+    _mm256_storeu_ps(lp + 8 * (n - 2), T4_nm2);
+    E_nm1  = E_n;
+    O_nm1  = O_n;
+    T1_nm2 = T1_nm1;
+    T2_nm2 = T2_nm1;
+    T3_nm3 = T3_nm2;
+  }
+
+  // Drain: scalar finish from the carried registers + mirrored accessors.
+  // P = 8*(n-2) is the first plane index not yet stored; the loop-exit bound
+  // gives NL - P <= 24, so window indices stay within the arrays.
+  {
+    const int32_t P    = 8 * (n - 2);
+    const int32_t base = P - 8;
+    float t1[48], t2[48], t3[48];
+    _mm256_storeu_ps(t1 + (P - base), T1_nm2);  // T1[P..P+7]
+    _mm256_storeu_ps(t2 + (P - base), T2_nm2);  // T2[P..P+7]
+    _mm256_storeu_ps(t3, T3_nm3);               // T3[P-8..P-1] (top lane = T3[P-1])
+    for (int32_t j = P + 8; j <= NL; ++j) t1[j - base] = std::fmaf(fA, E(j) + E(j + 1), O(j));
+    for (int32_t j = P + 8; j <= NL; ++j)
+      t2[j - base] = std::fmaf(fB, t1[j - base - 1] + t1[j - base], E(j));
+    for (int32_t j = P; j <= NL - 1; ++j)
+      t3[j - base] = std::fmaf(fC, t2[j - base] + t2[j - base + 1], t1[j - base]);
+    for (int32_t j = P; j <= NL - 1; ++j)
+      lp[j] = std::fmaf(fD, t3[j - base - 1] + t3[j - base], t2[j - base]);
+    for (int32_t j = P; j <= NH - 1; ++j) hp[j] = t3[j - base];
+  }
+}
 #endif

--- a/source/core/transform/fdwt_avx2.cpp
+++ b/source/core/transform/fdwt_avx2.cpp
@@ -479,8 +479,8 @@ void fdwt_1d_filtr_irrev97_planar_avx2(sprec_t *lp, sprec_t *hp, const sprec_t *
                                        const int32_t u1) {
   const int32_t NH = u1 / 2 - u0 / 2;
   const int32_t NL = ceil_int(u1, 2) - u0 / 2;
-  auto E           = [&](int32_t j) -> float { return in[PSEo(u0 + 2 * j, u0, u1) - u0]; };
-  auto O           = [&](int32_t j) -> float { return in[PSEo(u0 + 2 * j + 1, u0, u1) - u0]; };
+  auto E           = [&](int32_t j) -> float { return in[PSEo(u0 + 2 * j, u0, u1)]; };
+  auto O           = [&](int32_t j) -> float { return in[PSEo(u0 + 2 * j + 1, u0, u1)]; };
 
   const __m256 vA = _mm256_set1_ps(fA), vB = _mm256_set1_ps(fB);
   const __m256 vC = _mm256_set1_ps(fC), vD = _mm256_set1_ps(fD);


### PR DESCRIPTION
Encoder mirror of the planar IDWT port (#406–#409), per §7 of `docs/planar_idwt_porting.md`.

## Before / after

The streaming FDWT per emitted row did: ring row → `dwt_1d_extr_fixed` copy with PSE margins into `horiz_tmp` → in-place interleaved lifting (half-density slli-trick stores) → `fdwt_level_sink_fn` deinterleaves into LP/HP planes → quantize. The planar path collapses this to: ring row → fused planar kernel → planes → quantize. The extension copy and the interleave→deinterleave round trip disappear; only the input-side deinterleaving load remains (the irreducible half).

- **`fdwt_1d_filtr_irrev97_planar_avx2`** (`fdwt_avx2.cpp`): fused 4-stage 9/7 analysis pipeline, one deinterleaving load per 8-pair block, plain full-density plane stores, scalar warmup/drain with `PSEo`-mirrored boundary taps. The input ring row is read **only** — which is exactly why the copy existed (other rows still reference it as a vertical-lifting neighbour).
- **`fdwt_2d_state`** gains an optional planes sink (`put_planes`) plus plane scratch allocated only for eligible geometry (9/7 float, even `u0`, `u1/2−u0/2 ≥ 16`); `emit_ready_f` dispatches to it, everything else (rev 5/3, ATK, odd `u0`, narrow rows, single-column, the `v0==v1−1` flush) falls back to the unchanged in-place path.
- **`fdwt_level_sink_planes_fn`** (`coding_units.cpp`): the post-deinterleave half of `fdwt_level_sink_fn`, factored to take plane pointers; the legacy sink now routes through it after deinterleaving.

## Bit-exactness

Each kernel stage performs the same single-rounded operation as the in-place kernels — raw neighbour sum `(left + right)`, then one fused multiply-add — and boundary taps go through `PSEo` on the absolute position, so they read exactly the values the in-place kernel found in its PSE-filled margins. Verified: codestreams **byte-identical to main** on the 8K 12-bit fixture, lossy and lossless, single- and multi-threaded. Full ctest 407/407.

## Measured (8K 12-bit PPM, Ryzen 9 9950X, 1 thread, 30-iter interleaved A/B)

| | main | planar | Δ |
|---|---|---|---|
| lossy encode (median) | 385.3 ms | 376.8 ms | **−2.2%** |
| lossless encode | 360.6 ms | ~362–365 ms | +0.5–1.0% (see note) |

Hot-function shares (10-run profile): sink 7.5% → 4.9%, extension-copy `memmove` 4.9% → 3.3%; the planar kernel absorbs the lifting + input deinterleave at 5.1% (in-place kernel was 3.9% with the shuffles billed to the sink).

**Lossless note:** the reversible path executes no new code (rev 5/3 states allocate no plane scratch; output byte-identical; instruction count flat at +0.016%). The small wall delta is function-layout shift: the extra cycles sit in `emitFlat`, whose translation unit this PR does not touch — the same link-layout sensitivity documented in previous encoder work. It will reshuffle with any future size change.

Follow-ups (mirroring the decoder port's staging): dedicated AVX-512 kernel, NEON, WASM, and the rev 5/3 int32 planar variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)