### PR TITLE
feat(rtp_recv): BT.2390 EETF soft-knee tone mapping for PQ sources

### DIFF
--- a/docs/cli_rtp_recv.md
+++ b/docs/cli_rtp_recv.md
@@ -85,11 +85,25 @@ the two paths are visually indistinguishable. Byte values diverge
 slightly (max ~9/255 in the deep-grey region); pass
 `--display-encoding gamma22` for a bit-identical round-trip.
 
-**Tone mapping** is currently a hard `clamp(rgb, 0, 1)` in linear
-light, which is correct for any source below the display peak
-(including all HLG content treated as display-referred) but clips
-highlights on above-peak PQ content. The ITU-R BT.2390 EETF soft-knee
-curve is a planned follow-up.
+- `--tonemap {auto|clip|bt2390}` — Highlight handling for PQ sources.
+  Default `auto` applies the ITU-R BT.2390-9 EETF soft-knee whenever the
+  resolved transfer is PQ, and hard-clips otherwise; `bt2390` behaves
+  identically (the EETF has no meaning for display-referred gamma / HLG
+  signals, which always hard-clip); `clip` forces the previous behaviour
+  even for PQ. The EETF maps the assumed source range onto a 203-nit SDR
+  target (BT.2408 reference white), so PQ diffuse white lands near SDR
+  display white instead of the near-black the hard clip produced, with
+  highlights rolling off through a Hermite knee instead of clipping.
+- `--source-peak-nits <N>` — Assumed mastering peak for the EETF
+  (default `1000`, clamped to `[250, 10000]`). RFC 9828 Main Packets
+  carry no MDCV/MaxCLL-style metadata, so the source peak cannot be
+  auto-detected; lower values brighten mid-tones at the cost of earlier
+  highlight roll-off.
+
+**Tone mapping** for gamma and HLG content remains a hard
+`clamp(rgb, 0, 1)` in linear light, which is correct for
+display-referred signals. A proper HLG OOTF with tunable system gamma
+is a planned follow-up.
 
 ### Pacing and throughput
 

