### PR TITLE
docs: fix stale CLI references, complete coverage gaps, neutralize vendor mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ on modern x86-64**.
 - Shared library (`libopen_htj2k`) with C++ encoder/decoder APIs.
 - CLI tools: `open_htj2k_enc`, `open_htj2k_dec`, `open_htj2k_rtp_recv`,
   `open_htj2k_jpip_server`, `open_htj2k_jpip_demo`,
-  `open_htj2k_jpip_benchmark`.
+  `open_htj2k_jpip_benchmark`, plus validation / benchmark utilities
+  (`imgcmp`, `row_range_compare`, `estimate_qfactor`,
+  `open_htj2k_rtp_decode_profile`).
 - WebAssembly build (scalar / SIMD / pthreads / SIMD+pthreads) +
   Node.js CLI decoder + in-browser RTP replay and JPIP foveation
   demos (WebGL2 GPU rendering) — try them at

--- a/docs/building.md
+++ b/docs/building.md
@@ -77,7 +77,7 @@ on platform.
 
 Requires [Emscripten](https://emscripten.org/) (tested with 3.x / 5.x).
 
-Four variants are produced under `web/build/html/`:
+Six variants are produced under `web/build/html/`:
 
 - `libopen_htj2k.js`           — scalar, single-threaded
 - `libopen_htj2k_simd.js`      — WASM-SIMD 128-bit, single-threaded
@@ -85,6 +85,13 @@ Four variants are produced under `web/build/html/`:
 - `libopen_htj2k_mt.js`        — scalar + pthreads (multi-threaded)
 - `libopen_htj2k_mt_simd.js`   — WASM-SIMD + pthreads (fastest where
   available)
+- `libopen_htj2k_jpip.js`      — JPIP client + decoder wrapper
+  (WASM-SIMD), used by the browser JPIP demos
+- `libopen_htj2k_jpip_mt_simd.js` — JPIP client + decoder wrapper
+  (WASM-SIMD + pthreads)
+
+Add `-DOPENHTJ2K_WASM_PROFILE=ON` at configure time to preserve Wasm
+function names for profiling (see [wasm_bench.md](wasm_bench.md)).
 
 ```bash
 cd web

--- a/docs/cli_decoder.md
+++ b/docs/cli_decoder.md
@@ -1,8 +1,8 @@
 # `open_htj2k_dec` — decoder CLI reference
 
 Both Part 1 (JPEG 2000) and Part 15 (HTJ2K) compliant decoding are
-supported. Accepts `.j2c` / `.j2k` / `.jph` inputs and writes
-PGM / PPM / PGX / RAW outputs.
+supported. Accepts `.j2c` / `.j2k` / `.jhc` / `.jph` inputs and
+writes PGM / PPM / PGX / RAW outputs.
 
 Full runtime help: `open_htj2k_dec -h`.
 
@@ -30,12 +30,10 @@ output extension decides the writer:
     clamped to the number of consecutive bidirectional DWT levels,
     avoiding nonsensical HONLY / VONLY outputs.
 - `-num_threads n`
-  - Number of threads. `0` (default) uses all available hardware threads.
+  - Number of threads. `0` (default) uses the available hardware
+    threads, capped at 8.
 - `-iter n`
   - Repeat decoding `n` times (benchmarking). Output is written only once.
-- `-batch`
-  - Use the batch (full-image) decode path. The default path is
-    line-based (streaming).
 - `-ycbcr bt601|bt709` *(experimental)*
   - Convert YCbCr to RGB during PPM output using full-range
     ITU-R BT.601 or BT.709 coefficients. Handles 4:2:0 and 4:2:2

--- a/docs/cli_encoder.md
+++ b/docs/cli_encoder.md
@@ -1,11 +1,11 @@
 # `open_htj2k_enc` — encoder CLI reference
 
 Part 15 (HTJ2K) compliant encoder. Produces either a raw codestream
-(`.j2c`, `.jhc`) or an HTJ2K JPH file (`.jph`). Accepts PGM, PPM,
-PGX, and TIFF (with libtiff) inputs. The default streaming path
+(`.j2c`, `.j2k`, `.jphc`) or an HTJ2K JPH file (`.jph`). Accepts PGM,
+PPM, PGX, and TIFF (with libtiff) inputs. The streaming path
 handles all four formats — PGX with subsampled component sets
 (4:2:2, 4:2:0) and basic TIFF (8/16-bit, RGB or grayscale,
-single-strip or strip-compressed). Tiled TIFFs require `-batch`.
+single-strip or strip-compressed). Tiled TIFFs are not supported.
 
 Full runtime help: `open_htj2k_enc -h`.
 
@@ -23,8 +23,8 @@ open_htj2k_enc -i inputY.pgx,inputCb.pgx,inputCr.pgx -o output
 ```
 
 `-o` takes the base name; the extension decides the container:
-`.j2c` / `.jhc` for raw HTJ2K codestream, `.jph` for the JPH file
-format.
+`.j2c` / `.j2k` / `.jphc` for raw HTJ2K codestream, `.jph` for the
+JPH file format.
 
 ## Options
 
@@ -61,7 +61,12 @@ format.
 - `Qstep=Float`
   - Base step size for quantization. Valid range: `0.0 < Qstep <= 2.0`.
 - `Qguard=Int`
-  - Number of guard bits. Valid range: 0–8. Default is **1**.
+  - Number of guard bits. Valid range: 0–7. Default is **1**.
+- `Qderived=yes|no`
+  - `yes` selects scalar-derived quantization: a single step size is
+    signalled for the LL band and the other subband step sizes are
+    derived from it. Default is **no** (scalar-expounded; each
+    subband's step size is signalled explicitly).
 - `Qfactor=Int`
   - Quality factor for lossy compression. Valid range: 0–100
     (100 = best quality).
@@ -77,9 +82,10 @@ format.
 
 - `-num_threads Int`
   - Number of threads. `0` (default) uses all available hardware threads.
-- `-batch`
-  - Use the batch (full-image) encode path. Loads the entire image into
-    memory before encoding. The default path is line-based (streaming).
+- `-iter n`
+  - Repeat encoding `n` times (benchmarking) and report the mean
+    elapsed time. The input image is read only once and the output is
+    written only once.
 
 ## Examples
 

--- a/docs/jpip.md
+++ b/docs/jpip.md
@@ -341,6 +341,8 @@ source/core/jpip/
 - 0 — precinct (JPP-stream)
 - 1 — extended precinct (JPP-stream, has Aux)
 - 2 — tile header
+- 4 — tile (JPT-stream only; not emitted by this server)
+- 5 — extended tile (JPT-stream only, has Aux; not emitted by this server)
 - 6 — main header
 - 8 — metadata
 

--- a/docs/wasm_bench.md
+++ b/docs/wasm_bench.md
@@ -53,7 +53,7 @@ node web/wasm_bench.mjs -i <codestream> [options...]
 | `--threads N` | `1` | Number of decode threads. Ignored by `scalar` / `simd`. `0` = auto (uses `navigator.hardwareConcurrency`). |
 | `--iters N` | `20` | Number of measured iterations. |
 | `--warmup N` | `3` | Number of unmeasured iterations before measurement. |
-| `--mode stream\|planar_u8` | `stream` | Which decoder entry point to call. `stream` uses `invoke_decoder_stream` (PPM/PGM path); `planar_u8` uses `invoke_decoder_planar_u8` (WASM RTP demo path). |
+| `--mode stream\|planar_u8\|planar_ycbcr_u8` | `stream` | Which decoder entry point to call. `stream` uses `invoke_decoder_stream` (PPM/PGM path); `planar_u8` uses `invoke_decoder_planar_u8` (WASM RTP demo path); `planar_ycbcr_u8` uses `invoke_decoder_planar_ycbcr_u8` (raw YCbCr planes, no RGB conversion — the GPU-conversion path). |
 | `--reduce N` | `0` | Resolution reduction level (0 = full resolution). |
 | `--build-dir <path>` | `../build_wasm_prof/html` | Override WASM binary directory. |
 | `--dump-planes <prefix>` | off | `planar_u8` only: on the final iteration write each component plane as `<prefix>_{Y,Cb,Cr}.pgm`. Used for byte-exact diff checks. |

--- a/source/apps/encoder/enc_utils.hpp
+++ b/source/apps/encoder/enc_utils.hpp
@@ -74,7 +74,7 @@ void print_help(char *cmd) {
   printf("Cuse_sop=yes or no:\n  yes to use SOP (Start Of Packet) marker segment.\n  Default is no.\n");
   printf("Cuse_eph=yes or no:\n  yes to use EPH (End of Packet Header) marker.\n  Default is no.\n");
   printf("Qstep=Float:\n  Base step size for quantization.\n  0.0 < base step size <= 2.0.\n");
-  printf("Qguard=Int:\n  Number of guard bits. Valid range is from 0 to 8 (Default is 1.)\n");
+  printf("Qguard=Int:\n  Number of guard bits. Valid range is from 0 to 7 (Default is 1.)\n");
   printf("Qfactor=Int:\n  Quality factor. Valid range is from 0 to 100 (100 is for the best quality)\n");
   printf("  Note: If this option is present, Qstep is ignored and Cycc is set to `yes`.\n");
   printf(

--- a/source/apps/rtp_recv/main_rtp_recv.cpp
+++ b/source/apps/rtp_recv/main_rtp_recv.cpp
@@ -5,7 +5,7 @@
 
 // RFC 9828 RTP receiver for HTJ2K video with a GLFW/OpenGL preview window.
 //
-// Typical usage (alongside a black-box kdu_stream_send sender):
+// Typical usage (alongside an external RFC 9828 sender):
 //
 //     build/bin/open_htj2k_rtp_recv --port 6000 --colorspace bt709 --range full
 //

--- a/source/apps/rtp_recv/tools/rtp_loopback_send.py
+++ b/source/apps/rtp_recv/tools/rtp_loopback_send.py
@@ -8,8 +8,8 @@
 #
 # Wraps a single JPEG 2000 codestream (.j2k) in one RFC 9828 Main Packet and
 # sends it as a single UDP datagram to the receiver.  Used to regression-test
-# the depacketizer + decoder wiring without needing an external sender like
-# kdu_stream_send.
+# the depacketizer + decoder wiring without needing an external RFC 9828
+# sender.
 #
 # Usage:
 #   python3 rtp_loopback_send.py [CODESTREAM] [DST_HOST] [DST_PORT]

--- a/source/core/jph/jph.cpp
+++ b/source/core/jph/jph.cpp
@@ -61,7 +61,7 @@ static void jph_scan_boxes(const uint8_t *begin, const uint8_t *end, jph_info &o
       box_end = end;
     } else {
       // Clamp to file end: handles jp2c boxes whose declared lbox exceeds
-      // the actual file size (e.g. Kakadu streaming output pre-declares a
+      // the actual file size (e.g. some streaming writers pre-declare a
       // larger lbox; the codestream ends at EOF via its own EOC marker).
       if (lbox < 8) return;
       payload  = p + 8;

--- a/tools/wt_bridge/README.md
+++ b/tools/wt_bridge/README.md
@@ -51,8 +51,8 @@ rpicam-vid --rtp-host <bridge-ip> --rtp-port 6000 …
 node scripts/udp_replay.mjs <fixture.rtp> --port 6000 --fps 30 --loop
 ```
 
-Other RFC 9828 senders such as Kakadu's `kdu_stream_send` work the
-same way — the bridge is payload-agnostic.
+Any other RFC 9828 sender works the same way — the bridge is
+payload-agnostic.
 
 ## CLI
 


### PR DESCRIPTION
Follow-up to the doc audit discussed alongside #419.

## Wrong → fixed
- **cli_encoder.md / cli_decoder.md**: both documented a `-batch` flag the binaries reject (not in either parser's known-options list) — removed; the decoder entry is replaced by the previously undocumented `-iter` on the encoder side.
- **cli_encoder.md**: output extension list said `.jhc` (rejected by the encoder); actual accepted raw-codestream extensions are `.j2c` / `.j2k` / `.jphc`. Tiled TIFFs are rejected outright (`encoder.cpp:436`), not handled by `-batch`.
- **Qguard range**: docs and built-in help said 0–8; the parser clamps to 0–7, which matches the 3-bit SQcd guard-bits field. Both now say 0–7.
- **cli_decoder.md**: `-num_threads 0` is capped at 8 threads (`main_dec.cpp:557`), not "all available".

## Coverage gaps filled
- `Qderived=yes|no` documented (scalar-derived vs scalar-expounded).
- `.jhc` added to the decoder's accepted inputs.
- building.md: the two JPIP WASM wrapper variants (`libopen_htj2k_jpip*`) and `-DOPENHTJ2K_WASM_PROFILE=ON`.
- wasm_bench.md: `--mode planar_ycbcr_u8`.
- README.md: validation/benchmark utilities added to the deliverables list.
- jpip.md: JPT-only data-bin classes 4/5 listed for completeness (marked not emitted).

## Vendor mentions neutralized
Generic wording replaces vendor-specific sender/writer references in `tools/wt_bridge/README.md`, `main_rtp_recv.cpp`, `rtp_loopback_send.py`, and `jph.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)