### PR TITLE
perf(encoder): planar LP/HP horizontal FDWT lifting on NEON

### DIFF
--- a/source/core/transform/dwt.hpp
+++ b/source/core/transform/dwt.hpp
@@ -247,6 +247,13 @@ void fdwt_rev_ver_lp_step_neon(int32_t n, const float *prev, const float *next, 
 void fdwt_1d_filtr_rev53_i32_neon(int32_t *X, int32_t left, int32_t u_i0, int32_t u_i1);
 void fdwt_rev_ver_hp_step_i32_neon(int32_t n, const int32_t *prev, const int32_t *next, int32_t *tgt);
 void fdwt_rev_ver_lp_step_i32_neon(int32_t n, const int32_t *prev, const int32_t *next, int32_t *tgt);
+// Encoder planar mirror (see the AVX2 declarations below for the contract):
+// fused horizontal FDWT reading the natural-domain ring row, writing LP/HP
+// planes.  Dispatched from emit_ready_f, which guarantees u0 even and
+// u1/2 - u0/2 >= 12 (the 4-lane 9/7 warmup loads j = 0..7 unconditionally).
+void fdwt_1d_filtr_irrev97_planar_neon(sprec_t *lp, sprec_t *hp, const sprec_t *in, int32_t u0, int32_t u1);
+void fdwt_1d_filtr_rev53_planar_i32_neon(int32_t *lp, int32_t *hp, const int32_t *in, int32_t u0,
+                                         int32_t u1);
 
 #elif defined(OPENHTJ2K_ENABLE_AVX2)
 void fdwt_1d_filtr_irrev97_fixed_avx2(sprec_t *X, const int32_t left, const int32_t u_i0,

--- a/source/core/transform/fdwt.cpp
+++ b/source/core/transform/fdwt.cpp
@@ -990,6 +990,25 @@ static void emit_ready_f(fdwt_2d_state *s) {
       }
       continue;
     }
+#elif defined(OPENHTJ2K_ENABLE_ARM_NEON)
+    // Planar fast path, 4-lane NEON — same structure and gating as the AVX2
+    // block above (vld2q gives the deinterleaved E/O planes natively).
+    if (s->put_planes != nullptr && s->planar_lp != nullptr && (s->transformation == 0 || s->use_i32)) {
+      if (s->use_i32) {
+        fdwt_1d_filtr_rev53_planar_i32_neon(reinterpret_cast<int32_t *>(s->planar_lp),
+                                            reinterpret_cast<int32_t *>(s->planar_hp),
+                                            reinterpret_cast<const int32_t *>(ring_row), s->u0, s->u1);
+      } else {
+        fdwt_1d_filtr_irrev97_planar_neon(s->planar_lp, s->planar_hp, ring_row, s->u0, s->u1);
+      }
+      s->put_planes(s->sink_ctx, is_hp, r, s->planar_lp, s->planar_hp);
+      ++s->next_emit;
+      while (s->ring_origin < s->next_emit - 4 && get_dl_f(s, s->ring_origin) >= mxdl) {
+        s->d_level[s->ring_origin % FDWT_STATE_RING_DEPTH] = -1;
+        ++s->ring_origin;
+      }
+      continue;
+    }
 #endif
 
     if (s->u1 == s->u0 + 1) {
@@ -1071,14 +1090,23 @@ void fdwt_2d_state_init(fdwt_2d_state *s,
 
   // Planar horizontal fast path: plane scratch, allocated only when the
   // geometry is eligible (9/7 float or rev53, even u0, wide enough for the
-  // 8-lane warmup).  put_planes stays null until the state owner opts in.
-  // For rev53 the allocation is eager: the int32 opt-in (use_i32) flips after
-  // init, so emit_ready_f gates the rev53 leg on use_i32 at emit time.
+  // kernels' unconditional warmup loads).  put_planes stays null until the
+  // state owner opts in.  For rev53 the allocation is eager: the int32
+  // opt-in (use_i32) flips after init, so emit_ready_f gates the rev53 leg
+  // on use_i32 at emit time.
   s->put_planes = nullptr;
   s->planar_lp  = nullptr;
   s->planar_hp  = nullptr;
-#if defined(OPENHTJ2K_ENABLE_AVX2)
-  if (transformation <= 1 && (u0 & 1) == 0 && (u1 / 2 - u0 / 2) >= 16) {
+#if defined(OPENHTJ2K_ENABLE_AVX2) || defined(OPENHTJ2K_ENABLE_ARM_NEON)
+  // Minimum N = u1/2 - u0/2: 16 on AVX2 (the 8-lane 9/7 warmup loads
+  // j = 0..15), 12 on NEON (4-lane warmup loads j = 0..7; same guard as the
+  // decoder's planar dispatch).
+  #if defined(OPENHTJ2K_ENABLE_AVX2)
+  constexpr int32_t planar_min_n = 16;
+  #else
+  constexpr int32_t planar_min_n = 12;
+  #endif
+  if (transformation <= 1 && (u0 & 1) == 0 && (u1 / 2 - u0 / 2) >= planar_min_n) {
     const int32_t plane_cap = s->stride / 2 + SIMD_PADDING;  // NL <= stride/2 + 1, + SIMD slack
     s->planar_lp            = static_cast<sprec_t *>(
         aligned_mem_alloc(2U * sizeof(sprec_t) * static_cast<size_t>(plane_cap), 32));

--- a/source/core/transform/fdwt_neon.cpp
+++ b/source/core/transform/fdwt_neon.cpp
@@ -500,4 +500,142 @@ void fdwt_rev_ver_lp_step_i32_neon(int32_t n, const int32_t *prev, const int32_t
   }
   for (; i < n; ++i) tgt[i] += (prev[i] + next[i] + 2) >> 2;
 }
+
+  /********************************************************************************
+   * Planar horizontal FDWT — encoder mirror of the planar IDWT kernels
+   * (idwt_neon.cpp).  The natural-domain ring row is read with vld2q (native
+   * deinterleave: E[j] = in[2j], O[j] = in[2j+1]) and the LP/HP planes are
+   * written with plain vst1q stores — the interleaved in-place filter, its PSE
+   * extension copy, and the sink-side deinterleave all disappear.  Boundary
+   * taps mirror within the row via PSEo.  Every 9/7 lifting stage is the same
+   * single-rounded vfmaq_f32 / std::fmaf sequence per element as the in-place
+   * NEON kernel; the rev53 kernel is exact integer arithmetic.
+   *******************************************************************************/
+  // MSVC ARM64 noinline mirror — see the rationale in idwt_neon.cpp.
+  #if defined(_MSC_VER) && defined(_M_ARM64)
+    #define OPENHTJ2K_MSVC_ARM64_NOINLINE_F __declspec(noinline)
+  #else
+    #define OPENHTJ2K_MSVC_ARM64_NOINLINE_F
+  #endif
+
+// Fused single-pass 9/7 analysis, planar output.  Stage recurrences (even u0,
+// NL = ceil(u1/2)-u0/2, NH = u1/2-u0/2):
+//   T1[j] = O[j]  + fA*(E[j]    + E[j+1])   j in [-2, NL]
+//   T2[j] = E[j]  + fB*(T1[j-1] + T1[j])    j in [-1, NL]
+//   T3[j] = T1[j] + fC*(T2[j]   + T2[j+1])  j in [-1, NL-1]
+//   T4[j] = T2[j] + fD*(T3[j-1] + T3[j])    j in [ 0, NL-1]
+//   hp[j] = T3[j] (j < NH),  lp[j] = T4[j] (j < NL)
+OPENHTJ2K_MSVC_ARM64_NOINLINE_F void fdwt_1d_filtr_irrev97_planar_neon(sprec_t *lp, sprec_t *hp,
+                                                                       const sprec_t *in, const int32_t u0,
+                                                                       const int32_t u1) {
+  const int32_t NH = u1 / 2 - u0 / 2;
+  const int32_t NL = ceil_int(u1, 2) - u0 / 2;
+  auto E           = [&](int32_t j) -> float { return in[PSEo(u0 + 2 * j, u0, u1) - u0]; };
+  auto O           = [&](int32_t j) -> float { return in[PSEo(u0 + 2 * j + 1, u0, u1) - u0]; };
+
+  const float32x4_t vA = vdupq_n_f32(fA), vB = vdupq_n_f32(fB);
+  const float32x4_t vC = vdupq_n_f32(fC), vD = vdupq_n_f32(fD);
+
+  // Warmup: boundary scalars, blocks 0/1 loads, T1/T2 of block 0.
+  const float t1m2 = std::fmaf(fA, E(-2) + E(-1), O(-2));  // T1[-2]
+  const float t1m1 = std::fmaf(fA, E(-1) + E(0), O(-1));   // T1[-1]
+  float32x4x2_t b0 = vld2q_f32(in);                        // E/O block 0
+  float32x4x2_t b1 = vld2q_f32(in + 8);                    // E/O block 1
+  float32x4_t T1_0 = vfmaq_f32(b0.val[1], vaddq_f32(b0.val[0], vextq_f32(b0.val[0], b1.val[0], 1)), vA);
+  float32x4_t T2_0 = vfmaq_f32(b0.val[0], vaddq_f32(vextq_f32(vdupq_n_f32(t1m1), T1_0, 3), T1_0), vB);
+  const float t2m1 = std::fmaf(fB, t1m2 + t1m1, E(-1));                    // T2[-1]
+  const float t3m1 = std::fmaf(fC, t2m1 + vgetq_lane_f32(T2_0, 0), t1m1);  // T3[-1]
+
+  // Steady state: iteration n vld2q-loads input block n and emits finished
+  // plane block n-2 with two plain stores.
+  float32x4_t E_nm1 = b1.val[0], O_nm1 = b1.val[1], T1_nm2 = T1_0, T2_nm2 = T2_0;
+  float32x4_t T3_nm3 = vdupq_n_f32(t3m1);  // only its top lane is consumed (shr1)
+  int32_t n          = 2;
+  for (; 4 * n + 3 <= NH - 1; ++n) {
+    float32x4x2_t bn   = vld2q_f32(in + 8 * n);
+    float32x4_t T1_nm1 = vfmaq_f32(O_nm1, vaddq_f32(E_nm1, vextq_f32(E_nm1, bn.val[0], 1)), vA);
+    float32x4_t T2_nm1 = vfmaq_f32(E_nm1, vaddq_f32(vextq_f32(T1_nm2, T1_nm1, 3), T1_nm1), vB);
+    float32x4_t T3_nm2 = vfmaq_f32(T1_nm2, vaddq_f32(T2_nm2, vextq_f32(T2_nm2, T2_nm1, 1)), vC);
+    float32x4_t T4_nm2 = vfmaq_f32(T2_nm2, vaddq_f32(vextq_f32(T3_nm3, T3_nm2, 3), T3_nm2), vD);
+    vst1q_f32(hp + 4 * (n - 2), T3_nm2);
+    vst1q_f32(lp + 4 * (n - 2), T4_nm2);
+    E_nm1  = bn.val[0];
+    O_nm1  = bn.val[1];
+    T1_nm2 = T1_nm1;
+    T2_nm2 = T2_nm1;
+    T3_nm3 = T3_nm2;
+  }
+
+  // Drain: scalar finish from the carried registers + mirrored accessors.
+  // P = 4*(n-2) is the first plane index not yet stored; the loop-exit bound
+  // gives NL - P <= 12, so with base = P - 4 every stage index fits in 24.
+  {
+    const int32_t P    = 4 * (n - 2);
+    const int32_t base = P - 4;
+    float t1[24], t2[24], t3[24];
+    vst1q_f32(t1 + (P - base), T1_nm2);  // T1[P..P+3]
+    vst1q_f32(t2 + (P - base), T2_nm2);  // T2[P..P+3]
+    vst1q_f32(t3, T3_nm3);               // T3[P-4..P-1] (top lane = T3[P-1])
+    for (int32_t j = P + 4; j <= NL; ++j) t1[j - base] = std::fmaf(fA, E(j) + E(j + 1), O(j));
+    for (int32_t j = P + 4; j <= NL; ++j)
+      t2[j - base] = std::fmaf(fB, t1[j - base - 1] + t1[j - base], E(j));
+    for (int32_t j = P; j <= NL - 1; ++j)
+      t3[j - base] = std::fmaf(fC, t2[j - base] + t2[j - base + 1], t1[j - base]);
+    for (int32_t j = P; j <= NL - 1; ++j)
+      lp[j] = std::fmaf(fD, t3[j - base - 1] + t3[j - base], t2[j - base]);
+    for (int32_t j = P; j <= NH - 1; ++j) hp[j] = t3[j - base];
+  }
+}
+
+// Fused single-pass reversible 5/3 analysis, planar int32 output (lossless
+// pipe).  All shifts arithmetic — exact match to the interleaved
+// fdwt_1d_filtr_rev53_i32_neon lifting:
+//   T1[j] = O[j] - ((E[j]    + E[j+1]) >> 1)      j in [-1, NL-1]
+//   T2[j] = E[j] + ((T1[j-1] + T1[j] + 2) >> 2)   j in [ 0, NL-1]
+//   hp[j] = T1[j] (j < NH),  lp[j] = T2[j] (j < NL)
+void fdwt_1d_filtr_rev53_planar_i32_neon(int32_t *lp, int32_t *hp, const int32_t *in, const int32_t u0,
+                                         const int32_t u1) {
+  const int32_t NH = u1 / 2 - u0 / 2;
+  const int32_t NL = ceil_int(u1, 2) - u0 / 2;
+  auto E           = [&](int32_t j) -> int32_t { return in[PSEo(u0 + 2 * j, u0, u1) - u0]; };
+  auto O           = [&](int32_t j) -> int32_t { return in[PSEo(u0 + 2 * j + 1, u0, u1) - u0]; };
+
+  const int32x4_t vtwo = vdupq_n_s32(2);
+
+  // Warmup: boundary scalar T1[-1], block 0 load.
+  const int32_t t1m1 = O(-1) - ((E(-1) + E(0)) >> 1);
+  int32x4x2_t b0     = vld2q_s32(in);  // E/O block 0
+  int32x4_t E_nm1 = b0.val[0], O_nm1 = b0.val[1];
+  int32x4_t T1_nm2 = vdupq_n_s32(t1m1);  // only its top lane is consumed (shr1)
+
+  // Steady state: iteration n vld2q-loads input block n and emits finished
+  // plane block n-1 with two plain stores.
+  int32_t n = 1;
+  for (; 4 * n + 3 <= NH - 1; ++n) {
+    int32x4x2_t bn   = vld2q_s32(in + 8 * n);
+    int32x4_t T1_nm1 = vsubq_s32(O_nm1, vshrq_n_s32(vaddq_s32(E_nm1, vextq_s32(E_nm1, bn.val[0], 1)), 1));
+    int32x4_t T2_nm1 =
+        vaddq_s32(E_nm1, vshrq_n_s32(vaddq_s32(vaddq_s32(vextq_s32(T1_nm2, T1_nm1, 3), T1_nm1), vtwo), 2));
+    vst1q_s32(hp + 4 * (n - 1), T1_nm1);
+    vst1q_s32(lp + 4 * (n - 1), T2_nm1);
+    E_nm1  = bn.val[0];
+    O_nm1  = bn.val[1];
+    T1_nm2 = T1_nm1;
+  }
+
+  // Drain: scalar finish from the carried boundary lane + mirrored accessors.
+  // P = 4*(n-1) is the first plane index not yet stored; the loop-exit bound
+  // gives NH - P <= 7, so NL - P <= 8 and t1buf stays within bounds.
+  {
+    const int32_t P       = 4 * (n - 1);
+    const int32_t t1_prev = vgetq_lane_s32(T1_nm2, 3);  // T1[P-1] (== t1m1 when P == 0)
+    int32_t t1buf[8];
+    for (int32_t j = P; j <= NL - 1; ++j) t1buf[j - P] = O(j) - ((E(j) + E(j + 1)) >> 1);
+    for (int32_t j = P; j <= NH - 1; ++j) hp[j] = t1buf[j - P];
+    for (int32_t j = P; j <= NL - 1; ++j) {
+      const int32_t t1l = (j == P) ? t1_prev : t1buf[j - P - 1];
+      lp[j]             = E(j) + ((t1l + t1buf[j - P] + 2) >> 2);
+    }
+  }
+}
 #endif

--- a/source/core/transform/fdwt_neon.cpp
+++ b/source/core/transform/fdwt_neon.cpp
@@ -530,8 +530,8 @@ OPENHTJ2K_MSVC_ARM64_NOINLINE_F void fdwt_1d_filtr_irrev97_planar_neon(sprec_t *
                                                                        const int32_t u1) {
   const int32_t NH = u1 / 2 - u0 / 2;
   const int32_t NL = ceil_int(u1, 2) - u0 / 2;
-  auto E           = [&](int32_t j) -> float { return in[PSEo(u0 + 2 * j, u0, u1) - u0]; };
-  auto O           = [&](int32_t j) -> float { return in[PSEo(u0 + 2 * j + 1, u0, u1) - u0]; };
+  auto E           = [&](int32_t j) -> float { return in[PSEo(u0 + 2 * j, u0, u1)]; };
+  auto O           = [&](int32_t j) -> float { return in[PSEo(u0 + 2 * j + 1, u0, u1)]; };
 
   const float32x4_t vA = vdupq_n_f32(fA), vB = vdupq_n_f32(fB);
   const float32x4_t vC = vdupq_n_f32(fC), vD = vdupq_n_f32(fD);
@@ -597,8 +597,8 @@ void fdwt_1d_filtr_rev53_planar_i32_neon(int32_t *lp, int32_t *hp, const int32_t
                                          const int32_t u1) {
   const int32_t NH = u1 / 2 - u0 / 2;
   const int32_t NL = ceil_int(u1, 2) - u0 / 2;
-  auto E           = [&](int32_t j) -> int32_t { return in[PSEo(u0 + 2 * j, u0, u1) - u0]; };
-  auto O           = [&](int32_t j) -> int32_t { return in[PSEo(u0 + 2 * j + 1, u0, u1) - u0]; };
+  auto E           = [&](int32_t j) -> int32_t { return in[PSEo(u0 + 2 * j, u0, u1)]; };
+  auto O           = [&](int32_t j) -> int32_t { return in[PSEo(u0 + 2 * j + 1, u0, u1)]; };
 
   const int32x4_t vtwo = vdupq_n_s32(2);
 


### PR DESCRIPTION
## Summary

Ports the planar horizontal FDWT fast path (#412–#414) to 4-lane NEON, mirroring the decoder's NEON planar IDWT kernels (#406). Stacked on #414; only the last commit is new.

- The natural-domain ring row is read with `vld2q` (native E/O deinterleave — the input side is nearly free on NEON), and the LP/HP planes are written with plain `vst1q` stores. The PSE extension copy, the interleaved in-place filter, and the sink-side deinterleave all disappear on eligible rows.
- Every 9/7 lifting stage is the same single-rounded `vfmaq_f32` / `std::fmaf` sequence per element as the in-place NEON kernel, and the rev53 kernel is exact integer arithmetic, so planar and interleaved paths stay bit-identical per platform.
- Geometry guard `N = u1/2 - u0/2 >= 12`, matching the decoder's NEON planar dispatch.
- The 9/7 kernel carries the same MSVC-ARM64 noinline guard as the decoder kernels (see the rationale in `idwt_neon.cpp`).

## Verification

- x86 builds unaffected: 407/407 ctest, byte-identical encodes on the 8K fixture.
- ARM functional validation via the `ubuntu-24.04-arm` (gcc + clang) and `windows-11-arm` CI runners, whose suites include the encoder round-trip and lossless exact-recovery tests.
- **Benchmarks on ARM hardware pending** — measured numbers to follow from an Apple Silicon run before merge if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)