--- a/source/apps/rtp_recv/cli.cpp
+++ b/source/apps/rtp_recv/cli.cpp
@@ -94,6 +94,11 @@ void print_usage(const char* argv0) {
       "                           Target primaries for gamut stage (default bt709)\n"
       "  --display-encoding {srgb|gamma22|linear}\n"
       "                           Framebuffer encoding (default srgb)\n"
+      "  --tonemap {auto|clip|bt2390}\n"
+      "                           PQ highlight handling (default auto = BT.2390\n"
+      "                           EETF for PQ sources, hard clip otherwise)\n"
+      "  --source-peak-nits <N>   Assumed PQ mastering peak for the EETF\n"
+      "                           (default 1000, clamped to [250, 10000])\n"
       "  --pace-fps <N>           Frame-pacing target (default 30; 0 = disabled)\n"
       "                           Only active when vsync is off\n"
       "  --smoke-test             Run internal unit smoke tests and exit\n",
@@ -168,6 +173,24 @@ bool parse_cli(int argc, char* argv[], CliOptions& opt) {
       std::fprintf(stderr, "ERROR: --display-encoding must be srgb|gamma22|linear\n");
       return false;
     }
+  }
+  if (const char* v = get_arg(argc, argv, "--tonemap")) {
+    if (std::strcmp(v, "auto") == 0)        opt.tonemap = CliOptions::TonemapMode::Auto;
+    else if (std::strcmp(v, "clip") == 0)   opt.tonemap = CliOptions::TonemapMode::Clip;
+    else if (std::strcmp(v, "bt2390") == 0) opt.tonemap = CliOptions::TonemapMode::Bt2390;
+    else {
+      std::fprintf(stderr, "ERROR: --tonemap must be auto|clip|bt2390\n");
+      return false;
+    }
+  }
+  if (const char* v = get_arg(argc, argv, "--source-peak-nits")) {
+    char*        end = nullptr;
+    const double d   = std::strtod(v, &end);
+    if (end == v || d < 250.0 || d > 10000.0) {
+      std::fprintf(stderr, "ERROR: --source-peak-nits must be in [250, 10000]\n");
+      return false;
+    }
+    opt.source_peak_nits = static_cast<float>(d);
   }
   if (const char* v = get_arg(argc, argv, "--pace-fps")) {
     char*        end = nullptr;

--- a/source/apps/rtp_recv/cli.hpp
+++ b/source/apps/rtp_recv/cli.hpp
@@ -53,10 +53,19 @@ struct CliOptions {
   enum class TransferMode : uint8_t { Auto, Gamma, Pq, Hlg };
   enum class DisplayPrimaries : uint8_t { Bt709, Bt2020 };
   enum class DisplayEncoding : uint8_t { Srgb, Gamma22, Linear };
+  // Tone mapping is only meaningful for PQ sources (the only transfer
+  // with absolute-luminance semantics).  `Auto` and `Bt2390` both select
+  // the BT.2390 EETF when the resolved transfer is PQ and fall back to
+  // hard clipping otherwise; `Clip` forces the pre-v2 hard clip even for
+  // PQ.  `source_peak_nits` is the assumed mastering peak for the EETF
+  // (RFC 9828 carries no MDCV/MaxCLL metadata); clamped to [250, 10000].
+  enum class TonemapMode : uint8_t { Auto, Clip, Bt2390 };
   TransferMode     transfer          = TransferMode::Auto;
   int              transfer_fallback = TRANSFER_GAMMA22;  // used when Auto + S=0 or unknown TRANS
   DisplayPrimaries display_primaries = DisplayPrimaries::Bt709;
   DisplayEncoding  display_encoding  = DisplayEncoding::Srgb;
+  TonemapMode      tonemap           = TonemapMode::Auto;
+  float            source_peak_nits  = kTonemapDefaultSrcNits;
   // Frame-pacing target in fps, active only when vsync is off.  A 30 fps
   // source on a 60 Hz display without pacing shows 3:2 pulldown judder
   // because decoded frames are presented as soon as they're ready, which

--- a/source/apps/rtp_recv/color_pipeline.hpp
+++ b/source/apps/rtp_recv/color_pipeline.hpp
@@ -18,8 +18,8 @@
 //   2. Gamut matrix to linear light in display primaries
 //      (uGamutMatrix: identity for matched primaries, BT.2020 -> BT.709
 //      otherwise).
-//   3. Hard clipping to [0, 1] (tone mapping v1 — BT.2390 EETF is a
-//      follow-up).
+//   3. Tone mapping (uTonemap: hard clipping to [0, 1], or the ITU-R
+//      BT.2390-9 EETF Hermite soft-knee for PQ sources).
 //   4. Display encoding to non-linear framebuffer values
 //      (uDisplayEncoding: sRGB / gamma2.2 / linear).
 //
@@ -42,6 +42,19 @@ constexpr int TRANSFER_HLG     = 2;
 constexpr int DISPLAY_ENCODING_SRGB    = 0;
 constexpr int DISPLAY_ENCODING_GAMMA22 = 1;
 constexpr int DISPLAY_ENCODING_LINEAR  = 2;
+
+// Tone-mapping selector (uTonemap in the fragment shader).
+constexpr int TONEMAP_CLIP   = 0;
+constexpr int TONEMAP_BT2390 = 1;
+
+// SDR target peak for the BT.2390 EETF, anchored to the BT.2408 HDR
+// reference white so PQ diffuse white lands on SDR display white.
+constexpr float kTonemapDstNits      = 203.0f;
+// The same target in PQ linear-light units (1.0 == 10 000 nits).
+constexpr float kTonemapDstLinear    = kTonemapDstNits / 10000.0f;
+// Default assumed mastering peak when the stream carries no metadata
+// (RFC 9828 Main Packets have no MDCV/MaxCLL equivalent).
+constexpr float kTonemapDefaultSrcNits = 1000.0f;
 
 // 3x3 matrices in GL column-major layout so the same float[9] can be
 // passed straight to glUniformMatrix3fv(.., GL_FALSE, ..).
@@ -70,10 +83,19 @@ constexpr float kBt2020ToBt709[9] = {
 // Per-frame colour-pipeline state pushed from the decode thread to the
 // renderer.  `gamut_matrix` aliases immortal constexpr data (one of the
 // two arrays above); never owns.
+//
+// The three tm_* floats are the precomputed BT.2390 EETF parameters and
+// are only meaningful when tonemap == TONEMAP_BT2390 (see
+// compute_bt2390_params below); they default to the 1 000-nit source
+// values so a zero-initialized struct stays well-formed.
 struct ColorPipelineParams {
   int          transfer         = TRANSFER_GAMMA22;
   int          display_encoding = DISPLAY_ENCODING_SRGB;
   const float* gamut_matrix     = kIdentityMatrix3;
+  int          tonemap          = TONEMAP_CLIP;
+  float        tm_src_pq        = 0.751827f;  // PQ encoding of the assumed source peak
+  float        tm_max_lum       = 0.772370f;  // dst peak in source-normalized PQ space
+  float        tm_ks            = 0.658555f;  // Hermite knee start: 1.5*max_lum - 0.5
 };
 
 // ----- Host-side reference mirrors of the GLSL stages -----
@@ -104,6 +126,60 @@ inline float pq_to_linear(float e) {
   const float den = c2 - c3 * v;
   if (den <= 0.0f) return 1.0f;
   return std::pow(num / den, 1.0f / m1);
+}
+
+// SMPTE ST 2084 PQ inverse EOTF (linear -> PQ-encoded).  Input: linear
+// light in [0, 1] where 1.0 corresponds to the 10 000 nit reference
+// peak.  Exact inverse of pq_to_linear (same BT.2100 Table 4 constants).
+inline float linear_to_pq(float l) {
+  constexpr float m1 = 0.1593017578125f;
+  constexpr float m2 = 78.84375f;
+  constexpr float c1 = 0.8359375f;
+  constexpr float c2 = 18.8515625f;
+  constexpr float c3 = 18.6875f;
+  const float v = std::pow(std::max(l, 0.0f), m1);
+  return std::pow((c1 + c2 * v) / (1.0f + c3 * v), m2);
+}
+
+// Fill the BT.2390 EETF parameters on `p` for a source mastered at
+// `source_peak_nits` (clamped to [250, 10000]) and the fixed
+// kTonemapDstNits SDR target.  The EETF runs in PQ space normalized to
+// the source range (source black assumed 0, so the normalization is a
+// plain divide by the source peak's PQ encoding):
+//   max_lum — the display peak inside that normalized range
+//   ks      — knee start, 1.5 * max_lum - 0.5 (BT.2390-9 §5.4.1)
+// The 250-nit floor keeps ks comfortably below 1 so the Hermite span
+// (1 - ks) never degenerates.
+inline void compute_bt2390_params(float source_peak_nits, ColorPipelineParams& p) {
+  const float peak = std::max(250.0f, std::min(10000.0f, source_peak_nits));
+  const float dst_pq = linear_to_pq(kTonemapDstLinear);
+  p.tm_src_pq  = linear_to_pq(peak / 10000.0f);
+  p.tm_max_lum = dst_pq / p.tm_src_pq;
+  p.tm_ks      = 1.5f * p.tm_max_lum - 0.5f;
+}
+
+// ITU-R BT.2390-9 §5.4.1 EETF, per channel.  Input: linear light in
+// display primaries, 1.0 == 10 000 nits.  Output: display-relative
+// linear light in [0, 1] where 1.0 == kTonemapDstNits.
+//
+// Chain: PQ-encode -> normalize to the source range -> Hermite
+// soft-knee above ks (identity below) -> de-normalize -> PQ-decode ->
+// rescale so the display peak is 1.0.  Below the knee this reduces to
+// a pure brightness rescale (linear * 10000 / kTonemapDstNits), which
+// is what makes PQ diffuse white land on SDR display white instead of
+// the near-black the hard-clip path produced.
+inline float bt2390_eetf(const ColorPipelineParams& p, float lin) {
+  const float e1 = std::min(linear_to_pq(lin) / p.tm_src_pq, 1.0f);
+  float e2 = e1;
+  if (e1 >= p.tm_ks) {
+    const float t  = (e1 - p.tm_ks) / (1.0f - p.tm_ks);
+    const float t2 = t * t;
+    const float t3 = t2 * t;
+    e2 = (2.0f * t3 - 3.0f * t2 + 1.0f) * p.tm_ks + (t3 - 2.0f * t2 + t) * (1.0f - p.tm_ks)
+         + (-2.0f * t3 + 3.0f * t2) * p.tm_max_lum;
+  }
+  const float lin_mapped = pq_to_linear(e2 * p.tm_src_pq);
+  return std::max(0.0f, std::min(1.0f, lin_mapped / kTonemapDstLinear));
 }
 
 // ITU-R BT.2100 HLG inverse OETF.  Input: HLG-encoded e in [0, 1].
@@ -172,18 +248,33 @@ inline void apply_color_pipeline(const ColorPipelineParams& p, float r_in,
   const float lb = apply_transfer(p.transfer, b_in);
   float mr, mg, mb;
   apply_gamut_matrix(p.gamut_matrix, lr, lg, lb, mr, mg, mb);
-  // Stage 3 is hard-clipping.  sRGB encoding already clamps internally;
-  // the other encodings need the explicit clamp so out-of-range PQ
-  // highlights do not blow up in pow().
-  mr = std::max(0.0f, std::min(1.0f, mr));
-  mg = std::max(0.0f, std::min(1.0f, mg));
-  mb = std::max(0.0f, std::min(1.0f, mb));
+  // Stage 3: tone mapping.  BT.2390 EETF for PQ sources when selected
+  // (clamps internally); hard clipping otherwise.  sRGB encoding already
+  // clamps too, but the other encodings need the explicit clamp so
+  // out-of-range PQ highlights do not blow up in pow().
+  if (p.tonemap == TONEMAP_BT2390) {
+    mr = bt2390_eetf(p, mr);
+    mg = bt2390_eetf(p, mg);
+    mb = bt2390_eetf(p, mb);
+  } else {
+    mr = std::max(0.0f, std::min(1.0f, mr));
+    mg = std::max(0.0f, std::min(1.0f, mg));
+    mb = std::max(0.0f, std::min(1.0f, mb));
+  }
   r_out = apply_display_encoding(p.display_encoding, mr);
   g_out = apply_display_encoding(p.display_encoding, mg);
   b_out = apply_display_encoding(p.display_encoding, mb);
 }
 
 // Human-readable labels used by log_coefficients_choice_once.
+inline const char* tonemap_label(int t) {
+  switch (t) {
+    case TONEMAP_BT2390: return "bt2390";
+    case TONEMAP_CLIP:
+    default:             return "clip";
+  }
+}
+
 inline const char* transfer_label(int t) {
   switch (t) {
     case TRANSFER_PQ:  return "pq";

--- a/source/apps/rtp_recv/decode_helpers.cpp
+++ b/source/apps/rtp_recv/decode_helpers.cpp
@@ -71,9 +71,10 @@ void log_coefficients_choice_once(const CliOptions& opts, const ycbcr_coefficien
                                                         : "?"));
   }
   std::fprintf(stderr,
-               "info: colour pipeline transfer=%s gamut=%s display_encoding=%s\n",
+               "info: colour pipeline transfer=%s gamut=%s tonemap=%s display_encoding=%s\n",
                transfer_label(pipeline.transfer),
                gamut_matrix_label(pipeline.gamut_matrix),
+               tonemap_label(pipeline.tonemap),
                display_encoding_label(pipeline.display_encoding));
 }
 
@@ -137,6 +138,17 @@ ColorPipelineParams select_color_pipeline_for_frame(const AssembledFrame& frame,
     case CliOptions::DisplayEncoding::Linear:  p.display_encoding = DISPLAY_ENCODING_LINEAR;  break;
     case CliOptions::DisplayEncoding::Srgb:
     default:                                   p.display_encoding = DISPLAY_ENCODING_SRGB;    break;
+  }
+
+  // Tone mapping.  The BT.2390 EETF only has absolute-luminance semantics
+  // for PQ, so it engages exactly when the resolved transfer is PQ and the
+  // CLI does not force the pre-v2 hard clip.  Gamma and HLG sources are
+  // display-referred and keep the hard clip regardless of the CLI value.
+  if (p.transfer == TRANSFER_PQ && opts.tonemap != CliOptions::TonemapMode::Clip) {
+    p.tonemap = TONEMAP_BT2390;
+    compute_bt2390_params(opts.source_peak_nits, p);
+  } else {
+    p.tonemap = TONEMAP_CLIP;
   }
 
   return p;

--- a/source/apps/rtp_recv/gl_loader.cpp
+++ b/source/apps/rtp_recv/gl_loader.cpp
@@ -28,6 +28,7 @@ PFNGLDELETEPROGRAMPROC           DeleteProgram           = nullptr;
 
 PFNGLGETUNIFORMLOCATIONPROC      GetUniformLocation      = nullptr;
 PFNGLUNIFORM1IPROC               Uniform1i               = nullptr;
+PFNGLUNIFORM1FPROC               Uniform1f               = nullptr;
 PFNGLUNIFORM3FVPROC              Uniform3fv              = nullptr;
 PFNGLUNIFORMMATRIX3FVPROC        UniformMatrix3fv        = nullptr;
 
@@ -80,6 +81,7 @@ bool load_functions() {
 
   LOAD(GetUniformLocation,      "glGetUniformLocation");
   LOAD(Uniform1i,               "glUniform1i");
+  LOAD(Uniform1f,               "glUniform1f");
   LOAD(Uniform3fv,              "glUniform3fv");
   LOAD(UniformMatrix3fv,        "glUniformMatrix3fv");
 

--- a/source/apps/rtp_recv/gl_loader.hpp
+++ b/source/apps/rtp_recv/gl_loader.hpp
@@ -106,6 +106,7 @@ extern PFNGLDELETEPROGRAMPROC           DeleteProgram;
 
 extern PFNGLGETUNIFORMLOCATIONPROC      GetUniformLocation;
 extern PFNGLUNIFORM1IPROC               Uniform1i;
+extern PFNGLUNIFORM1FPROC               Uniform1f;
 extern PFNGLUNIFORM3FVPROC              Uniform3fv;
 extern PFNGLUNIFORMMATRIX3FVPROC        UniformMatrix3fv;
 

--- a/source/apps/rtp_recv/gl_renderer.cpp
+++ b/source/apps/rtp_recv/gl_renderer.cpp
@@ -77,6 +77,11 @@ vec3 pq_to_linear(vec3 e) {
   return pow(num / den, vec3(1.0 / kPqM1));
 }
 
+vec3 linear_to_pq(vec3 l) {
+  vec3 v = pow(max(l, vec3(0.0)), vec3(kPqM1));
+  return pow((vec3(kPqC1) + kPqC2 * v) / (vec3(1.0) + kPqC3 * v), vec3(kPqM2));
+}
+
 vec3 hlg_inverse(vec3 e) {
   const float a = 0.17883277;
   const float b = 0.28466892;
@@ -84,6 +89,28 @@ vec3 hlg_inverse(vec3 e) {
   vec3 lo = (e * e) / 3.0;
   vec3 hi = (exp((e - vec3(c)) / a) + vec3(b)) / 12.0;
   return mix(lo, hi, vec3(greaterThan(e, vec3(0.5))));
+}
+
+// ITU-R BT.2390-9 EETF, per channel.  Input: linear light, 1.0 == 10 000
+// nits.  Output: display-relative linear in [0, 1] where 1.0 == 203 nits
+// (BT.2408 reference white).  uTmSrcPq / uTmKs / uTmMaxLum are
+// precomputed on the CPU (compute_bt2390_params in color_pipeline.hpp,
+// which also documents the math).
+vec3 bt2390_eetf(vec3 lin) {
+  const float kDstLinear = 0.0203;  // 203 / 10000
+  vec3 e1 = min(linear_to_pq(lin) / uTmSrcPq, vec3(1.0));
+  vec3 t  = (e1 - vec3(uTmKs)) / (1.0 - uTmKs);
+  vec3 t2 = t * t;
+  vec3 t3 = t2 * t;
+  vec3 p  = (2.0 * t3 - 3.0 * t2 + 1.0) * uTmKs + (t3 - 2.0 * t2 + t) * (1.0 - uTmKs)
+           + (-2.0 * t3 + 3.0 * t2) * uTmMaxLum;
+  vec3 e2 = mix(p, e1, vec3(lessThan(e1, vec3(uTmKs))));
+  return clamp(pq_to_linear(e2 * uTmSrcPq) / kDstLinear, 0.0, 1.0);
+}
+
+vec3 apply_tonemap(vec3 lin) {
+  if (uTonemap == 1) return bt2390_eetf(lin);
+  return clamp(lin, 0.0, 1.0);
 }
 
 vec3 apply_inverse_transfer(vec3 e) {
@@ -122,6 +149,10 @@ uniform vec3      uNormScale;
 uniform int  uTransfer;
 uniform mat3 uGamutMatrix;
 uniform int  uDisplayEncoding;
+uniform int   uTonemap;
+uniform float uTmSrcPq;
+uniform float uTmKs;
+uniform float uTmMaxLum;
 )glsl";
 
 constexpr const char* kFragmentShaderYcbcrMain = R"glsl(
@@ -135,7 +166,7 @@ void main() {
   rgb_nl      = clamp(rgb_nl, 0.0, 1.0);
   vec3 lin_s  = apply_inverse_transfer(rgb_nl);
   vec3 lin_d  = uGamutMatrix * lin_s;
-  lin_d       = clamp(lin_d, 0.0, 1.0);
+  lin_d       = apply_tonemap(lin_d);
   vec3 out_nl = apply_display_encoding(lin_d);
   fragColor   = vec4(clamp(out_nl, 0.0, 1.0), 1.0);
 }
@@ -154,6 +185,10 @@ uniform vec3      uNormScale;
 uniform int  uTransfer;
 uniform mat3 uGamutMatrix;
 uniform int  uDisplayEncoding;
+uniform int   uTonemap;
+uniform float uTmSrcPq;
+uniform float uTmKs;
+uniform float uTmMaxLum;
 )glsl";
 
 constexpr const char* kFragmentShaderPlanarRgbMain = R"glsl(
@@ -166,7 +201,7 @@ void main() {
   rgb_nl      = clamp(rgb_nl, 0.0, 1.0);
   vec3 lin_s  = apply_inverse_transfer(rgb_nl);
   vec3 lin_d  = uGamutMatrix * lin_s;
-  lin_d       = clamp(lin_d, 0.0, 1.0);
+  lin_d       = apply_tonemap(lin_d);
   vec3 out_nl = apply_display_encoding(lin_d);
   fragColor   = vec4(clamp(out_nl, 0.0, 1.0), 1.0);
 }
@@ -317,6 +352,10 @@ bool GlRenderer::compile_shader_programs() {
   u_yc_transfer_   = gl::GetUniformLocation(prog_ycbcr_, "uTransfer");
   u_yc_gamut_      = gl::GetUniformLocation(prog_ycbcr_, "uGamutMatrix");
   u_yc_display_enc_ = gl::GetUniformLocation(prog_ycbcr_, "uDisplayEncoding");
+  u_yc_tonemap_    = gl::GetUniformLocation(prog_ycbcr_, "uTonemap");
+  u_yc_tm_src_pq_  = gl::GetUniformLocation(prog_ycbcr_, "uTmSrcPq");
+  u_yc_tm_ks_      = gl::GetUniformLocation(prog_ycbcr_, "uTmKs");
+  u_yc_tm_max_lum_ = gl::GetUniformLocation(prog_ycbcr_, "uTmMaxLum");
 
   // Planar RGB passthrough program: preamble + helpers + main.
   const char* fs_pr_srcs[] = {kFragmentShaderPlanarRgbSrc, kFragmentPlanarHelpers,
@@ -349,6 +388,10 @@ bool GlRenderer::compile_shader_programs() {
   u_pr_transfer_         = gl::GetUniformLocation(prog_planar_rgb_, "uTransfer");
   u_pr_gamut_            = gl::GetUniformLocation(prog_planar_rgb_, "uGamutMatrix");
   u_pr_display_enc_      = gl::GetUniformLocation(prog_planar_rgb_, "uDisplayEncoding");
+  u_pr_tonemap_          = gl::GetUniformLocation(prog_planar_rgb_, "uTonemap");
+  u_pr_tm_src_pq_        = gl::GetUniformLocation(prog_planar_rgb_, "uTmSrcPq");
+  u_pr_tm_ks_            = gl::GetUniformLocation(prog_planar_rgb_, "uTmKs");
+  u_pr_tm_max_lum_       = gl::GetUniformLocation(prog_planar_rgb_, "uTmMaxLum");
 
   check_gl_error("compile_shader_programs");
   return true;
@@ -642,6 +685,10 @@ void GlRenderer::draw_ycbcr_program(int w_y, int h_y, const ycbcr_coefficients* 
   gl::Uniform1i(u_yc_transfer_, pipeline.transfer);
   gl::UniformMatrix3fv(u_yc_gamut_, 1, GL_FALSE, pipeline.gamut_matrix);
   gl::Uniform1i(u_yc_display_enc_, pipeline.display_encoding);
+  gl::Uniform1i(u_yc_tonemap_, pipeline.tonemap);
+  gl::Uniform1f(u_yc_tm_src_pq_, pipeline.tm_src_pq);
+  gl::Uniform1f(u_yc_tm_ks_, pipeline.tm_ks);
+  gl::Uniform1f(u_yc_tm_max_lum_, pipeline.tm_max_lum);
 
   if (coeffs != nullptr) {
     const float mat[9] = {
@@ -698,6 +745,10 @@ void GlRenderer::draw_planar_rgb_program(int w_y, int h_y, const float* norm_sca
   gl::Uniform1i(u_pr_transfer_, pipeline.transfer);
   gl::UniformMatrix3fv(u_pr_gamut_, 1, GL_FALSE, pipeline.gamut_matrix);
   gl::Uniform1i(u_pr_display_enc_, pipeline.display_encoding);
+  gl::Uniform1i(u_pr_tonemap_, pipeline.tonemap);
+  gl::Uniform1f(u_pr_tm_src_pq_, pipeline.tm_src_pq);
+  gl::Uniform1f(u_pr_tm_ks_, pipeline.tm_ks);
+  gl::Uniform1f(u_pr_tm_max_lum_, pipeline.tm_max_lum);
 
   int fb_w = 0;
   int fb_h = 0;

--- a/source/apps/rtp_recv/gl_renderer.hpp
+++ b/source/apps/rtp_recv/gl_renderer.hpp
@@ -152,6 +152,10 @@ class GlRenderer {
   int          u_yc_transfer_    = -1;
   int          u_yc_gamut_       = -1;
   int          u_yc_display_enc_ = -1;
+  int          u_yc_tonemap_     = -1;
+  int          u_yc_tm_src_pq_   = -1;
+  int          u_yc_tm_ks_       = -1;
+  int          u_yc_tm_max_lum_  = -1;
 
   // Planar RGB passthrough program — no matrix/bias/scale, just HDR pipeline.
   unsigned int prog_planar_rgb_       = 0;
@@ -162,6 +166,10 @@ class GlRenderer {
   int          u_pr_transfer_         = -1;
   int          u_pr_gamut_            = -1;
   int          u_pr_display_enc_      = -1;
+  int          u_pr_tonemap_          = -1;
+  int          u_pr_tm_src_pq_        = -1;
+  int          u_pr_tm_ks_            = -1;
+  int          u_pr_tm_max_lum_       = -1;
   unsigned int tex_y_            = 0;
   unsigned int tex_cb_           = 0;
   unsigned int tex_cr_           = 0;

--- a/source/apps/rtp_recv/metal_renderer.mm
+++ b/source/apps/rtp_recv/metal_renderer.mm
@@ -47,6 +47,10 @@ struct FragmentUniforms {
   float3x3 gamut_matrix;
   int      transfer;
   int      display_encoding;
+  int      tonemap;
+  float    tm_src_pq;
+  float    tm_ks;
+  float    tm_max_lum;
 };
 
 vertex VertexOut vertex_main(VertexIn in [[stage_in]]) {
@@ -87,6 +91,34 @@ static float3 apply_inverse_transfer(float3 e, int transfer) {
   return pow(max(e, float3(0.0)), float3(2.2));
 }
 
+static float3 linear_to_pq(float3 l) {
+  float3 v = pow(max(l, float3(0.0)), float3(kPqM1));
+  return pow((float3(kPqC1) + kPqC2 * v) / (float3(1.0) + kPqC3 * v), float3(kPqM2));
+}
+
+// ITU-R BT.2390-9 EETF, per channel.  Direct port of bt2390_eetf from
+// gl_renderer.cpp; the parameter math is documented in
+// color_pipeline.hpp (compute_bt2390_params).
+static float3 bt2390_eetf(float3 lin, float src_pq, float ks, float max_lum) {
+  const float kDstLinear = 0.0203;  // 203 / 10000
+  float3 e1 = min(linear_to_pq(lin) / src_pq, float3(1.0));
+  float3 t  = (e1 - float3(ks)) / (1.0 - ks);
+  float3 t2 = t * t;
+  float3 t3 = t2 * t;
+  float3 p  = (2.0 * t3 - 3.0 * t2 + 1.0) * ks + (t3 - 2.0 * t2 + t) * (1.0 - ks)
+            + (-2.0 * t3 + 3.0 * t2) * max_lum;
+  float3 sel = float3(e1.x < ks ? 1.0 : 0.0,
+                      e1.y < ks ? 1.0 : 0.0,
+                      e1.z < ks ? 1.0 : 0.0);
+  float3 e2 = mix(p, e1, sel);
+  return saturate(pq_to_linear(e2 * src_pq) / kDstLinear);
+}
+
+static float3 apply_tonemap(float3 lin, int tonemap, float src_pq, float ks, float max_lum) {
+  if (tonemap == 1) return bt2390_eetf(lin, src_pq, ks, max_lum);
+  return saturate(lin);
+}
+
 static float3 linear_to_srgb(float3 l) {
   float3 lo  = l * 12.92;
   float3 hi  = 1.055 * pow(l, float3(1.0 / 2.4)) - 0.055;
@@ -122,7 +154,7 @@ fragment float4 fragment_ycbcr(VertexOut in [[stage_in]],
   rgb_nl        = saturate(rgb_nl);
   float3 lin_s  = apply_inverse_transfer(rgb_nl, u.transfer);
   float3 lin_d  = u.gamut_matrix * lin_s;
-  lin_d         = saturate(lin_d);
+  lin_d         = apply_tonemap(lin_d, u.tonemap, u.tm_src_pq, u.tm_ks, u.tm_max_lum);
   float3 out_nl = apply_display_encoding(lin_d, u.display_encoding);
   return float4(saturate(out_nl), 1.0);
 }
@@ -140,7 +172,7 @@ fragment float4 fragment_planar_rgb(VertexOut in [[stage_in]],
   rgb_nl        = saturate(rgb_nl);
   float3 lin_s  = apply_inverse_transfer(rgb_nl, u.transfer);
   float3 lin_d  = u.gamut_matrix * lin_s;
-  lin_d         = saturate(lin_d);
+  lin_d         = apply_tonemap(lin_d, u.tonemap, u.tm_src_pq, u.tm_ks, u.tm_max_lum);
   float3 out_nl = apply_display_encoding(lin_d, u.display_encoding);
   return float4(saturate(out_nl), 1.0);
 }
@@ -155,6 +187,10 @@ struct FragmentUniforms {
   simd_float3x3 gamut_matrix;
   int32_t       transfer;
   int32_t       display_encoding;
+  int32_t       tonemap;
+  float         tm_src_pq;
+  float         tm_ks;
+  float         tm_max_lum;
 };
 
 // Copy 9 packed floats (column-major) into a padded simd_float3x3.
@@ -486,6 +522,10 @@ void MetalRenderer::upload_planar_and_draw(const uint8_t* y_plane, const uint8_t
   u.transfer = pipeline.transfer;
   u.display_encoding = pipeline.display_encoding;
   u.gamut_matrix = mat3_from_packed(pipeline.gamut_matrix);
+  u.tonemap = pipeline.tonemap;
+  u.tm_src_pq = pipeline.tm_src_pq;
+  u.tm_ks = pipeline.tm_ks;
+  u.tm_max_lum = pipeline.tm_max_lum;
 
   if (!components_are_rgb && coeffs) {
     // Column-major 3x3 YCbCr→RGB matrix (same layout as the GLSL version).
@@ -547,6 +587,10 @@ void MetalRenderer::upload_planar_16_and_draw(const uint16_t* y_plane, const uin
   u.transfer = pipeline.transfer;
   u.display_encoding = pipeline.display_encoding;
   u.gamut_matrix = mat3_from_packed(pipeline.gamut_matrix);
+  u.tonemap = pipeline.tonemap;
+  u.tm_src_pq = pipeline.tm_src_pq;
+  u.tm_ks = pipeline.tm_ks;
+  u.tm_max_lum = pipeline.tm_max_lum;
 
   if (!components_are_rgb && coeffs) {
     float mat[9] = {
@@ -626,6 +670,10 @@ void MetalRenderer::draw_acquired_planes(int ring_index, int w_y, int h_y, int /
   u.transfer = pipeline.transfer;
   u.display_encoding = pipeline.display_encoding;
   u.gamut_matrix = mat3_from_packed(pipeline.gamut_matrix);
+  u.tonemap = pipeline.tonemap;
+  u.tm_src_pq = pipeline.tm_src_pq;
+  u.tm_ks = pipeline.tm_ks;
+  u.tm_max_lum = pipeline.tm_max_lum;
 
   if (!components_are_rgb && coeffs) {
     float mat[9] = {

--- a/source/apps/rtp_recv/shaders.metal
+++ b/source/apps/rtp_recv/shaders.metal
@@ -30,6 +30,10 @@ struct FragmentUniforms {
   float3x3 gamut_matrix;    // Identity or BT.2020→BT.709
   int      transfer;        // 0=gamma22, 1=PQ, 2=HLG
   int      display_encoding;// 0=sRGB, 1=gamma22, 2=linear
+  int      tonemap;         // 0=clip, 1=BT.2390 EETF
+  float    tm_src_pq;       // PQ encoding of the assumed source peak
+  float    tm_ks;           // Hermite knee start (1.5*tm_max_lum - 0.5)
+  float    tm_max_lum;      // dst peak in source-normalized PQ space
 };
 
 // ── Vertex shader (shared by all fragment programs) ──────────────────────
@@ -76,6 +80,34 @@ static float3 apply_inverse_transfer(float3 e, int transfer) {
   return pow(max(e, float3(0.0)), float3(2.2));
 }
 
+static float3 linear_to_pq(float3 l) {
+  float3 v = pow(max(l, float3(0.0)), float3(kPqM1));
+  return pow((float3(kPqC1) + kPqC2 * v) / (float3(1.0) + kPqC3 * v), float3(kPqM2));
+}
+
+// ITU-R BT.2390-9 EETF, per channel.  Direct port of bt2390_eetf from
+// gl_renderer.cpp; the parameter math is documented in
+// color_pipeline.hpp (compute_bt2390_params).
+static float3 bt2390_eetf(float3 lin, float src_pq, float ks, float max_lum) {
+  const float kDstLinear = 0.0203;  // 203 / 10000
+  float3 e1 = min(linear_to_pq(lin) / src_pq, float3(1.0));
+  float3 t  = (e1 - float3(ks)) / (1.0 - ks);
+  float3 t2 = t * t;
+  float3 t3 = t2 * t;
+  float3 p  = (2.0 * t3 - 3.0 * t2 + 1.0) * ks + (t3 - 2.0 * t2 + t) * (1.0 - ks)
+            + (-2.0 * t3 + 3.0 * t2) * max_lum;
+  float3 sel = float3(e1.x < ks ? 1.0 : 0.0,
+                      e1.y < ks ? 1.0 : 0.0,
+                      e1.z < ks ? 1.0 : 0.0);
+  float3 e2 = mix(p, e1, sel);
+  return saturate(pq_to_linear(e2 * src_pq) / kDstLinear);
+}
+
+static float3 apply_tonemap(float3 lin, int tonemap, float src_pq, float ks, float max_lum) {
+  if (tonemap == 1) return bt2390_eetf(lin, src_pq, ks, max_lum);
+  return saturate(lin);
+}
+
 static float3 linear_to_srgb(float3 l) {
   float3 lo  = l * 12.92;
   float3 hi  = 1.055 * pow(l, float3(1.0 / 2.4)) - 0.055;
@@ -115,7 +147,7 @@ fragment float4 fragment_ycbcr(VertexOut in [[stage_in]],
   rgb_nl        = saturate(rgb_nl);
   float3 lin_s  = apply_inverse_transfer(rgb_nl, u.transfer);
   float3 lin_d  = u.gamut_matrix * lin_s;
-  lin_d         = saturate(lin_d);
+  lin_d         = apply_tonemap(lin_d, u.tonemap, u.tm_src_pq, u.tm_ks, u.tm_max_lum);
   float3 out_nl = apply_display_encoding(lin_d, u.display_encoding);
   return float4(saturate(out_nl), 1.0);
 }
@@ -135,7 +167,7 @@ fragment float4 fragment_planar_rgb(VertexOut in [[stage_in]],
   rgb_nl        = saturate(rgb_nl);
   float3 lin_s  = apply_inverse_transfer(rgb_nl, u.transfer);
   float3 lin_d  = u.gamut_matrix * lin_s;
-  lin_d         = saturate(lin_d);
+  lin_d         = apply_tonemap(lin_d, u.tonemap, u.tm_src_pq, u.tm_ks, u.tm_max_lum);
   float3 out_nl = apply_display_encoding(lin_d, u.display_encoding);
   return float4(saturate(out_nl), 1.0);
 }

--- a/source/apps/rtp_recv/smoke_tests.cpp
+++ b/source/apps/rtp_recv/smoke_tests.cpp
@@ -264,7 +264,71 @@ int smoke_test_color_pipeline() {
   if (!approx(pg, 0.0947f, 2e-3f)) return 1;
   if (!approx(pb, 0.0947f, 2e-3f)) return 1;
 
+  // --- linear_to_pq is the exact inverse of pq_to_linear. ---
+  for (int i = 1; i <= 10; ++i) {
+    const float e = static_cast<float>(i) / 10.0f;
+    if (!approx(linear_to_pq(pq_to_linear(e)), e, 1e-3f)) return 1;
+  }
+  // PQ(1000 nits) = 0.751827 and PQ(203 nits) = 0.580689 are tabulated
+  // reference points (BT.2408 uses the latter as HDR reference white).
+  if (!approx(linear_to_pq(0.1f), 0.751827f, 1e-3f)) return 1;
+  if (!approx(linear_to_pq(kTonemapDstLinear), 0.580689f, 1e-3f)) return 1;
+
+  // --- BT.2390 EETF parameter derivation for the 1 000-nit default. ---
+  // max_lum = PQ(203 nits) / PQ(1000 nits) = 0.772370;
+  // ks = 1.5 * max_lum - 0.5 = 0.658555.
+  ColorPipelineParams tm;
+  tm.tonemap = TONEMAP_BT2390;
+  compute_bt2390_params(1000.0f, tm);
+  if (!approx(tm.tm_src_pq, 0.751827f, 1e-3f)) return 1;
+  if (!approx(tm.tm_max_lum, 0.772370f, 2e-3f)) return 1;
+  if (!approx(tm.tm_ks, 0.658555f, 3e-3f)) return 1;
+
+  // --- EETF endpoints and below-knee linearity. ---
+  // Zero stays zero; the source peak (0.1 linear == 1000 nits) maps to
+  // display peak; anything above the assumed source peak clamps there too.
+  if (!approx(bt2390_eetf(tm, 0.0f), 0.0f, 1e-5f)) return 1;
+  if (!approx(bt2390_eetf(tm, 0.1f), 1.0f, 2e-3f)) return 1;
+  if (!approx(bt2390_eetf(tm, 0.5f), 1.0f, 2e-3f)) return 1;
+  // Below the knee (~88 nits for the default parameters) the EETF is a
+  // pure rescale by 10000/203, so 50 nits -> 0.005 / 0.0203 = 0.246305.
+  if (!approx(bt2390_eetf(tm, 0.005f), 0.005f / kTonemapDstLinear, 1e-3f)) return 1;
+
+  // --- EETF is monotonic and bounded over the full input sweep. ---
+  {
+    float prev = -1.0f;
+    for (int i = 0; i <= 256; ++i) {
+      const float out = bt2390_eetf(tm, static_cast<float>(i) / 256.0f);
+      if (out < 0.0f || out > 1.0f) return 1;
+      if (out < prev - 1e-5f) return 1;
+      prev = out;
+    }
+  }
+
+  // --- Full PQ pipeline with the EETF: BT.2408 reference white. ---
+  // A PQ-encoded 203-nit grey lands in the Hermite knee (the knee starts
+  // at ~88 nits with a 1 000-nit source) and comes out at ~0.784 linear
+  // -> ~0.898 sRGB.  The hard-clip path renders the same input at ~0.153
+  // sRGB, so this also locks in the headline fix: PQ diffuse white now
+  // lands near SDR display white instead of near-black.
+  ColorPipelineParams pq_tm_pipeline;
+  pq_tm_pipeline.transfer         = TRANSFER_PQ;
+  pq_tm_pipeline.display_encoding = DISPLAY_ENCODING_SRGB;
+  pq_tm_pipeline.gamut_matrix     = kIdentityMatrix3;
+  pq_tm_pipeline.tonemap          = TONEMAP_BT2390;
+  compute_bt2390_params(1000.0f, pq_tm_pipeline);
+  {
+    const float ref_white_pq = linear_to_pq(kTonemapDstLinear);
+    float tr, tg, tb;
+    apply_color_pipeline(pq_tm_pipeline, ref_white_pq, ref_white_pq, ref_white_pq, tr, tg, tb);
+    if (!approx(tr, 0.898f, 5e-3f)) return 1;
+    if (!approx(tg, tr, 1e-5f)) return 1;
+    if (!approx(tb, tr, 1e-5f)) return 1;
+  }
+
   // Pipeline label helpers.
+  if (std::strcmp(tonemap_label(TONEMAP_BT2390), "bt2390") != 0) return 1;
+  if (std::strcmp(tonemap_label(TONEMAP_CLIP), "clip") != 0) return 1;
   if (std::strcmp(transfer_label(TRANSFER_PQ), "pq") != 0) return 1;
   if (std::strcmp(transfer_label(TRANSFER_HLG), "hlg") != 0) return 1;
   if (std::strcmp(transfer_label(TRANSFER_GAMMA22), "gamma2.2") != 0) return 1;


### PR DESCRIPTION
## Summary

The HDR colour pipeline's tone-mapping stage has been a hard `clamp(rgb, 0, 1)` on linear light normalized to the 10 000-nit PQ reference peak. For PQ content that renders diffuse white (203 nits) at ~15% sRGB signal — visually near-black — and clips any highlight structure. This PR implements the planned follow-up: the ITU-R BT.2390-9 EETF soft-knee for PQ sources.

### Pipeline change (PQ only)

PQ-encode the post-gamut linear light, normalize to the assumed source peak, apply the BT.2390 §5.4.1 Hermite spline above the knee (`ks = 1.5·maxLum − 0.5`), decode, and rescale so the 203-nit BT.2408 reference white range maps onto the SDR display range. Below the knee the curve is a pure brightness rescale, so PQ diffuse white now lands near SDR display white (~0.90 sRGB instead of ~0.15); highlights between the knee and the source peak roll off smoothly instead of clipping.

Gamma and HLG sources are display-referred, so they keep the hard clip unconditionally — their rendering is **bit-identical to current main**.

### CLI

- `--tonemap {auto|clip|bt2390}` (default `auto`): the EETF engages exactly when the resolved transfer is PQ (H.273 `TRANS = 16` or `--transfer pq`); `clip` restores the previous PQ behaviour.
- `--source-peak-nits <N>` (default `1000`, clamped to `[250, 10000]`): assumed mastering peak. RFC 9828 Main Packets carry no MDCV/MaxCLL-style metadata, so the peak cannot be auto-detected; the 250-nit floor keeps the Hermite span non-degenerate.

### Implementation notes

- The GLSL, embedded-MSL, and `shaders.metal` implementations are line-for-line ports of the CPU reference in `color_pipeline.hpp` (`linear_to_pq`, `bt2390_eetf`, `compute_bt2390_params`), following the existing convention that the smoke test exercises the CPU mirrors.
- EETF parameters are precomputed on the CPU and passed as three float uniforms (`uTmSrcPq`, `uTmKs`, `uTmMaxLum`) plus the `uTonemap` selector; the Metal `FragmentUniforms` struct gains the same four fields on both the MSL and host side.
- Adds `glUniform1f` to the GL loader (first float scalar uniform in the renderer).

## Test plan

- [x] `--smoke-test`: all suites pass, including new EETF checks — exact-inverse property of `linear_to_pq`/`pq_to_linear`, tabulated reference points (PQ(1000 nits) = 0.751827, PQ(203 nits) = 0.580689), derived parameters (maxLum = 0.772370, ks = 0.658555), endpoint mapping (source peak → display peak), below-knee linearity (50 nits → 0.2463), monotonicity over a 257-point sweep, and a hand-computed end-to-end value (PQ 203-nit grey → 0.898 sRGB).
- [x] Full ctest: 407/407.
- [x] SDR/HLG non-regression by construction: the tonemap selector resolves to the existing clip path for non-PQ transfers, and `--tonemap clip` forces it for PQ.
- [ ] Visual check on a real BT.2020 PQ stream (no PQ test fixture is currently available; the smoke-test reference values stand in for it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)