### PR TITLE
fix(rtp_recv): S=0 BT.2020 gamut mapping never engaged (cross-TU pointer mismatch)

### DIFF
--- a/source/apps/rtp_recv/color_pipeline.hpp
+++ b/source/apps/rtp_recv/color_pipeline.hpp
@@ -60,7 +60,7 @@ constexpr float kTonemapDefaultSrcNits = 1000.0f;
 // passed straight to glUniformMatrix3fv(.., GL_FALSE, ..).
 //
 // Identity — used when the source primaries already match the display.
-constexpr float kIdentityMatrix3[9] = {
+inline constexpr float kIdentityMatrix3[9] = {
     1.0f, 0.0f, 0.0f,
     0.0f, 1.0f, 0.0f,
     0.0f, 0.0f, 1.0f,
@@ -74,7 +74,7 @@ constexpr float kIdentityMatrix3[9] = {
 //   [-0.018151  -0.100579   1.118730]
 //
 // Stored column-major below.  The values match the BT.2087-0 rounding.
-constexpr float kBt2020ToBt709[9] = {
+inline constexpr float kBt2020ToBt709[9] = {
      1.660491f, -0.124550f, -0.018151f,   // column 0
     -0.587641f,  1.132900f, -0.100579f,   // column 1
     -0.072850f, -0.008350f,  1.118730f,   // column 2

--- a/source/apps/rtp_recv/ycbcr_rgb.hpp
+++ b/source/apps/rtp_recv/ycbcr_rgb.hpp
@@ -54,7 +54,7 @@ struct ycbcr_coefficients {
 };
 
 // ITU-R BT.601 full-range (JPEG / JFIF convention)
-constexpr ycbcr_coefficients YCBCR_BT601_FULL = {
+inline constexpr ycbcr_coefficients YCBCR_BT601_FULL = {
     /*narrow_range*/ false,
     /*cr_to_r*/ 1.402f,
     /*cb_to_g*/ 0.344136f,
@@ -63,7 +63,7 @@ constexpr ycbcr_coefficients YCBCR_BT601_FULL = {
 };
 
 // ITU-R BT.709 full-range
-constexpr ycbcr_coefficients YCBCR_BT709_FULL = {
+inline constexpr ycbcr_coefficients YCBCR_BT709_FULL = {
     /*narrow_range*/ false,
     /*cr_to_r*/ 1.5748f,
     /*cb_to_g*/ 0.1873f,
@@ -72,7 +72,7 @@ constexpr ycbcr_coefficients YCBCR_BT709_FULL = {
 };
 
 // ITU-R BT.601 narrow-range (SMPTE 170M, studio-range 16..235 luma, 16..240 chroma)
-constexpr ycbcr_coefficients YCBCR_BT601_NARROW = {
+inline constexpr ycbcr_coefficients YCBCR_BT601_NARROW = {
     /*narrow_range*/ true,
     /*cr_to_r*/ 1.596f,
     /*cb_to_g*/ 0.391f,
@@ -81,7 +81,7 @@ constexpr ycbcr_coefficients YCBCR_BT601_NARROW = {
 };
 
 // ITU-R BT.709 narrow-range
-constexpr ycbcr_coefficients YCBCR_BT709_NARROW = {
+inline constexpr ycbcr_coefficients YCBCR_BT709_NARROW = {
     /*narrow_range*/ true,
     /*cr_to_r*/ 1.793f,
     /*cb_to_g*/ 0.213f,
@@ -95,7 +95,7 @@ constexpr ycbcr_coefficients YCBCR_BT709_NARROW = {
 //   cb_to_b = 2*(1 - Kb)                         = 1.8814
 //   cr_to_g = (2 * Kr * (1 - Kr)) / Kg           = 0.571353...
 //   cb_to_g = (2 * Kb * (1 - Kb)) / Kg           = 0.164553...
-constexpr ycbcr_coefficients YCBCR_BT2020_FULL = {
+inline constexpr ycbcr_coefficients YCBCR_BT2020_FULL = {
     /*narrow_range*/ false,
     /*cr_to_r*/ 1.4746f,
     /*cb_to_g*/ 0.16455313f,
@@ -110,7 +110,7 @@ constexpr ycbcr_coefficients YCBCR_BT2020_FULL = {
 // whether that convention is itself arithmetically correct under the
 // shader's `(s - uBias) * uScale` prelude is tracked as a separate
 // investigation rather than being fixed in this slice.
-constexpr ycbcr_coefficients YCBCR_BT2020_NARROW = {
+inline constexpr ycbcr_coefficients YCBCR_BT2020_NARROW = {
     /*narrow_range*/ true,
     /*cr_to_r*/ 1.67861f,    // 1.4746   * 255/224
     /*cb_to_g*/ 0.18732f,    // 0.164553 * 255/224


### PR DESCRIPTION
## Bug
The YCbCr coefficient tables in `ycbcr_rgb.hpp` were namespace-scope `constexpr` — implicitly internal linkage, so each translation unit owned a private copy. `cli.cpp` stored `&YCBCR_BT2020_FULL` (its copy) into `opts.s0_fallback`; `decode_helpers.cpp:123` compared against *its* copy. The comparison could never be true, so the documented `--colorspace bt2020` S=0 path silently resolved `gamut=identity` instead of the BT.2020 → BT.709 matrix. The S=1 path (`PRIMS = 9`) was unaffected.

Found during the macOS verification of #418: the loopback PQ check logged `gamut=identity` where the docs promise `bt2020->bt709`.

## Fix
Make the six coefficient tables `inline constexpr` (one shared object across TUs). Also inlined `kIdentityMatrix3` / `kBt2020ToBt709` in `color_pipeline.hpp`: the inline `gamut_matrix_label()` referencing per-TU internal-linkage arrays was an ODR violation with the same failure mode waiting to happen.

## Verification (M3 Max, Metal path)
- `--smoke-test`: all six OK.
- Loopback S=0 run with `--colorspace bt2020 --transfer pq --frames 1`: now logs
  `info: colour pipeline transfer=pq gamut=bt2020->bt709 tonemap=bt2390 display_encoding=srgb`
  (previously `gamut=identity`), one frame decoded, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)