### PR TITLE
perf(encoder): planar rev53 int32 horizontal FDWT lifting on AVX2

### DIFF
--- a/source/core/coding/coding_units.cpp
+++ b/source/core/coding/coding_units.cpp
@@ -728,15 +728,23 @@ static inline void sink_quantize_row_i32(const int32_t *src, int32_t sub_row, in
 // switched at the state level for reversible 5/3); we reinterpret_cast and
 // deinterleave as int32, write int32 into lp_tmp/hp_tmp, and call the int32
 // sink/memcpy/push paths.
-// Planar sink: same routing as the float path of fdwt_level_sink_fn below,
-// but receives the horizontal output as LP/HP planes straight from the planar
-// FDWT kernel — the interleave→deinterleave round trip is skipped entirely.
+// Planar sink: same routing as fdwt_level_sink_fn below, but receives the
+// horizontal output as LP/HP planes straight from the planar FDWT kernel —
+// the interleave→deinterleave round trip is skipped entirely.
+// When c->use_i32 is true the plane bytes are int32_t (reversible 5/3 pipe).
+// sizeof(int32_t) == sizeof(sprec_t), so the memcpy and child-push legs are
+// shared; only the quantize calls and the LL0 conversion branch on use_i32.
 static void fdwt_level_sink_planes_fn(void *ctx, bool is_hp, int32_t abs_row, const sprec_t *lp_row,
                                       const sprec_t *hp_row) {
   auto *c = static_cast<fdwt_level_sink_ctx *>(ctx);
 
-  // Strip-ring stamp (same contract as in fdwt_level_sink_fn; the equality
-  // guard makes a duplicate stamp from the other leg a no-op).
+  // Strip-ring stamp: re-stamp block->sample_buf at the first emitted row of
+  // each new cblk-row strip.  In the overlap path, hl_y0 == lh_y0 (asserted
+  // at setup), so both legs compute the same strip index for the same
+  // vertical position.  Whichever leg fires first for strip br does the
+  // stamp; the other leg short-circuits via the equality check.
+  // sink_quantize_row* reads block->sample_buf, so this must run BEFORE the
+  // sink_quantize_row* calls below.
   if (c->cb_h > 0 && c->sink_quantize) {
     const int32_t band_y0 = is_hp ? c->lh_y0 : c->hl_y0;
     const int32_t sub_row = (abs_row >> 1) - band_y0;
@@ -750,13 +758,37 @@ static void fdwt_level_sink_planes_fn(void *ctx, bool is_hp, int32_t abs_row, co
   if (!is_hp) {
     // LP vertical row: HP-horiz → HL, LP-horiz → child/LL0
     const int32_t hl_sub = (abs_row >> 1) - c->hl_y0;
-    if (c->sink_quantize)
-      sink_quantize_row(hp_row, hl_sub, 0, c);
-    else
+    if (c->sink_quantize) {
+      if (c->use_i32)
+        sink_quantize_row_i32(reinterpret_cast<const int32_t *>(hp_row), hl_sub, 0, c);
+      else
+        sink_quantize_row(hp_row, hl_sub, 0, c);
+    } else {
       memcpy(c->hl_samples + static_cast<ptrdiff_t>(hl_sub) * static_cast<ptrdiff_t>(c->hl_stride), hp_row,
              static_cast<size_t>(c->hp_width) * sizeof(sprec_t));
+    }
     if (c->has_child) {
-      fdwt_2d_state_push_row(c->child_state, lp_row);
+      fdwt_2d_state_push_row(c->child_state, lp_row);  // i32: bytes stay int32; child reads accordingly
+    } else if (c->use_i32) {
+      // Coarsest level: LL0 is sequentially t1_encoded after finalize and
+      // expects float in i_samples.  Convert int32 → float on this small row
+      // (subsampled by 2^NL, runs ≪ once per pushed input row).
+      const int32_t *lp_i  = reinterpret_cast<const int32_t *>(lp_row);
+      const int32_t ll_sub = (abs_row >> 1) - c->ll0_y0;
+      sprec_t *ll_dst =
+          c->ll0_samples + static_cast<ptrdiff_t>(ll_sub) * static_cast<ptrdiff_t>(c->ll0_stride);
+      int32_t k = 0;
+#if defined(__AVX2__)
+      for (; k + 7 < c->lp_width; k += 8) {
+        __m256 v = _mm256_cvtepi32_ps(_mm256_loadu_si256((const __m256i *)(lp_i + k)));
+        _mm256_storeu_ps(ll_dst + k, v);
+      }
+#elif defined(OPENHTJ2K_ENABLE_ARM_NEON)
+      for (; k + 3 < c->lp_width; k += 4) {
+        vst1q_f32(ll_dst + k, vcvtq_f32_s32(vld1q_s32(lp_i + k)));
+      }
+#endif
+      for (; k < c->lp_width; ++k) ll_dst[k] = static_cast<sprec_t>(lp_i[k]);
     } else {
       const int32_t ll_sub = (abs_row >> 1) - c->ll0_y0;
       memcpy(c->ll0_samples + static_cast<ptrdiff_t>(ll_sub) * static_cast<ptrdiff_t>(c->ll0_stride),
@@ -775,8 +807,13 @@ static void fdwt_level_sink_planes_fn(void *ctx, bool is_hp, int32_t abs_row, co
     // HP vertical row: LP-horiz → LH, HP-horiz → HH
     const int32_t hp_sub = (abs_row >> 1) - c->lh_y0;
     if (c->sink_quantize) {
-      sink_quantize_row(lp_row, hp_sub, 1, c);
-      sink_quantize_row(hp_row, hp_sub, 2, c);
+      if (c->use_i32) {
+        sink_quantize_row_i32(reinterpret_cast<const int32_t *>(lp_row), hp_sub, 1, c);
+        sink_quantize_row_i32(reinterpret_cast<const int32_t *>(hp_row), hp_sub, 2, c);
+      } else {
+        sink_quantize_row(lp_row, hp_sub, 1, c);
+        sink_quantize_row(hp_row, hp_sub, 2, c);
+      }
     } else {
       memcpy(c->lh_samples + static_cast<ptrdiff_t>(hp_sub) * static_cast<ptrdiff_t>(c->lh_stride), lp_row,
              static_cast<size_t>(c->lp_width) * sizeof(sprec_t));
@@ -795,27 +832,13 @@ static void fdwt_level_sink_planes_fn(void *ctx, bool is_hp, int32_t abs_row, co
   }
 }
 
+// Interleaved sink: deinterleaves the row into lp_tmp/hp_tmp (int32 or float
+// per c->use_i32), then routes through fdwt_level_sink_planes_fn above —
+// which also does the strip-ring stamp before any sink_quantize_row* call.
 static void fdwt_level_sink_fn(void *ctx, bool is_hp, int32_t abs_row, const sprec_t *interleaved_row) {
   auto *c = static_cast<fdwt_level_sink_ctx *>(ctx);
 
   const int32_t u_off = c->u0 & 1;
-
-  // Strip-ring stamp: re-stamp block->sample_buf at the
-  // first emitted row of each new cblk-row strip.  In the overlap path,
-  // hl_y0 == lh_y0 (asserted at setup), so both legs compute the same strip
-  // index for the same vertical position.  Whichever leg fires first for
-  // strip br does the stamp; the other leg short-circuits via the equality
-  // check.  sink_quantize_row* reads block->sample_buf, so this must run
-  // BEFORE the sink_quantize_row calls below.
-  if (c->cb_h > 0 && c->sink_quantize) {
-    const int32_t band_y0 = is_hp ? c->lh_y0 : c->hl_y0;
-    const int32_t sub_row = (abs_row >> 1) - band_y0;
-    const int32_t br_curr = sub_row / c->cb_h;
-    if (br_curr != c->last_stamped_br) {
-      stamp_strip_pointers(c, br_curr);
-      c->last_stamped_br = br_curr;
-    }
-  }
 
   if (c->use_i32) {
     const int32_t *intr_i = reinterpret_cast<const int32_t *>(interleaved_row);
@@ -864,66 +887,7 @@ static void fdwt_level_sink_fn(void *ctx, bool is_hp, int32_t abs_row, const spr
     for (int32_t i = 0; i < c->hp_width; ++i) hp_i[i] = hp_src[2 * i];
 #endif
 
-    if (!is_hp) {
-      const int32_t hl_sub = (abs_row >> 1) - c->hl_y0;
-      if (c->sink_quantize)
-        sink_quantize_row_i32(hp_i, hl_sub, 0, c);
-      else
-        memcpy(c->hl_samples + static_cast<ptrdiff_t>(hl_sub) * static_cast<ptrdiff_t>(c->hl_stride), hp_i,
-               static_cast<size_t>(c->hp_width) * sizeof(int32_t));
-      if (c->has_child) {
-        fdwt_2d_state_push_row(c->child_state,
-                               c->lp_tmp);  // lp_tmp bytes are int32; child use_i32 reads accordingly
-      } else {
-        // Coarsest level: LL0 is sequentially t1_encoded after finalize and
-        // expects float in i_samples.  Convert int32 → float on this small row
-        // (subsampled by 2^NL, runs ≪ once per pushed input row).
-        const int32_t ll_sub = (abs_row >> 1) - c->ll0_y0;
-        sprec_t *ll_dst =
-            c->ll0_samples + static_cast<ptrdiff_t>(ll_sub) * static_cast<ptrdiff_t>(c->ll0_stride);
-        int32_t k = 0;
-#if defined(__AVX2__)
-        for (; k + 7 < c->lp_width; k += 8) {
-          __m256 v = _mm256_cvtepi32_ps(_mm256_loadu_si256((const __m256i *)(lp_i + k)));
-          _mm256_storeu_ps(ll_dst + k, v);
-        }
-#elif defined(OPENHTJ2K_ENABLE_ARM_NEON)
-        for (; k + 3 < c->lp_width; k += 4) {
-          vst1q_f32(ll_dst + k, vcvtq_f32_s32(vld1q_s32(lp_i + k)));
-        }
-#endif
-        for (; k < c->lp_width; ++k) ll_dst[k] = static_cast<sprec_t>(lp_i[k]);
-      }
-      if (c->cb_h > 0) {
-        const int32_t br   = hl_sub / c->cb_h;
-        const int32_t last = std::min((br + 1) * c->cb_h, c->hl_h) - 1;
-        if (hl_sub == last) {
-          const uint8_t old =
-              c->cblk_row_done[static_cast<size_t>(br)].fetch_or(1, std::memory_order_acq_rel);
-          if ((old | 1) == 3) enc_overlap_dispatch(c, br);
-        }
-      }
-    } else {
-      const int32_t hp_sub = (abs_row >> 1) - c->lh_y0;
-      if (c->sink_quantize) {
-        sink_quantize_row_i32(lp_i, hp_sub, 1, c);
-        sink_quantize_row_i32(hp_i, hp_sub, 2, c);
-      } else {
-        memcpy(c->lh_samples + static_cast<ptrdiff_t>(hp_sub) * static_cast<ptrdiff_t>(c->lh_stride), lp_i,
-               static_cast<size_t>(c->lp_width) * sizeof(int32_t));
-        memcpy(c->hh_samples + static_cast<ptrdiff_t>(hp_sub) * static_cast<ptrdiff_t>(c->hh_stride), hp_i,
-               static_cast<size_t>(c->hp_width) * sizeof(int32_t));
-      }
-      if (c->cb_h > 0) {
-        const int32_t br   = hp_sub / c->cb_h;
-        const int32_t last = std::min((br + 1) * c->cb_h, c->lh_h) - 1;
-        if (hp_sub == last) {
-          const uint8_t old =
-              c->cblk_row_done[static_cast<size_t>(br)].fetch_or(2, std::memory_order_acq_rel);
-          if ((old | 2) == 3) enc_overlap_dispatch(c, br);
-        }
-      }
-    }
+    fdwt_level_sink_planes_fn(ctx, is_hp, abs_row, c->lp_tmp, c->hp_tmp);
     return;
   }
 
@@ -969,7 +933,7 @@ static void fdwt_level_sink_fn(void *ctx, bool is_hp, int32_t abs_row, const spr
 #endif
 
   // Route through the planes sink (identical logic; lp_tmp/hp_tmp now hold
-  // the deinterleaved planes).  The duplicate strip stamp is a guarded no-op.
+  // the deinterleaved planes).
   fdwt_level_sink_planes_fn(ctx, is_hp, abs_row, c->lp_tmp, c->hp_tmp);
 }
 
@@ -3377,7 +3341,8 @@ void j2k_tile_component::init_line_encode() {
     // float consumers (t1_encode on subbands) are bypassed via sink_quantize.
     fdwt_2d_state_init(&states[i], u0, u1, v0, v1, xform, /*use_i32=*/false, fdwt_level_sink_fn, cx);
     // Opt in to the planar horizontal fast path (taken only where the state
-    // allocated plane scratch: 9/7 float, even u0, full-warmup width).
+    // allocated plane scratch: 9/7 float or rev53 int32, even u0,
+    // full-warmup width).
     states[i].put_planes = fdwt_level_sink_planes_fn;
   }
 }

--- a/source/core/transform/dwt.hpp
+++ b/source/core/transform/dwt.hpp
@@ -401,6 +401,11 @@ void idwt_1d_filtr_rev53_planar_i32_avx2(int32_t *out, const int32_t *lp, const 
 // j = 0..15 unconditionally), lp/hp with >= 8 writable floats of slack past
 // their plane widths.
 void fdwt_1d_filtr_irrev97_planar_avx2(sprec_t *lp, sprec_t *hp, const sprec_t *in, int32_t u0, int32_t u1);
+// Reversible 5/3 int32 variant (lossless pipe), same dispatch guarantees as
+// the 9/7 planar kernel.  All shifts arithmetic — bit-exact vs the
+// interleaved fdwt_1d_filtr_rev53_i32_avx2 + sink-deinterleave path.
+void fdwt_1d_filtr_rev53_planar_i32_avx2(int32_t *lp, int32_t *hp, const int32_t *in, int32_t u0,
+                                         int32_t u1);
 #endif
 
 // WASM-SIMD DWT kernels (EMSCRIPTEN builds only, no NEON dependency).
@@ -713,6 +718,8 @@ typedef void (*fdwt_row_sink_fn)(void *ctx, bool is_hp, int32_t abs_phys_row,
 // planes (lp_row[j] = LP sample j, hp_row[j] = HP sample j), skipping the
 // interleave→deinterleave round trip.  Optional — only called when the state
 // owner sets fdwt_2d_state::put_planes and the planar kernel guards hold.
+// On the int32 pipe (use_i32) the plane bytes are int32_t behind the sprec_t
+// pointers, same as fdwt_row_sink_fn's interleaved_row.
 typedef void (*fdwt_row_sink_planes_fn)(void *ctx, bool is_hp, int32_t abs_phys_row, const sprec_t *lp_row,
                                         const sprec_t *hp_row);
 
@@ -756,11 +763,13 @@ struct fdwt_2d_state {
   fdwt_row_sink_fn put_row;
   void            *sink_ctx;
 
-  // ── planar horizontal fast path (9/7 float only) ──────────────────────────
+  // ── planar horizontal fast path (9/7 float + rev53 int32) ─────────────────
   // put_planes: optional planes sink set by the state owner (nullptr = off).
   // planar_lp/planar_hp: per-state plane scratch (allocated by init when the
   // geometry is planar-eligible; views into one allocation).  emit_ready_f
-  // takes the planar path only when put_planes and planar_lp are non-null.
+  // takes the planar path only when put_planes and planar_lp are non-null,
+  // and additionally requires use_i32 for rev53 (the int32 opt-in happens
+  // after init; a float rev53 state keeps the interleaved path).
   fdwt_row_sink_planes_fn put_planes;
   sprec_t *planar_lp;
   sprec_t *planar_hp;

--- a/source/core/transform/fdwt.cpp
+++ b/source/core/transform/fdwt.cpp
@@ -947,12 +947,21 @@ static void emit_ready_f(fdwt_2d_state *s) {
     const sprec_t *ring_row = rptr_f(s, r);
 
 #if defined(OPENHTJ2K_ENABLE_AVX2)
-    // Planar 9/7 fast path: lift straight from the (read-only) ring row into
-    // LP/HP planes — no extension copy, no interleaved stores, and the sink
-    // consumes the planes without deinterleaving.  Eligibility was baked into
-    // the planar_lp allocation at init; put_planes is the owner's opt-in.
-    if (s->put_planes != nullptr && s->planar_lp != nullptr) {
-      fdwt_1d_filtr_irrev97_planar_avx2(s->planar_lp, s->planar_hp, ring_row, s->u0, s->u1);
+    // Planar fast path (9/7 float + rev53 int32): lift straight from the
+    // (read-only) ring row into LP/HP planes — no extension copy, no
+    // interleaved stores, and the sink consumes the planes without
+    // deinterleaving.  Eligibility was baked into the planar_lp allocation at
+    // init; put_planes is the owner's opt-in.  rev53 additionally requires
+    // the int32 pipe: use_i32 flips after init, so a float rev53 state falls
+    // through to the interleaved path below.
+    if (s->put_planes != nullptr && s->planar_lp != nullptr && (s->transformation == 0 || s->use_i32)) {
+      if (s->use_i32) {
+        fdwt_1d_filtr_rev53_planar_i32_avx2(reinterpret_cast<int32_t *>(s->planar_lp),
+                                            reinterpret_cast<int32_t *>(s->planar_hp),
+                                            reinterpret_cast<const int32_t *>(ring_row), s->u0, s->u1);
+      } else {
+        fdwt_1d_filtr_irrev97_planar_avx2(s->planar_lp, s->planar_hp, ring_row, s->u0, s->u1);
+      }
       s->put_planes(s->sink_ctx, is_hp, r, s->planar_lp, s->planar_hp);
       ++s->next_emit;
       while (s->ring_origin < s->next_emit - 4 && get_dl_f(s, s->ring_origin) >= mxdl) {
@@ -1041,13 +1050,15 @@ void fdwt_2d_state_init(fdwt_2d_state *s,
   s->sink_ctx  = sink_ctx;
 
   // Planar horizontal fast path: plane scratch, allocated only when the
-  // geometry is eligible (9/7 float, even u0, wide enough for the 8-lane
-  // warmup).  put_planes stays null until the state owner opts in.
+  // geometry is eligible (9/7 float or rev53, even u0, wide enough for the
+  // 8-lane warmup).  put_planes stays null until the state owner opts in.
+  // For rev53 the allocation is eager: the int32 opt-in (use_i32) flips after
+  // init, so emit_ready_f gates the rev53 leg on use_i32 at emit time.
   s->put_planes = nullptr;
   s->planar_lp  = nullptr;
   s->planar_hp  = nullptr;
 #if defined(OPENHTJ2K_ENABLE_AVX2)
-  if (transformation == 0 && !s->use_i32 && (u0 & 1) == 0 && (u1 / 2 - u0 / 2) >= 16) {
+  if (transformation <= 1 && (u0 & 1) == 0 && (u1 / 2 - u0 / 2) >= 16) {
     const int32_t plane_cap = s->stride / 2 + SIMD_PADDING;  // NL <= stride/2 + 1, + SIMD slack
     s->planar_lp            = static_cast<sprec_t *>(
         aligned_mem_alloc(2U * sizeof(sprec_t) * static_cast<size_t>(plane_cap), 32));

--- a/source/core/transform/fdwt_avx2.cpp
+++ b/source/core/transform/fdwt_avx2.cpp
@@ -537,4 +537,78 @@ void fdwt_1d_filtr_irrev97_planar_avx2(sprec_t *lp, sprec_t *hp, const sprec_t *
     for (int32_t j = P; j <= NH - 1; ++j) hp[j] = t3[j - base];
   }
 }
+
+// Integer counterparts of the cross-element shift / deinterleave helpers
+// (same lane movement; alignr is byte-granular so the epi32 versions are the
+// identical shuffle sequence on integer registers).
+static inline __m256i fdwt_shl1_epi32(__m256i a, __m256i b) {
+  __m256i t = _mm256_permute2x128_si256(a, b, 0x21);  // [a4..a7, b0..b3]
+  return _mm256_alignr_epi8(t, a, 4);
+}
+static inline __m256i fdwt_shr1_epi32(__m256i p, __m256i a) {
+  __m256i t = _mm256_permute2x128_si256(p, a, 0x21);  // [p4..p7, a0..a3]
+  return _mm256_alignr_epi8(a, t, 12);
+}
+static inline void fdwt_load_deint_epi32(const int32_t *p, __m256i &e, __m256i &o) {
+  __m256 ef, of;
+  fdwt_load_deint_ps(reinterpret_cast<const float *>(p), ef, of);
+  e = _mm256_castps_si256(ef);
+  o = _mm256_castps_si256(of);
+}
+
+// Fused single-pass reversible 5/3 analysis, planar int32 output (lossless
+// pipe).  Stage recurrences (even u0, E[j] = in[2j], O[j] = in[2j+1],
+// NL = ceil(u1/2)-u0/2, NH = u1/2-u0/2, all shifts arithmetic — exact match
+// to the interleaved fdwt_1d_filtr_rev53_i32_avx2 lifting):
+//   T1[j] = O[j] - ((E[j]    + E[j+1]) >> 1)      j in [-1, NL-1]
+//   T2[j] = E[j] + ((T1[j-1] + T1[j] + 2) >> 2)   j in [ 0, NL-1]
+//   hp[j] = T1[j] (j < NH),  lp[j] = T2[j] (j < NL)
+void fdwt_1d_filtr_rev53_planar_i32_avx2(int32_t *lp, int32_t *hp, const int32_t *in, const int32_t u0,
+                                         const int32_t u1) {
+  const int32_t NH = u1 / 2 - u0 / 2;
+  const int32_t NL = ceil_int(u1, 2) - u0 / 2;
+  auto E           = [&](int32_t j) -> int32_t { return in[PSEo(u0 + 2 * j, u0, u1) - u0]; };
+  auto O           = [&](int32_t j) -> int32_t { return in[PSEo(u0 + 2 * j + 1, u0, u1) - u0]; };
+
+  const __m256i vtwo = _mm256_set1_epi32(2);
+
+  // Warmup: boundary scalar T1[-1], block 0 load.
+  const int32_t t1m1 = O(-1) - ((E(-1) + E(0)) >> 1);
+  __m256i E_nm1, O_nm1;
+  fdwt_load_deint_epi32(in, E_nm1, O_nm1);
+  __m256i T1_nm2 = _mm256_set1_epi32(t1m1);  // only its top lane is consumed (shr1)
+
+  // Steady state: iteration n deinterleave-loads input block n and emits
+  // finished plane block n-1 with two plain stores.
+  int32_t n = 1;
+  for (; 8 * n + 7 <= NH - 1; ++n) {
+    __m256i E_n, O_n;
+    fdwt_load_deint_epi32(in + 16 * n, E_n, O_n);
+    __m256i T1_nm1 =
+        _mm256_sub_epi32(O_nm1, _mm256_srai_epi32(_mm256_add_epi32(E_nm1, fdwt_shl1_epi32(E_nm1, E_n)), 1));
+    __m256i T2_nm1 = _mm256_add_epi32(
+        E_nm1, _mm256_srai_epi32(
+                   _mm256_add_epi32(_mm256_add_epi32(fdwt_shr1_epi32(T1_nm2, T1_nm1), T1_nm1), vtwo), 2));
+    _mm256_storeu_si256(reinterpret_cast<__m256i *>(hp + 8 * (n - 1)), T1_nm1);
+    _mm256_storeu_si256(reinterpret_cast<__m256i *>(lp + 8 * (n - 1)), T2_nm1);
+    E_nm1  = E_n;
+    O_nm1  = O_n;
+    T1_nm2 = T1_nm1;
+  }
+
+  // Drain: scalar finish from the carried boundary lane + mirrored accessors.
+  // P = 8*(n-1) is the first plane index not yet stored; the loop-exit bound
+  // gives NH - P <= 15, so NL - P <= 16 and t1buf stays within bounds.
+  {
+    const int32_t P       = 8 * (n - 1);
+    const int32_t t1_prev = _mm256_extract_epi32(T1_nm2, 7);  // T1[P-1] (== t1m1 when P == 0)
+    int32_t t1buf[16];
+    for (int32_t j = P; j <= NL - 1; ++j) t1buf[j - P] = O(j) - ((E(j) + E(j + 1)) >> 1);
+    for (int32_t j = P; j <= NH - 1; ++j) hp[j] = t1buf[j - P];
+    for (int32_t j = P; j <= NL - 1; ++j) {
+      const int32_t t1l = (j == P) ? t1_prev : t1buf[j - P - 1];
+      lp[j]             = E(j) + ((t1l + t1buf[j - P] + 2) >> 2);
+    }
+  }
+}
 #endif

--- a/source/core/transform/fdwt_avx2.cpp
+++ b/source/core/transform/fdwt_avx2.cpp
@@ -567,8 +567,8 @@ void fdwt_1d_filtr_rev53_planar_i32_avx2(int32_t *lp, int32_t *hp, const int32_t
                                          const int32_t u1) {
   const int32_t NH = u1 / 2 - u0 / 2;
   const int32_t NL = ceil_int(u1, 2) - u0 / 2;
-  auto E           = [&](int32_t j) -> int32_t { return in[PSEo(u0 + 2 * j, u0, u1) - u0]; };
-  auto O           = [&](int32_t j) -> int32_t { return in[PSEo(u0 + 2 * j + 1, u0, u1) - u0]; };
+  auto E           = [&](int32_t j) -> int32_t { return in[PSEo(u0 + 2 * j, u0, u1)]; };
+  auto O           = [&](int32_t j) -> int32_t { return in[PSEo(u0 + 2 * j + 1, u0, u1)]; };
 
   const __m256i vtwo = _mm256_set1_epi32(2);
 


### PR DESCRIPTION
## Summary

Extends the planar horizontal FDWT fast path (#412) to the reversible 5/3 int32 pipe, accelerating **lossless** encode. Stacked on #412 (`perf/planar-fdwt-avx2`); only the last commit is new.

- New fused single-pass kernel `fdwt_1d_filtr_rev53_planar_i32_avx2`: lifts the ring row directly into LP/HP int32 planes. All lifting uses arithmetic shifts, exactly matching the interleaved `fdwt_1d_filtr_rev53_i32_avx2` semantics, so output is bit-exact by construction.
- The planes sink consumes LP/HP planes directly — the extension copy, interleaved in-place filter, and sink-side deinterleave are all skipped on eligible rows.
- Plane scratch is now also allocated for rev53 states. The int32 opt-in (`use_i32`) flips after state init, so `emit_ready_f` gates the rev53 leg on `use_i32` at emit time; a float rev53 state falls through to the interleaved path unchanged.
- `fdwt_level_sink_fn`'s int32 routing moves into `fdwt_level_sink_planes_fn`, which both sinks now share (the memcpy/child-push legs are element-size agnostic since `sizeof(int32_t) == sizeof(sprec_t)`); only the quantize calls and the LL0 int→float conversion branch on `use_i32`. This mirrors how the float path was already routed.

## Measurements

8K 12-bit PPM (7680×4320), Ryzen 9 9950X, lossless (`Creversible=yes`), 30-iter interleaved A/B:

| | base (#412) | this PR | delta |
|---|---|---|---|
| 1 thread | 345.5 ms | 334.4 ms | **−3.2%** |
| all threads | 192.8 ms | 186.3 ms | **−3.4%** |

`instructions:u` −1.4% (real work reduction, not link-layout shift). maxrss +0.5 MB (205.0 → 205.5 MB) from the eager per-level plane scratch. Lossy timing unaffected (path unchanged).

## Verification

- Codestreams **byte-identical** to base for lossy + lossless × single/multi-thread on the 8K fixture.
- 407/407 ctest.
- perf confirms the planar kernel is on the lossless hot path (interleaved rev53 filter + deinterleave no longer appear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)