### PR TITLE
feat(jpip): session-mode channels per ISO/IEC 15444-9 §B.2/§C.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,6 +353,11 @@ set_target_properties(
   PROPERTIES OUTPUT_NAME
              $<IF:$<CONFIG:Debug>,open_htj2k_jpip_server_dbg,open_htj2k_jpip_server>)
 
+# JPIP session/channel management self-test (§B.2, §C.3, §C.9, §D.2)
+add_executable(jpip_session_check)
+add_subdirectory(tests/tools/jpip_session_check)
+target_link_libraries(jpip_session_check PUBLIC open_htj2k)
+
 # JPIP issue #297 chunked-transfer round-trip self-test
 add_executable(jpip_chunked_check)
 add_subdirectory(tests/tools/jpip_chunked_check)

--- a/docs/jpip.md
+++ b/docs/jpip.md
@@ -90,6 +90,13 @@ open_htj2k_jpip_server <input.j2c>
     [--no-chunked]                               # accepted for back-compat (now the default)
 ```
 
+> **Warning** — `--chunked` is for the browser/WASM streaming demos
+> only.  Some interactive reference JPIP clients (native desktop
+> viewers) cannot parse chunked responses and fail with "connection
+> closed unexpectedly"; serve those clients with the default
+> `Content-Length` mode.  See
+> [Progressive (chunked) delivery](#progressive-chunked-delivery).
+
 Query grammar (§C.4):
 
 ```
@@ -169,18 +176,23 @@ correctness.
 `Transfer-Encoding: chunked` *off* because some interactive reference
 JPIP clients do not implement chunked transfer parsing and report
 "connection closed unexpectedly" when the Content-Length header they
-expect is absent.  Our browser demos + C++ `JpipClient` accept either
-format; the client-side chunked refactor that enabled the TTFB win
-stays useful wherever the server is started with `--chunked`.  Opt in
-with:
+expect is absent — a session that otherwise negotiates perfectly
+(`JPIP-cnew` granted, image data flowing) fails at the HTTP layer with
+no JPIP-level error to point at the cause.  Use the default mode for
+native desktop viewers; reserve `--chunked` for the browser demos and
+`JpipClient`, which accept either format.  The client-side chunked
+refactor that enabled the TTFB win stays useful wherever the server
+is started with `--chunked`.  Opt in with:
 
 ```
 open_htj2k_jpip_server <input.j2c> --chunked
 ```
 
-The §C.6.1 `len=` rollback still works in chunked mode — each message
-is built into a reusable scratch buffer and only committed to a wire
-chunk once it fits under the cap.  HTTP/3 continues to use the
+The §C.6.1 `len=` cap works identically in chunked mode — data-bins
+are emitted through budget-aware byte windows, so each wire chunk is
+already guaranteed to fit under the cap when it is flushed, and a bin
+interrupted by the cap resumes from its recorded byte offset on the
+next request.  HTTP/3 continues to use the
 buffered data-reader path; progressive DATA-frame delivery over H3
 would require an nghttp3 data-reader refactor and is tracked as a
 follow-up.

--- a/docs/jpip.md
+++ b/docs/jpip.md
@@ -74,9 +74,13 @@ Emscripten — see [building.md → Building for WebAssembly](building.md#buildi
 
 ## Server — `open_htj2k_jpip_server`
 
-Stateless HTTP/1.1 (optionally HTTP/3) server. Loads one `.j2c`
-codestream, builds the precinct index + packet locator once, then
-serves view-window requests.
+HTTP/1.1 (optionally HTTP/3) server. Loads one `.j2c` codestream,
+builds the precinct index + packet locator once, then serves
+view-window requests — statelessly by default (the client's `model`
+field carries its cache state), or within §B.2 sessions when the
+client establishes a channel with `cnew=http` (the server then keeps
+a per-channel cache model; see `cnew`/`cid` below).  The HTTP/3 path
+is stateless only.
 
 ```
 open_htj2k_jpip_server <input.j2c>
@@ -100,19 +104,39 @@ GET /jpip?fsiz=<fx>,<fy>&roff=<ox>,<oy>&rsiz=<sx>,<sy>&type=jpp-stream
 - `type=jpp-stream` — JPP-stream response (the only wire format this
   server speaks).
 - `len=<N>` — §C.6.1 Maximum Response Length, in bytes.  The server
-  emits whole messages up to `N` bytes of JPP-stream payload (EOR
-  does not count) and terminates with EOR reason=4 (`ByteLimit`)
-  when it stops early, or reason=2 (`WindowDone`) when the entire
-  view-window fit.
+  fills the response up to `N` bytes (EOR does not count) and
+  terminates with EOR reason=4 (`ByteLimit`) when it stops early,
+  or reason=2 (`WindowDone`) when the entire view-window fit.
+  Delivery is resumable at byte granularity: a data-bin larger than
+  the remaining budget contributes a prefix now and continues from
+  that byte offset on the next request (tracked per-session, or via
+  the `model` field's `:bytes` qualifier in stateless mode), so
+  byte-limited clients always make forward progress.  `len=0` is
+  legal and yields an EOR-only response.
 - `model` — §C.9 cache-model advertisement; see
   [cache-model field](#cache-model-field--c9).
-- `cnew=http` — §C.3.3 session/channel establishment.  The server
-  replies with a `JPIP-cnew:
-  cid=C<n>,path=jpip,transport=http` response header.  This server
-  is stateless — the `cid` is opaque and the cache-model field
-  carries all session state — but interactive clients require the
-  header before they will commit received data-bins to their
-  persistent cache.
+- `cnew=<transports>` — §C.3.3 session/channel establishment.  When
+  the comma-separated list contains `http` (the only transport this
+  server grants), the reply carries `JPIP-cnew:
+  cid=<token>,path=jpip,transport=http` and the server creates a
+  session: a per-channel cache model remembers every data-bin (and
+  partial-bin byte offset) delivered on that `cid`, so follow-up
+  requests — which session clients send *without* a `model` field —
+  never receive the same bytes twice (§B.2).  Once a window
+  completes, repeating the request returns an empty body with EOR
+  reason=2, as Table D.2 requires.  If no offered transport is
+  supported (e.g. `cnew=http-tcp` alone), no `JPIP-cnew` header is
+  returned and the request is served statelessly per §C.3.3 —
+  never a transport the client did not offer (Table D.1).
+- `cid=<token>` — request within an existing channel.  Unknown or
+  expired cids get HTTP 404 so the client re-establishes rather
+  than looping on stateless duplicates.  Channels are evicted LRU
+  beyond 64 concurrent sessions.
+- `cclose=*` (or a cid list) — §C.3.4 channel close, honoured after
+  the response completes.
+- `qid=<N>` — §C.3.5 request ID; echoed back verbatim in a
+  `JPIP-qid` response header (§D.2.4).  Session responses also
+  carry `Cache-Control: no-cache`.
 
 HTTP **POST** is also accepted (§C.1): the query string moves into
 the request body when GET's URL-length limit would otherwise
@@ -391,18 +415,25 @@ in WASM at `reduce=0` instead of ~3000 ms for the full canvas.
 
 ### Cache-model field (§C.9)
 
-A client-side `CacheModel` tracks which non-precinct data-bins have
-been received. Its `format()` method emits the §C.9 model field body
-used as `&model=` — for example `Hm,Ht0,Ht1-5,M0`. Range compression
-(`Ht1-5` instead of `Ht1,Ht2,Ht3,Ht4,Ht5`) keeps the query short on
-multi-tile images.
+`CacheModel` tracks the data-bins a client holds — completely, or up
+to a byte offset. Its `format()` method emits the §C.9 model field
+body used as `&model=` — for example `Hm,Ht0,Ht1-5,M0,P7:987`. Range
+compression (`Ht1-5` instead of `Ht1,Ht2,Ht3,Ht4,Ht5`) keeps the
+query short on multi-tile images; partial holdings carry the §C.9.2
+`:bytes` qualifier and are never range-compressed.
 
 | Class | Prefix | Example |
 |---|---|---|
 | Main header (6) | `Hm` | `Hm` (id always 0) |
 | Tile header (2) | `Ht` | `Ht0`, `Ht1-5` |
-| Precinct (0) | `Hp` | *not sent by the demos* |
+| Precinct (0) | `P` | `P7`, `P7:987` (first 987 bytes) |
 | Metadata (8) | `M` | `M0` |
+
+`parse()`/`apply()` accept the legacy `Hp` precinct prefix, the
+`:bytes` partial qualifier (the server resumes delivery from that
+offset), and `-`-prefixed subtractive statements (`-P5` — the client
+discarded the bin; the server forgets it was sent). The same model
+statements work in stateless requests and as session-mode updates.
 
 The browser demos track only headers — precincts are intentionally
 excluded so the foveation demo's periphery decays when the gaze

--- a/source/apps/jpip_server/main.cpp
+++ b/source/apps/jpip_server/main.cpp
@@ -15,11 +15,15 @@
 //
 // The server responds with a complete JPP-stream containing the
 // main-header, tile-header, metadata-bin-0, and every precinct data-bin
-// selected by the view-window resolver.  Stateless — no session, no
-// cache model, each request is self-contained.
+// selected by the view-window resolver.
+//
+// Requests are served statelessly (the client's `model=` field carries
+// its cache state) unless the client establishes a session with
+// `cnew=http`: the server then issues a channel-id (JPIP-cnew, §D.2.3)
+// and keeps a per-channel cache model so bins already delivered on that
+// channel are never re-sent (§B.2).
 
 #include <algorithm>
-#include <atomic>
 #include <cctype>
 #include <chrono>
 #include <cstdint>
@@ -28,6 +32,7 @@
 #include <cstring>
 #include <functional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "codestream_walker.hpp"
@@ -38,6 +43,7 @@
 #include "packet_locator.hpp"
 #include "precinct_index.hpp"
 #include "cache_model.hpp"
+#include "channel_manager.hpp"
 #include "tcp_socket.hpp"
 #include "view_window.hpp"
 #ifdef OPENHTJ2K_ENABLE_QUIC
@@ -77,6 +83,10 @@ struct ServerState {
   // browser demos + C++ JpipClient both accept either format, so the
   // conservative default is Content-Length.
   bool                              chunked_responses = false;
+  // §B.2 sessions: per-channel cache models, keyed by the cid issued in
+  // JPIP-cnew.  Granting a channel commits the server to never re-sending
+  // bins already delivered on it; ChannelManager carries that state.
+  ChannelManager                    channels;
 };
 
 // Callback invoked once per completed JPP-stream message (including EOR).
@@ -95,18 +105,25 @@ using JppMessageSink = std::function<bool(const uint8_t *data, std::size_t len, 
 // the cumulative payload size (excluding EOR, matching the §C.6.1 cap
 // accounting).
 //
-// `max_bytes`, when non-zero, is the §C.6.1 "Maximum Response Length"
-// cap: the cumulative payload size excluding the EOR message (the EOR
-// does not count per §D.3).  Messages are emitted in whole units —
-// if adding the next message would push the total past the cap, that
-// message is dropped before flushing and emission stops.  EOR reason
-// then becomes `ByteLimit` (4) instead of `WindowDone` (2).  A
-// `max_bytes` of 0 means no cap.
+// `max_bytes` is the §C.6.1 "Maximum Response Length" cap: the cumulative
+// response size excluding the EOR message (the EOR does not count per
+// §D.3).  Bins are delivered through resumable byte windows (BinWindow):
+// a bin larger than the remaining budget contributes a prefix now and
+// resumes at that byte offset on the next request, so byte-limited
+// clients always make forward progress.  EOR reason becomes `ByteLimit`
+// (4) instead of `WindowDone` (2) when the cap interrupted delivery.
+// Pass UINT64_MAX for "no cap"; `len=0` is a legal request meaning "EOR
+// only", so 0 is a real cap value here.
+//
+// `sent_out`, when non-null, receives one SentBin per data-bin that
+// contributed bytes to the response — what a session server must commit
+// to the channel's cache model afterwards.
 bool stream_jpp_response(const ServerState &st, const ViewWindow &vw,
                          const CacheModel &client_cache, uint64_t max_bytes,
                          const JppMessageSink &sink,
                          size_t *n_keys_out = nullptr,
-                         std::size_t *total_bytes_out = nullptr) {
+                         std::size_t *total_bytes_out = nullptr,
+                         std::vector<SentBin> *sent_out = nullptr) {
   auto keys = resolve_view_window(*st.idx, vw);
   if (n_keys_out) *n_keys_out = keys.size();
 
@@ -114,50 +131,54 @@ bool stream_jpp_response(const ServerState &st, const ViewWindow &vw,
   std::vector<uint8_t> scratch;
   scratch.reserve(64 * 1024);
   std::size_t total = 0;
-  bool aborted = false;
+  bool aborted   = false;
+  bool truncated = false;
 
-  // Build the next message into `scratch`; on §C.6.1 overflow drop it
-  // (so the context captured by `fn` must not have been consumed — since
-  // emitters only append, the rollback is a simple `scratch.clear()` plus
-  // restoring any MessageHeaderContext changes).  For correctness we
-  // snapshot `ctx` before each emission and restore on overflow.
-  auto try_emit = [&](auto &&fn, bool is_eor) -> bool {
-    const MessageHeaderContext ctx_snap = ctx;
+  // Deliver one data-bin (or the part of it the remaining budget allows)
+  // to `sink`.  A bin the client holds in full is skipped; a partial
+  // holding resumes at its recorded byte offset (§C.9.2).  Returns false
+  // when emission of further bins must stop — budget exhausted
+  // (`truncated`) or sink failure (`aborted`).  The emitter only encodes
+  // message headers for messages it actually appends, so `ctx` needs no
+  // rollback handling here.
+  auto emit_bin = [&](uint8_t cls, uint64_t id, auto &&fn) -> bool {
+    if (client_cache.has(cls, id)) return true;
+    BinWindow win;
+    win.skip   = static_cast<std::size_t>(client_cache.received_bytes(cls, id));
+    win.budget = (max_bytes > total)
+                     ? static_cast<std::size_t>(std::min<uint64_t>(max_bytes - total, SIZE_MAX))
+                     : 0;
     scratch.clear();
-    fn();
-    if (!is_eor && max_bytes > 0 && total + scratch.size() > max_bytes) {
-      ctx = ctx_snap;
-      scratch.clear();
-      return false;
-    }
+    fn(&win);
     if (!scratch.empty()) {
-      if (!sink(scratch.data(), scratch.size(), is_eor)) {
+      if (!sink(scratch.data(), scratch.size(), false)) {
         aborted = true;
         return false;
       }
-      if (!is_eor) total += scratch.size();
+      total += scratch.size();
+      if (sent_out) {
+        sent_out->push_back({cls, id, win.skip + win.payload_sent, win.complete});
+      }
+    }
+    if (win.budget_blocked) {
+      truncated = true;
+      return false;
     }
     return true;
   };
 
-  bool truncated = false;
   // §A.3.6.1: "servers should send metadata-bin 0 in advance of all other
   // bins."  Interactive clients use its arrival (even as an empty bin with
   // is_last=1) as the session-binding signal before they commit precinct
   // data into their cache, so emit it first — before main-header — even
   // for bare J2C codestreams that have no JP2/JPX box structure to ship.
-  if (!client_cache.has(kMsgClassMetadata, 0)) {
-    if (!try_emit([&] { emit_metadata_bin_zero(ctx, scratch); }, false)) {
-      if (!aborted) truncated = true;
-    }
-  }
-  if (!aborted && !truncated && !client_cache.has(kMsgClassMainHeader, 0)) {
-    if (!try_emit([&] {
-          emit_main_header_databin(st.codestream.data(), st.codestream.size(),
-                                    st.layout, ctx, scratch);
-        }, false)) {
-      if (!aborted) truncated = true;
-    }
+  bool emitting = emit_bin(kMsgClassMetadata, 0,
+                           [&](BinWindow *w) { emit_metadata_bin_zero(ctx, scratch, w); });
+  if (emitting) {
+    emitting = emit_bin(kMsgClassMainHeader, 0, [&](BinWindow *w) {
+      emit_main_header_databin(st.codestream.data(), st.codestream.size(),
+                               st.layout, ctx, scratch, w);
+    });
   }
   // §A.3.3: deliver the tile-header data-bin for every tile whose index
   // appears in the view-window result — NOT for every tile in the image.
@@ -166,7 +187,7 @@ bool stream_jpp_response(const ServerState &st, const ViewWindow &vw,
   // tiles well outside the fovea, crowding out actual precinct payload.
   // Collect tile indices from `keys` in first-seen order so the resulting
   // tile-header messages are deterministic.
-  if (!aborted && !truncated) {
+  if (emitting) {
     std::vector<uint16_t> window_tiles;
     {
       std::vector<bool> seen(st.idx->num_tiles(), false);
@@ -175,14 +196,11 @@ bool stream_jpp_response(const ServerState &st, const ViewWindow &vw,
       }
     }
     for (uint16_t t : window_tiles) {
-      if (client_cache.has(kMsgClassTileHeader, t)) continue;
-      if (!try_emit([&] {
-            emit_tile_header_databin(st.codestream.data(), st.codestream.size(),
-                                      t, st.layout, ctx, scratch);
-          }, false)) {
-        if (!aborted) truncated = true;
-        break;
-      }
+      emitting = emit_bin(kMsgClassTileHeader, t, [&](BinWindow *w) {
+        emit_tile_header_databin(st.codestream.data(), st.codestream.size(),
+                                 t, st.layout, ctx, scratch, w);
+      });
+      if (!emitting) break;
     }
   }
 
@@ -197,7 +215,7 @@ bool stream_jpp_response(const ServerState &st, const ViewWindow &vw,
   // they DID receive (because from their perspective those have not been
   // "accepted" into the contiguous portion of the cache).  Sort by I
   // before emission so deliveries are gap-free.
-  if (!aborted && !truncated) {
+  if (emitting) {
     struct KeyWithId { PrecinctKey k; uint64_t I; };
     std::vector<KeyWithId> ordered;
     ordered.reserve(keys.size());
@@ -207,22 +225,19 @@ bool stream_jpp_response(const ServerState &st, const ViewWindow &vw,
     std::sort(ordered.begin(), ordered.end(),
               [](const KeyWithId &a, const KeyWithId &b) { return a.I < b.I; });
     for (const auto &e : ordered) {
-      if (client_cache.has(kMsgClassPrecinct, e.I)) continue;
-      if (!try_emit([&] {
-            emit_precinct_databin(st.codestream.data(), st.codestream.size(),
-                                  e.k.t, e.k.c, e.k.r, e.k.p_rc,
-                                  *st.idx, *st.locator, ctx, scratch);
-          }, false)) {
-        if (!aborted) truncated = true;
-        break;
-      }
+      emitting = emit_bin(kMsgClassPrecinct, e.I, [&](BinWindow *w) {
+        emit_precinct_databin(st.codestream.data(), st.codestream.size(),
+                              e.k.t, e.k.c, e.k.r, e.k.p_rc,
+                              *st.idx, *st.locator, ctx, scratch, w);
+      });
+      if (!emitting) break;
     }
   }
 
   if (!aborted) {
-    try_emit([&] {
-      emit_eor(truncated ? EorReason::ByteLimit : EorReason::WindowDone, ctx, scratch);
-    }, true);
+    scratch.clear();
+    emit_eor(truncated ? EorReason::ByteLimit : EorReason::WindowDone, ctx, scratch);
+    if (!sink(scratch.data(), scratch.size(), /*is_eor=*/true)) aborted = true;
   }
 
   if (total_bytes_out) *total_bytes_out = total;
@@ -234,7 +249,8 @@ bool stream_jpp_response(const ServerState &st, const ViewWindow &vw,
 std::vector<uint8_t> build_jpp_stream(const ServerState &st, const ViewWindow &vw,
                                       const CacheModel &client_cache = {},
                                       size_t *n_keys_out = nullptr,
-                                      uint64_t max_bytes = 0) {
+                                      uint64_t max_bytes = UINT64_MAX,
+                                      std::vector<SentBin> *sent_out = nullptr) {
   std::vector<uint8_t> stream;
   stream.reserve(64 * 1024);
   stream_jpp_response(
@@ -243,7 +259,7 @@ std::vector<uint8_t> build_jpp_stream(const ServerState &st, const ViewWindow &v
         stream.insert(stream.end(), data, data + len);
         return true;
       },
-      n_keys_out, /*total_bytes_out=*/nullptr);
+      n_keys_out, /*total_bytes_out=*/nullptr, sent_out);
   return stream;
 }
 
@@ -284,7 +300,7 @@ std::string find_header(const uint8_t *buf, std::size_t len, const char *name) {
   return {};
 }
 
-void handle_connection(TcpStream &conn, const ServerState &st) {
+void handle_connection(TcpStream &conn, ServerState &st) {
   std::vector<uint8_t> raw;
   const std::size_t hdr_bytes = conn.recv_until_header_end(raw, 65536);
   if (hdr_bytes == 0) return;
@@ -397,32 +413,58 @@ void handle_connection(TcpStream &conn, const ServerState &st) {
   using Clock = std::chrono::steady_clock;
   const auto t0 = Clock::now();
 
-  CacheModel client_cache;
-  if (!req.model.empty()) client_cache = CacheModel::parse(req.model);
-
-  // §C.3.3 / §D.2.5: when the client requests `cnew=http`, reply with
-  // `JPIP-cnew: cid=…,path=…,transport=http`.  Our server is stateless,
-  // so the cid is effectively a token the client can echo in later
-  // requests without the server needing to validate it; the cache-model
-  // field carries all the state we actually need.  Interactive GUI
-  // clients will not commit received precincts to their persistent cache
-  // unless this header arrives on the channel-establishment response,
-  // leading to a silent retry loop.
-  std::string cnew_header;
-  if (req.has_cnew && (req.cnew.empty() || req.cnew.find("http") != std::string::npos)) {
-    // Monotonic cid counter — survives for the process lifetime.  Stateless
-    // so collisions across restarts are harmless; the client treats the
-    // cid as opaque.
-    static std::atomic<uint64_t> s_cid_counter{0};
-    const uint64_t cid = s_cid_counter.fetch_add(1, std::memory_order_relaxed) + 1;
-    char buf[192];
-    std::snprintf(buf, sizeof(buf),
-                  "cid=C%llu,path=jpip,transport=http",
-                  static_cast<unsigned long long>(cid));
-    cnew_header.assign(buf);
+  // §D.2.4: when the request carries a qid, the response shall echo it.
+  std::string extra_headers;
+  if (req.has_qid) {
+    extra_headers += "JPIP-qid: " + std::to_string(req.qid) + "\r\n";
   }
 
-  const uint64_t max_bytes = req.has_len ? req.len : 0;
+  // ── Session resolution (§B.2, §C.3) ──────────────────────────────────
+  // Three modes:
+  //   cid present  → request within an existing channel: serve against the
+  //                  channel's server-side cache model (the client does NOT
+  //                  send `model=` in sessions, §B.3); unknown cid → 404 so
+  //                  the client re-establishes instead of silently looping
+  //                  on stateless duplicates.
+  //   cnew present → channel-establishment request: grant only when a
+  //                  transport we actually support is in the client's list
+  //                  (Table D.1: the granted transport shall be one the
+  //                  client offered).  Otherwise §C.3.3: serve statelessly
+  //                  with NO JPIP-cnew header.
+  //   neither      → stateless: the `model=` field carries the client state.
+  CacheModel  client_cache;
+  std::string session_cid;
+  std::string cnew_header;
+  if (req.has_cid) {
+    if (!st.channels.snapshot(req.cid, &client_cache)) {
+      conn.send_all(format_error_response(404, "Channel Not Found"));
+      return;
+    }
+    session_cid = req.cid;
+    // Sessions still accept client-initiated model updates (e.g. the
+    // client discarded cached bins): fold them into the channel's model
+    // and into this response's view of it.
+    if (!req.model.empty()) {
+      st.channels.apply_model(session_cid, req.model);
+      client_cache.apply(req.model);
+    }
+  } else {
+    if (!req.model.empty()) client_cache = CacheModel::parse(req.model);
+    if (req.has_cnew) {
+      const std::string transport = ChannelManager::negotiate_transport(req.cnew);
+      if (!transport.empty()) {
+        session_cid = st.channels.open();
+        if (!req.model.empty()) st.channels.apply_model(session_cid, req.model);
+        cnew_header = "cid=" + session_cid + ",path=jpip,transport=" + transport;
+      }
+    }
+  }
+  // Session responses must not be cached by intermediaries (Annex F).
+  if (!session_cid.empty()) extra_headers += "Cache-Control: no-cache\r\n";
+
+  const uint64_t max_bytes = req.has_len ? req.len : UINT64_MAX;
+  std::vector<SentBin> sent_bins;
+  auto *sent_out = session_cid.empty() ? nullptr : &sent_bins;
   size_t n_keys = 0;
   std::size_t body_bytes = 0;
   if (st.chunked_responses) {
@@ -431,7 +473,7 @@ void handle_connection(TcpStream &conn, const ServerState &st) {
     // JPP message as its own HTTP chunk.  `sink` returning false on
     // send_all failure aborts the emission early so we don't waste
     // CPU building messages that can't be delivered.
-    auto hdrs = format_jpp_response_headers_chunked(st.target_id, cnew_header);
+    auto hdrs = format_jpp_response_headers_chunked(st.target_id, cnew_header, extra_headers);
     if (!conn.send_all(hdrs)) return;
     bool send_ok = true;
     stream_jpp_response(
@@ -446,28 +488,51 @@ void handle_connection(TcpStream &conn, const ServerState &st) {
           body_bytes += len;
           return true;
         },
-        &n_keys, /*total_bytes_out=*/nullptr);
+        &n_keys, /*total_bytes_out=*/nullptr, sent_out);
     if (send_ok) {
       auto last = format_last_chunk();
       conn.send_all(last);
     }
   } else {
-    auto jpp = build_jpp_stream(st, req.view_window, client_cache, &n_keys, max_bytes);
+    auto jpp = build_jpp_stream(st, req.view_window, client_cache, &n_keys, max_bytes, sent_out);
     body_bytes = jpp.size();
-    auto resp = format_jpp_response(jpp.data(), jpp.size(), st.target_id, cnew_header);
+    auto resp = format_jpp_response(jpp.data(), jpp.size(), st.target_id, cnew_header, extra_headers);
     conn.send_all(resp);
+  }
+
+  // Bins handed to the transport are now part of the channel's history —
+  // the next request on this cid must not receive them again.  Aborted
+  // sends never reach `sent_bins`, so a dropped connection re-sends.
+  if (!session_cid.empty()) st.channels.commit(session_cid, sent_bins);
+
+  // §C.3.4 cclose: close channels only after the response completes.
+  if (req.has_cclose) {
+    if (req.cclose == "*") {
+      if (!session_cid.empty()) st.channels.close(session_cid);
+    } else {
+      std::size_t p = 0;
+      while (p <= req.cclose.size()) {
+        std::size_t c = req.cclose.find(',', p);
+        if (c == std::string::npos) c = req.cclose.size();
+        const std::string one = req.cclose.substr(p, c - p);
+        if (!one.empty()) st.channels.close(one);
+        p = c + 1;
+      }
+    }
   }
 
   const auto t1 = Clock::now();
   const double ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
 
-  std::printf("  → %zu precincts (%.1f%%), %zu bytes JPP-stream, %.1f ms%s\n",
+  std::printf("  → %zu precincts (%.1f%%), %zu bytes JPP-stream, %.1f ms%s%s%s\n",
               n_keys,
               st.idx->total_precincts()
                   ? (100.0 * static_cast<double>(n_keys) / static_cast<double>(st.idx->total_precincts()))
                   : 0.0,
               body_bytes, ms,
-              st.chunked_responses ? " [chunked]" : "");
+              st.chunked_responses ? " [chunked]" : "",
+              session_cid.empty() ? "" : " cid=",
+              session_cid.c_str());
   std::fflush(stdout);
 }
 
@@ -495,7 +560,7 @@ std::vector<uint8_t> handle_h3_request(const ServerState &st,
   if (!jpip_req.model.empty()) h3_cache = CacheModel::parse(jpip_req.model);
   size_t n_keys = 0;
   auto jpp = build_jpp_stream(st, jpip_req.view_window, h3_cache, &n_keys,
-                              jpip_req.has_len ? jpip_req.len : 0);
+                              jpip_req.has_len ? jpip_req.len : UINT64_MAX);
   const auto t1 = Clock::now();
   const double ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
 

--- a/source/core/jpip/CMakeLists.txt
+++ b/source/core/jpip/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(open_htj2k
     tcp_socket.cpp
     jpip_client.cpp
     cache_model.cpp
+    channel_manager.cpp
     h3_server.cpp
     h3_client.cpp
 )

--- a/source/core/jpip/cache_model.cpp
+++ b/source/core/jpip/cache_model.cpp
@@ -13,7 +13,12 @@ namespace open_htj2k {
 namespace jpip {
 
 void CacheModel::mark(uint8_t class_id, uint64_t in_class_id) {
-  bins_.insert(key(class_id, in_class_id));
+  bins_[key(class_id, in_class_id)].complete = true;
+}
+
+void CacheModel::mark_partial(uint8_t class_id, uint64_t in_class_id, uint64_t bytes) {
+  Entry &e = bins_[key(class_id, in_class_id)];
+  if (!e.complete && bytes > e.bytes) e.bytes = bytes;
 }
 
 void CacheModel::unmark(uint8_t class_id, uint64_t in_class_id) {
@@ -21,7 +26,13 @@ void CacheModel::unmark(uint8_t class_id, uint64_t in_class_id) {
 }
 
 bool CacheModel::has(uint8_t class_id, uint64_t in_class_id) const {
-  return bins_.count(key(class_id, in_class_id)) > 0;
+  auto it = bins_.find(key(class_id, in_class_id));
+  return it != bins_.end() && it->second.complete;
+}
+
+uint64_t CacheModel::received_bytes(uint8_t class_id, uint64_t in_class_id) const {
+  auto it = bins_.find(key(class_id, in_class_id));
+  return it == bins_.end() ? 0 : it->second.bytes;
 }
 
 void CacheModel::clear() { bins_.clear(); }
@@ -57,18 +68,28 @@ static uint8_t prefix_to_class(const std::string &s, size_t &pos) {
 }
 
 std::string CacheModel::format() const {
-  // Group bins by class, sort IDs, compress into ranges.
-  struct ClassGroup { uint8_t cls; std::vector<uint64_t> ids; };
+  // Group bins by class, sort IDs, compress complete bins into ranges.
+  // Partial holdings are emitted individually with the §C.9.2 ":bytes"
+  // qualifier and never participate in range compression.
+  struct ClassGroup {
+    uint8_t cls;
+    std::vector<uint64_t> complete_ids;
+    std::vector<std::pair<uint64_t, uint64_t>> partial;  // (id, bytes)
+  };
   std::vector<ClassGroup> groups;
-  for (uint64_t k : bins_) {
-    uint8_t cls = static_cast<uint8_t>(k >> 56);
-    uint64_t id = k & 0x00FFFFFFFFFFFFFF;
+  for (const auto &kv : bins_) {
+    uint8_t cls = static_cast<uint8_t>(kv.first >> 56);
+    uint64_t id = kv.first & 0x00FFFFFFFFFFFFFF;
     auto it = std::find_if(groups.begin(), groups.end(),
                            [cls](const ClassGroup &g) { return g.cls == cls; });
     if (it == groups.end()) {
-      groups.push_back({cls, {id}});
-    } else {
-      it->ids.push_back(id);
+      groups.push_back({cls, {}, {}});
+      it = groups.end() - 1;
+    }
+    if (kv.second.complete) {
+      it->complete_ids.push_back(id);
+    } else if (kv.second.bytes > 0) {
+      it->partial.emplace_back(id, kv.second.bytes);
     }
   }
 
@@ -76,26 +97,42 @@ std::string CacheModel::format() const {
   for (auto &g : groups) {
     const char *pfx = class_prefix(g.cls);
     if (!pfx) continue;
-    std::sort(g.ids.begin(), g.ids.end());
+    std::sort(g.complete_ids.begin(), g.complete_ids.end());
+    std::sort(g.partial.begin(), g.partial.end());
 
-    // Main header (class 6) has only id=0 — emit just "Hm"
+    // Main header (class 6) has only id=0 — emit just "Hm" when complete.
     if (g.cls == kMsgClassMainHeader) {
-      if (!out.empty()) out += ',';
-      out += pfx;
+      if (!g.complete_ids.empty()) {
+        if (!out.empty()) out += ',';
+        out += pfx;
+      }
+      for (const auto &p : g.partial) {
+        if (!out.empty()) out += ',';
+        out += pfx;
+        out += ':';
+        out += std::to_string(p.second);
+      }
       continue;
     }
 
-    // Compress into ranges: 0-3,5,7-10
+    // Compress complete bins into ranges: 0-3,5,7-10
     size_t i = 0;
-    while (i < g.ids.size()) {
+    while (i < g.complete_ids.size()) {
       if (!out.empty()) out += ',';
       out += pfx;
-      uint64_t start = g.ids[i];
+      uint64_t start = g.complete_ids[i];
       uint64_t end = start;
-      while (i + 1 < g.ids.size() && g.ids[i + 1] == end + 1) { ++end; ++i; }
+      while (i + 1 < g.complete_ids.size() && g.complete_ids[i + 1] == end + 1) { ++end; ++i; }
       out += std::to_string(start);
       if (end != start) { out += '-'; out += std::to_string(end); }
       ++i;
+    }
+    for (const auto &p : g.partial) {
+      if (!out.empty()) out += ',';
+      out += pfx;
+      out += std::to_string(p.first);
+      out += ':';
+      out += std::to_string(p.second);
     }
   }
   return out;
@@ -103,36 +140,66 @@ std::string CacheModel::format() const {
 
 CacheModel CacheModel::parse(const std::string &model_str) {
   CacheModel m;
-  if (model_str.empty()) return m;
+  m.apply(model_str);
+  return m;
+}
+
+void CacheModel::apply(const std::string &model_str) {
+  CacheModel &m = *this;
+  if (model_str.empty()) return;
 
   // Split by comma
   std::istringstream ss(model_str);
   std::string token;
   while (std::getline(ss, token, ',')) {
     size_t pos = 0;
+    // §C.9.2: a "-" prefix makes the statement subtractive — the client
+    // has discarded the bin and the server must forget it was sent.
+    bool subtractive = false;
+    if (pos < token.size() && token[pos] == '-') { subtractive = true; ++pos; }
     uint8_t cls = prefix_to_class(token, pos);
     if (cls == 0xFF) continue;
 
-    // Main header: just "Hm" with no ID
+    // Main header: just "Hm" with no ID.  A ":bytes" qualifier (§C.9.2,
+    // partial holding) can still follow.
     if (cls == kMsgClassMainHeader) {
-      m.mark(cls, 0);
+      const std::size_t colon = token.find(':', pos);
+      if (subtractive) {
+        m.unmark(cls, 0);
+      } else if (colon != std::string::npos) {
+        m.mark_partial(cls, 0, std::strtoull(token.c_str() + colon + 1, nullptr, 10));
+      } else {
+        m.mark(cls, 0);
+      }
       continue;
     }
 
-    // Parse ID or range: "5" or "5-10"
+    // Parse ID or range: "5" or "5-10", optionally with a ":bytes"
+    // qualifier (§C.9.2 explicit-bin-descriptor) recording a partial
+    // holding.  Partial bins resume from their byte offset on the next
+    // delivery (BinWindow skip).  Subtractive statements discard the
+    // holding entirely — conservative for "-P5:1234" too, so the whole
+    // bin is re-sent rather than risking a withheld tail.
     if (pos >= token.size()) continue;
     const char *numstart = token.c_str() + pos;
     char *numend = nullptr;
     uint64_t start = std::strtoull(numstart, &numend, 10);
+    if (numend == numstart) continue;
     uint64_t end = start;
     if (numend && *numend == '-') {
-      end = std::strtoull(numend + 1, nullptr, 10);
+      const char *hs = numend + 1;
+      end = std::strtoull(hs, &numend, 10);
+      if (numend == hs || end < start) continue;
     }
+    uint64_t partial_bytes = 0;
+    const bool partial = (numend && *numend == ':');
+    if (partial) partial_bytes = std::strtoull(numend + 1, nullptr, 10);
     for (uint64_t id = start; id <= end; ++id) {
-      m.mark(cls, id);
+      if (subtractive) m.unmark(cls, id);
+      else if (partial) m.mark_partial(cls, id, partial_bytes);
+      else m.mark(cls, id);
     }
   }
-  return m;
 }
 
 }  // namespace jpip

--- a/source/core/jpip/cache_model.hpp
+++ b/source/core/jpip/cache_model.hpp
@@ -9,7 +9,7 @@
 
 #include <cstdint>
 #include <string>
-#include <unordered_set>
+#include <unordered_map>
 
 #if defined(_MSC_VER) && !defined(OHTJ2K_STATIC)
   #define OPENHTJ2K_JPIP_EXPORT __declspec(dllexport)
@@ -22,12 +22,24 @@ namespace jpip {
 
 class OPENHTJ2K_JPIP_EXPORT CacheModel {
  public:
+  // Mark a bin as held in full.
   void mark(uint8_t class_id, uint64_t in_class_id);
+  // Mark a bin as held up to `bytes` payload bytes (§C.9.2 ":bytes"
+  // qualifier).  Holdings only grow: a smaller `bytes` than already
+  // recorded is a no-op, and a bin already complete stays complete.
+  void mark_partial(uint8_t class_id, uint64_t in_class_id, uint64_t bytes);
   // Remove a previously marked bin from the cache model.  Used by the
   // LRU precinct cache when a bin is evicted so the client stops
   // advertising it in the `&model=` field.
   void unmark(uint8_t class_id, uint64_t in_class_id);
+  // True only when the bin is held in full — a partial holding does not
+  // satisfy a skip decision.
   bool has(uint8_t class_id, uint64_t in_class_id) const;
+  // Payload bytes held for the bin: 0 if absent, the partial byte count,
+  // or the recorded count for complete bins (callers check has() first
+  // for completeness).  Servers use this as the resume offset (BinWindow
+  // skip) when continuing a byte-limited delivery.
+  uint64_t received_bytes(uint8_t class_id, uint64_t in_class_id) const;
   void clear();
   size_t size() const { return bins_.size(); }
 
@@ -39,11 +51,23 @@ class OPENHTJ2K_JPIP_EXPORT CacheModel {
   // Parse a model request field value into a CacheModel.
   static CacheModel parse(const std::string &model_str);
 
+  // Apply a model request field value onto this model in statement order
+  // (§C.9.2): additive statements mark bins, "-"-prefixed subtractive
+  // statements unmark them.  Partial-bin statements (":bytes" qualifier)
+  // unmark — we only emit complete bins, so a partial holding must be
+  // re-sent in full rather than skipped.  Used by session servers to fold
+  // a request's `model=` updates into the channel's persistent model.
+  void apply(const std::string &model_str);
+
  private:
   static uint64_t key(uint8_t cls, uint64_t id) {
     return (static_cast<uint64_t>(cls) << 56) | id;
   }
-  std::unordered_set<uint64_t> bins_;
+  struct Entry {
+    uint64_t bytes    = 0;
+    bool     complete = false;
+  };
+  std::unordered_map<uint64_t, Entry> bins_;
 };
 
 }  // namespace jpip

--- a/source/core/jpip/channel_manager.cpp
+++ b/source/core/jpip/channel_manager.cpp
@@ -1,0 +1,84 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+
+#include "channel_manager.hpp"
+
+#include <cstdio>
+
+namespace open_htj2k {
+namespace jpip {
+
+std::string ChannelManager::negotiate_transport(const std::string &cnew_list) {
+  std::size_t pos = 0;
+  while (pos <= cnew_list.size()) {
+    std::size_t comma = cnew_list.find(',', pos);
+    if (comma == std::string::npos) comma = cnew_list.size();
+    std::size_t b = pos, e = comma;
+    while (b < e && (cnew_list[b] == ' ' || cnew_list[b] == '\t')) ++b;
+    while (e > b && (cnew_list[e - 1] == ' ' || cnew_list[e - 1] == '\t')) --e;
+    if (cnew_list.compare(b, e - b, "http") == 0 && e - b == 4) return "http";
+    pos = comma + 1;
+  }
+  return {};
+}
+
+std::string ChannelManager::open() {
+  std::lock_guard<std::mutex> lk(mtx_);
+  if (channels_.size() >= max_channels_) {
+    auto victim = channels_.begin();
+    for (auto it = channels_.begin(); it != channels_.end(); ++it) {
+      if (it->second.last_used < victim->second.last_used) victim = it;
+    }
+    channels_.erase(victim);
+  }
+  char buf[32];
+  std::snprintf(buf, sizeof(buf), "JPH%llu", static_cast<unsigned long long>(next_cid_++));
+  std::string cid(buf);
+  channels_[cid].last_used = ++use_clock_;
+  return cid;
+}
+
+bool ChannelManager::snapshot(const std::string &cid, CacheModel *out) {
+  std::lock_guard<std::mutex> lk(mtx_);
+  auto it = channels_.find(cid);
+  if (it == channels_.end()) return false;
+  it->second.last_used = ++use_clock_;
+  if (out) *out = it->second.model;
+  return true;
+}
+
+void ChannelManager::commit(const std::string &cid, const std::vector<SentBin> &sent) {
+  std::lock_guard<std::mutex> lk(mtx_);
+  auto it = channels_.find(cid);
+  if (it == channels_.end()) return;
+  it->second.last_used = ++use_clock_;
+  for (const auto &b : sent) {
+    if (b.complete) {
+      it->second.model.mark(b.class_id, b.in_class_id);
+    } else {
+      it->second.model.mark_partial(b.class_id, b.in_class_id, b.end_bytes);
+    }
+  }
+}
+
+bool ChannelManager::apply_model(const std::string &cid, const std::string &model_str) {
+  std::lock_guard<std::mutex> lk(mtx_);
+  auto it = channels_.find(cid);
+  if (it == channels_.end()) return false;
+  it->second.last_used = ++use_clock_;
+  it->second.model.apply(model_str);
+  return true;
+}
+
+bool ChannelManager::close(const std::string &cid) {
+  std::lock_guard<std::mutex> lk(mtx_);
+  return channels_.erase(cid) > 0;
+}
+
+std::size_t ChannelManager::size() const {
+  std::lock_guard<std::mutex> lk(mtx_);
+  return channels_.size();
+}
+
+}  // namespace jpip
+}  // namespace open_htj2k

--- a/source/core/jpip/channel_manager.hpp
+++ b/source/core/jpip/channel_manager.hpp
@@ -1,0 +1,111 @@
+// Copyright (c) 2026, Osamu Watanabe
+// All rights reserved.
+//
+// JPIP channel/session manager (ISO/IEC 15444-9 §B.2, §C.3).
+//
+// A JPIP session is created when the server grants a New Channel request
+// (`cnew=`, §C.3.3) by returning a `JPIP-cnew: cid=…` response header
+// (§D.2.3).  Granting a channel is a contract: the server must keep a
+// per-session cache model and never re-send data-bins it has already
+// delivered on that session (§B.2, Table D.2 reason codes 1/2).  A server
+// unwilling to keep that state shall NOT return the header — the request
+// then degrades to stateless service where the client carries the model
+// in `&model=` itself.
+//
+// This manager maps channel-id → CacheModel with an LRU cap.  Channels and
+// sessions are 1:1 here (one channel per session); §C.3.4 `cclose` with a
+// list of cids or "*" therefore closes exactly the named channels.
+//
+// Access pattern: `snapshot()` copies the model out so the (possibly slow)
+// response emission never holds the lock; `commit()` merges the bins that
+// were actually delivered back in afterwards.  Bins whose send aborted are
+// simply not committed, so the next request re-sends them.
+
+#ifndef OPENHTJ2K_CHANNEL_MANAGER_HPP
+#define OPENHTJ2K_CHANNEL_MANAGER_HPP
+
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "cache_model.hpp"
+
+#if defined(_MSC_VER) && !defined(OHTJ2K_STATIC)
+  #define OPENHTJ2K_JPIP_EXPORT __declspec(dllexport)
+#else
+  #define OPENHTJ2K_JPIP_EXPORT
+#endif
+
+namespace open_htj2k {
+namespace jpip {
+
+// One data-bin's delivery outcome within a response, as committed to the
+// channel's cache model: the client now holds `end_bytes` payload bytes of
+// the bin, and `complete` records whether the is_last message went out.
+struct SentBin {
+  uint8_t  class_id    = 0;
+  uint64_t in_class_id = 0;
+  uint64_t end_bytes   = 0;
+  bool     complete    = false;
+};
+
+class OPENHTJ2K_JPIP_EXPORT ChannelManager {
+ public:
+  explicit ChannelManager(std::size_t max_channels = 64) : max_channels_(max_channels) {}
+
+  // Pick a transport from the §C.3.3 `cnew` value (comma-separated list of
+  // transport names, e.g. "http-tcp,http").  Table D.1: the granted
+  // transport shall be one of the values the client supplied — exact token
+  // match, never substring ("http-tcp" must not be answered with "http"
+  // unless "http" itself is also in the list).  Returns the chosen token,
+  // or an empty string when nothing in the list is supported (the caller
+  // must then serve the request statelessly without a JPIP-cnew header).
+  // An empty list counts as unsupported.
+  static std::string negotiate_transport(const std::string &cnew_list);
+
+  // Create a new channel and return its channel-id (IDTOKEN, §C.3.2).
+  // Evicts the least-recently-used channel when the cap is reached.
+  std::string open();
+
+  // Copy the channel's cache model into *out.  Returns false (and leaves
+  // *out untouched) when the cid is unknown — expired, evicted, or never
+  // issued.  Touches the channel's LRU recency.
+  bool snapshot(const std::string &cid, CacheModel *out);
+
+  // Merge data-bins delivered on this channel into its cache model:
+  // complete bins are marked held-in-full, partial deliveries record
+  // their byte offset so the next request resumes there.  Unknown cids
+  // are ignored (the channel may have been evicted while the response
+  // was streaming).
+  void commit(const std::string &cid, const std::vector<SentBin> &sent);
+
+  // Fold a request's §C.9 `model=` statements into the channel's model
+  // (additive statements mark, subtractive/partial unmark — see
+  // CacheModel::apply).  Sessions still accept client model updates, e.g.
+  // when the client discards cached bins.  Returns false if cid unknown.
+  bool apply_model(const std::string &cid, const std::string &model_str);
+
+  // §C.3.4 cclose: close one channel.  Returns true if it existed.
+  bool close(const std::string &cid);
+
+  std::size_t size() const;
+
+ private:
+  struct Channel {
+    CacheModel model;
+    uint64_t   last_used = 0;
+  };
+
+  mutable std::mutex mtx_;
+  std::unordered_map<std::string, Channel> channels_;
+  std::size_t max_channels_;
+  uint64_t    next_cid_  = 1;
+  uint64_t    use_clock_ = 0;
+};
+
+}  // namespace jpip
+}  // namespace open_htj2k
+
+#endif  // OPENHTJ2K_CHANNEL_MANAGER_HPP

--- a/source/core/jpip/data_bin_emitter.cpp
+++ b/source/core/jpip/data_bin_emitter.cpp
@@ -20,24 +20,47 @@ namespace {
 // monotonically increasing `msg_offset`.
 constexpr std::size_t kMaxMessagePayload = 987;
 
-// Append a complete JPP-stream data-bin contribution.  For bins whose
-// payload fits in `kMaxMessagePayload` this is a single message with
-// `is_last=1`.  Larger bins are split into multiple messages with
+// Append a data-bin contribution as one or more JPP-stream messages.  For
+// bins whose payload fits in `kMaxMessagePayload` this is a single message
+// with `is_last=1`.  Larger bins are split into multiple messages with
 // monotonically increasing `msg_offset`; only the final message has
 // `is_last=1`.  The split is on byte boundaries — JPP messages do not
 // constrain split points within the payload.
+//
+// When `win` is non-null, emission starts at payload offset `win->skip`
+// and appends at most `win->budget` bytes (headers + payload).  The
+// header-size reservation is conservative (kMessageHeaderMaxBytes), so a
+// few bytes of budget can go unused at the response tail; the §C.6.1 cap
+// is an upper bound, never an entitlement, so under-filling is safe.
+// Empty bins (and `skip == payload_len` resumptions) emit the zero-length
+// `is_last=1` message that declares the bin complete.
 std::size_t append_message(MessageHeader hdr, const uint8_t *payload,
                            std::size_t payload_len,
                            MessageHeaderContext &ctx,
-                           std::vector<uint8_t> &out) {
+                           std::vector<uint8_t> &out,
+                           BinWindow *win = nullptr) {
   std::size_t written = 0;
-  std::size_t offset  = 0;
-  // Always emit at least one message, even for empty bins (so callers can
-  // declare "empty and complete" via msg_length=0, is_last=1).
-  do {
+  std::size_t offset  = win ? std::min(win->skip, payload_len) : 0;
+  const std::size_t budget = win ? win->budget : SIZE_MAX;
+  const std::size_t first_offset = offset;
+  bool complete = false;
+
+  // Always try to emit at least one message, even for empty bins (so
+  // callers can declare "empty and complete" via msg_length=0, is_last=1).
+  for (;;) {
     const std::size_t remaining = payload_len - offset;
-    const std::size_t this_len  = std::min(remaining, kMaxMessagePayload);
-    const bool        is_last   = (offset + this_len == payload_len);
+    const std::size_t avail     = (budget > written) ? budget - written : 0;
+    if (avail <= kMessageHeaderMaxBytes) {
+      if (win) win->budget_blocked = true;
+      break;
+    }
+    const std::size_t this_len =
+        std::min(std::min(remaining, kMaxMessagePayload), avail - kMessageHeaderMaxBytes);
+    if (remaining > 0 && this_len == 0) {
+      if (win) win->budget_blocked = true;
+      break;
+    }
+    const bool is_last = (offset + this_len == payload_len);
 
     hdr.msg_offset = offset;
     hdr.msg_length = this_len;
@@ -52,7 +75,13 @@ std::size_t append_message(MessageHeader hdr, const uint8_t *payload,
     }
     written += hdr_bytes + this_len;
     offset  += this_len;
-  } while (offset < payload_len);
+    if (is_last) { complete = true; break; }
+  }
+
+  if (win) {
+    win->payload_sent = offset - first_offset;
+    win->complete     = complete;
+  }
   return written;
 }
 
@@ -61,7 +90,8 @@ std::size_t append_message(MessageHeader hdr, const uint8_t *payload,
 std::size_t emit_main_header_databin(const uint8_t *codestream, std::size_t len,
                                      const CodestreamLayout &layout,
                                      MessageHeaderContext &ctx,
-                                     std::vector<uint8_t> &out) {
+                                     std::vector<uint8_t> &out,
+                                     BinWindow *win) {
   if (codestream == nullptr || layout.main_header_end == 0) return 0;
   if (layout.main_header_end > len) return 0;
   MessageHeader hdr{};
@@ -69,14 +99,15 @@ std::size_t emit_main_header_databin(const uint8_t *codestream, std::size_t len,
   hdr.cs_n        = 0;
   hdr.in_class_id = 0;
   return append_message(hdr, codestream + layout.soc_offset,
-                        layout.main_header_end - layout.soc_offset, ctx, out);
+                        layout.main_header_end - layout.soc_offset, ctx, out, win);
 }
 
 std::size_t emit_tile_header_databin(const uint8_t *codestream, std::size_t len,
                                      uint16_t tile_index,
                                      const CodestreamLayout &layout,
                                      MessageHeaderContext &ctx,
-                                     std::vector<uint8_t> &out) {
+                                     std::vector<uint8_t> &out,
+                                     BinWindow *win) {
   if (codestream == nullptr) return 0;
   // Per §A.3.3, the server "is required to send a tile header data bin for
   // a tile even if the tile header is empty" — so we emit the message
@@ -103,16 +134,17 @@ std::size_t emit_tile_header_databin(const uint8_t *codestream, std::size_t len,
   hdr.class_id    = kMsgClassTileHeader;
   hdr.cs_n        = 0;
   hdr.in_class_id = tile_index;
-  return append_message(hdr, payload.data(), payload.size(), ctx, out);
+  return append_message(hdr, payload.data(), payload.size(), ctx, out, win);
 }
 
 std::size_t emit_metadata_bin_zero(MessageHeaderContext &ctx,
-                                   std::vector<uint8_t> &out) {
+                                   std::vector<uint8_t> &out,
+                                   BinWindow *win) {
   MessageHeader hdr{};
   hdr.class_id    = kMsgClassMetadata;
   hdr.cs_n        = 0;
   hdr.in_class_id = 0;
-  return append_message(hdr, /*payload=*/nullptr, 0, ctx, out);
+  return append_message(hdr, /*payload=*/nullptr, 0, ctx, out, win);
 }
 
 std::size_t emit_precinct_databin(const uint8_t *codestream, std::size_t len,
@@ -120,7 +152,8 @@ std::size_t emit_precinct_databin(const uint8_t *codestream, std::size_t len,
                                   const CodestreamIndex &idx,
                                   const PacketLocator &locator,
                                   MessageHeaderContext &ctx,
-                                  std::vector<uint8_t> &out) {
+                                  std::vector<uint8_t> &out,
+                                  BinWindow *win) {
   if (codestream == nullptr) return 0;
   const auto &ranges = locator.packets_of(t, c, r, p_rc);
   if (ranges.empty()) return 0;
@@ -142,7 +175,7 @@ std::size_t emit_precinct_databin(const uint8_t *codestream, std::size_t len,
   hdr.class_id    = kMsgClassPrecinct;
   hdr.cs_n        = 0;
   hdr.in_class_id = idx.I(t, c, r, p_rc);
-  return append_message(hdr, payload.data(), payload.size(), ctx, out);
+  return append_message(hdr, payload.data(), payload.size(), ctx, out, win);
 }
 
 std::size_t emit_eor(EorReason reason, MessageHeaderContext &ctx, std::vector<uint8_t> &out) {

--- a/source/core/jpip/data_bin_emitter.hpp
+++ b/source/core/jpip/data_bin_emitter.hpp
@@ -8,15 +8,15 @@
 // through so dependent-form headers (Class/CSn omission) work across
 // successive data-bins.
 //
-// The v1 emitters always pack each data-bin into a single message — i.e.
-// msg_offset = 0, msg_length = (bin size), is_last = true.  Splitting a
-// bin across multiple messages is allowed by the spec (and useful for
-// flow-control and progressive delivery) but unnecessary for the local
-// round-trip use case in PHASE2_PLAN.md.
+// Bins whose payload exceeds kMaxMessagePayload are split across multiple
+// messages with monotonically increasing msg_offset; only the final
+// message carries is_last = 1.
 //
-// Precinct data-bins (class 0/1) are not emitted by this header — they
-// require packet-header parsing and live in a follow-up commit; see
-// PHASE2_PLAN.md item B3-precincts.
+// Every emitter accepts an optional BinWindow for resumable, byte-capped
+// delivery (§C.6.1 Maximum Response Length): `skip` payload bytes the
+// client already holds are not re-sent (messages start at msg_offset =
+// skip), and no more than `budget` bytes (headers + payload) are appended.
+// Without a BinWindow the whole bin is emitted unconditionally.
 #pragma once
 #include <cstddef>
 #include <cstdint>
@@ -36,6 +36,26 @@
 namespace open_htj2k {
 namespace jpip {
 
+// Byte-window control for resumable, budget-capped bin delivery.
+//
+// In:  `skip`   — payload bytes of this bin the client already holds (from
+//                 its cache model); emission resumes at msg_offset = skip.
+//      `budget` — maximum bytes (message headers + payload) the emitter
+//                 may append to `out` in this call.
+// Out: `payload_sent`   — payload bytes emitted (excludes headers); the
+//                 client now holds skip + payload_sent bytes of the bin.
+//      `complete`       — the is_last message was emitted: the bin is done.
+//      `budget_blocked` — emission stopped (or never started) because the
+//                 budget could not fit the next message.  Distinguishes
+//                 "response is full" from "bin had nothing to send".
+struct BinWindow {
+  std::size_t skip           = 0;
+  std::size_t budget         = SIZE_MAX;
+  std::size_t payload_sent   = 0;
+  bool        complete       = false;
+  bool        budget_blocked = false;
+};
+
 // Emit the main-header data-bin (class 6, in-class id 0).  Payload is the
 // codestream bytes from the SOC marker (inclusive) up to the first SOT
 // marker (exclusive).  Returns the number of bytes appended to `out`, or 0
@@ -44,7 +64,8 @@ OPENHTJ2K_JPIP_EXPORT std::size_t
 emit_main_header_databin(const uint8_t *codestream, std::size_t len,
                          const CodestreamLayout &layout,
                          MessageHeaderContext &ctx,
-                         std::vector<uint8_t> &out);
+                         std::vector<uint8_t> &out,
+                         BinWindow *win = nullptr);
 
 // Emit the tile-header data-bin (class 2, in-class id = `tile_index`).
 // Per §A.3.3, the bin contains all tile-part-header marker segments for
@@ -58,14 +79,16 @@ emit_tile_header_databin(const uint8_t *codestream, std::size_t len,
                          uint16_t tile_index,
                          const CodestreamLayout &layout,
                          MessageHeaderContext &ctx,
-                         std::vector<uint8_t> &out);
+                         std::vector<uint8_t> &out,
+                         BinWindow *win = nullptr);
 
 // Emit metadata-bin 0 (class 8, in-class id 0).  Per §A.3.6.1 the server
 // must always send this bin; for raw .j2c codestreams (no JP2/JPH boxes)
 // it is empty.  This implementation emits a single zero-length, is_last
 // message.
 OPENHTJ2K_JPIP_EXPORT std::size_t
-emit_metadata_bin_zero(MessageHeaderContext &ctx, std::vector<uint8_t> &out);
+emit_metadata_bin_zero(MessageHeaderContext &ctx, std::vector<uint8_t> &out,
+                       BinWindow *win = nullptr);
 
 // Emit a precinct data-bin (class 0, in-class id = `I` per §A.3.2.1
 // Eq. A-1) covering every packet of this precinct across every layer.
@@ -86,7 +109,8 @@ emit_precinct_databin(const uint8_t *codestream, std::size_t len,
                       const CodestreamIndex &idx,
                       const PacketLocator &locator,
                       MessageHeaderContext &ctx,
-                      std::vector<uint8_t> &out);
+                      std::vector<uint8_t> &out,
+                      BinWindow *win = nullptr);
 
 // Emit an End-of-Response (EOR) message (§D.3) with the given reason
 // code.  EOR is not an Annex A message and not a class; the wire form

--- a/source/core/jpip/jpip_request.cpp
+++ b/source/core/jpip/jpip_request.cpp
@@ -41,6 +41,20 @@ bool parse_pair(const std::string &val, uint32_t &a, uint32_t &b) {
   return true;
 }
 
+// §C.4: one image-return-type element, either the reserved short token
+// ("jpp-stream") or the media-type form ("image/jpp-stream"), optionally
+// followed by ";parameter" suffixes which we ignore.
+bool is_acceptable_return_type(const std::string &item) {
+  std::size_t b = 0, e = item.size();
+  while (b < e && (item[b] == ' ' || item[b] == '\t')) ++b;
+  while (e > b && (item[e - 1] == ' ' || item[e - 1] == '\t')) --e;
+  const std::size_t semi = item.find(';', b);
+  if (semi != std::string::npos && semi < e) e = semi;
+  const std::size_t n = e - b;
+  return (n == 10 && item.compare(b, n, "jpp-stream") == 0) ||
+         (n == 16 && item.compare(b, n, "image/jpp-stream") == 0);
+}
+
 }  // namespace
 
 RequestParseStatus parse_jpip_query(const std::string &query_in, JpipRequest *out) {
@@ -89,15 +103,30 @@ RequestParseStatus parse_jpip_query(const std::string &query_in, JpipRequest *ou
       }
       out->has_rsiz = true;
     } else if (key == "comps") {
-      // Comma-separated uint16 list, e.g. "0,1,2" or "0-2".
-      // v1: only comma-separated individual indices.
+      // §C.4.6: comma-separated list of indices or ranges, e.g. "0,2" or
+      // "0-2" or "0,3-5".
       out->view_window.comps.clear();
       std::size_t p = 0;
       while (p < val.size()) {
         const std::size_t c = val.find(',', p);
         const std::string item = val.substr(p, c == std::string::npos ? std::string::npos : c - p);
         if (!item.empty()) {
-          out->view_window.comps.push_back(static_cast<uint16_t>(std::strtoul(item.c_str(), nullptr, 10)));
+          char *end = nullptr;
+          const unsigned long lo = std::strtoul(item.c_str(), &end, 10);
+          unsigned long hi = lo;
+          if (end == item.c_str()) { status = RequestParseStatus::MalformedField; return; }
+          if (*end == '-') {
+            const char *hs = end + 1;
+            hi = std::strtoul(hs, &end, 10);
+            if (end == hs || *end != '\0' || hi < lo) {
+              status = RequestParseStatus::MalformedField; return;
+            }
+          } else if (*end != '\0') {
+            status = RequestParseStatus::MalformedField; return;
+          }
+          for (unsigned long v = lo; v <= hi; ++v) {
+            out->view_window.comps.push_back(static_cast<uint16_t>(v));
+          }
         }
         p = (c == std::string::npos) ? val.size() : c + 1;
       }
@@ -125,11 +154,23 @@ RequestParseStatus parse_jpip_query(const std::string &query_in, JpipRequest *ou
       out->quality     = static_cast<uint32_t>(n);
       out->has_quality = true;
     } else if (key == "type") {
-      out->type = val;
-      if (val != "jpp-stream") {
+      // §C.4: comma-separated preference list; accept the request if ANY
+      // element is a jpp-stream form.  We always serve jpp-stream, so the
+      // stored type is the token we will put on the wire.
+      bool acceptable = false;
+      std::size_t p = 0;
+      while (p <= val.size()) {
+        std::size_t c = val.find(',', p);
+        if (c == std::string::npos) c = val.size();
+        if (is_acceptable_return_type(val.substr(p, c - p))) { acceptable = true; break; }
+        p = c + 1;
+      }
+      if (!acceptable) {
+        out->type = val;
         status = RequestParseStatus::UnsupportedType;
         return;
       }
+      out->type = "jpp-stream";
     } else if (key == "cnew") {
       // §C.3.3: client requests a new JPIP channel; value is the preferred
       // transport (typically "http").  Server echoes a channel id back in
@@ -143,6 +184,20 @@ RequestParseStatus parse_jpip_query(const std::string &query_in, JpipRequest *ou
       // information required for each response.
       out->cid     = val;
       out->has_cid = true;
+    } else if (key == "cclose") {
+      // §C.3.4: "*" or a comma-separated list of channel-ids.
+      out->cclose     = val;
+      out->has_cclose = true;
+    } else if (key == "qid") {
+      // §C.3.5: non-negative decimal request ID.
+      char *end = nullptr;
+      const unsigned long long n = std::strtoull(val.c_str(), &end, 10);
+      if (end == val.c_str() || *end != '\0') {
+        status = RequestParseStatus::MalformedField;
+        return;
+      }
+      out->qid     = static_cast<uint64_t>(n);
+      out->has_qid = true;
     }
     // Unknown keys are silently ignored per §C.1.
   });

--- a/source/core/jpip/jpip_request.hpp
+++ b/source/core/jpip/jpip_request.hpp
@@ -34,7 +34,12 @@ struct JpipRequest {
   bool        has_roff   = false;
   bool        has_rsiz   = false;
   bool        has_comps  = false;
-  // §C.4 Table C.4: image return type.  Must be "jpp-stream" for our use.
+  // §C.4: image return type.  The request field is a comma-separated
+  // preference list (`type = "type" "=" 1#image-return-type`) and each
+  // element may be the short token ("jpp-stream") or the equivalent
+  // media-type form ("image/jpp-stream").  The parser stores the type the
+  // server will actually serve — always "jpp-stream" — and fails with
+  // UnsupportedType only when no element of the list is acceptable.
   std::string type;
   // §C.9: client cache model — lists data-bins the client already has.
   std::string model;
@@ -63,6 +68,14 @@ struct JpipRequest {
   // cid arrives for trace only; accept it without validation.
   std::string cid;
   bool        has_cid     = false;
+  // §C.3.4 `cclose` — close channels.  Value is "*" (all channels of the
+  // session named by cid) or a comma-separated list of channel-ids.
+  std::string cclose;
+  bool        has_cclose  = false;
+  // §C.3.5 `qid` — request ID.  §D.2.4: when present the server shall
+  // echo it back verbatim in a `JPIP-qid:` response header.
+  uint64_t    qid         = 0;
+  bool        has_qid     = false;
 };
 
 enum class RequestParseStatus : uint8_t {

--- a/source/core/jpip/jpip_response.cpp
+++ b/source/core/jpip/jpip_response.cpp
@@ -11,7 +11,8 @@ namespace jpip {
 
 std::vector<uint8_t> format_jpp_response(const uint8_t *body, std::size_t body_len,
                                          const std::string &target_id,
-                                         const std::string &cnew_header) {
+                                         const std::string &cnew_header,
+                                         const std::string &extra_headers) {
   char header[512];
   int n = std::snprintf(header, sizeof(header),
                         "HTTP/1.1 200 OK\r\n"
@@ -36,6 +37,7 @@ std::vector<uint8_t> format_jpp_response(const uint8_t *body, std::size_t body_l
     out.insert(out.end(), reinterpret_cast<const uint8_t *>(cn),
                reinterpret_cast<const uint8_t *>(cn) + cnn);
   }
+  out.insert(out.end(), extra_headers.begin(), extra_headers.end());
   out.push_back('\r');
   out.push_back('\n');
   if (body != nullptr && body_len > 0) {
@@ -45,7 +47,8 @@ std::vector<uint8_t> format_jpp_response(const uint8_t *body, std::size_t body_l
 }
 
 std::vector<uint8_t> format_jpp_response_headers_chunked(const std::string &target_id,
-                                                         const std::string &cnew_header) {
+                                                         const std::string &cnew_header,
+                                                         const std::string &extra_headers) {
   // Same status line + JPIP response headers as the buffered path but with
   // `Transfer-Encoding: chunked` in place of `Content-Length`.  HTTP/1.1
   // §4.1: a message MUST NOT carry both Content-Length and Transfer-Encoding.
@@ -72,6 +75,7 @@ std::vector<uint8_t> format_jpp_response_headers_chunked(const std::string &targ
     out.insert(out.end(), reinterpret_cast<const uint8_t *>(cn),
                reinterpret_cast<const uint8_t *>(cn) + cnn);
   }
+  out.insert(out.end(), extra_headers.begin(), extra_headers.end());
   out.push_back('\r');
   out.push_back('\n');
   return out;

--- a/source/core/jpip/jpip_response.hpp
+++ b/source/core/jpip/jpip_response.hpp
@@ -21,10 +21,14 @@ namespace jpip {
 // payload.  `target_id` is the JPIP-tid response header (§D.2.3); an
 // empty string omits the header.  The response uses Connection: close
 // for v1 simplicity.
+// `extra_headers`, when non-empty, is a block of pre-formatted header
+// lines each terminated by CRLF (e.g. "JPIP-qid: 7\r\nCache-Control:
+// no-cache\r\n") inserted verbatim before the blank line.
 OPENHTJ2K_JPIP_EXPORT std::vector<uint8_t>
 format_jpp_response(const uint8_t *body, std::size_t body_len,
                     const std::string &target_id = "",
-                    const std::string &cnew_header = "");
+                    const std::string &cnew_header = "",
+                    const std::string &extra_headers = "");
 
 // Format only the HTTP/1.1 response headers for a chunked (`Transfer-Encoding:
 // chunked`) JPP-stream delivery.  The body bytes are written separately as
@@ -34,7 +38,8 @@ format_jpp_response(const uint8_t *body, std::size_t body_len,
 // headers from body.
 OPENHTJ2K_JPIP_EXPORT std::vector<uint8_t>
 format_jpp_response_headers_chunked(const std::string &target_id = "",
-                                    const std::string &cnew_header = "");
+                                    const std::string &cnew_header = "",
+                                    const std::string &extra_headers = "");
 
 // Build the HTTP/1.1 chunk header for a payload of `n` bytes: the hex length
 // followed by CRLF.  The caller writes this, then the `n` bytes of payload,

--- a/tests/jpip_phase1.cmake
+++ b/tests/jpip_phase1.cmake
@@ -14,6 +14,10 @@ add_test(NAME jpip_vbas_codec COMMAND jpip_vbas_check)
 # ── JPIP HTTP request/response formatting (§C.1–C.4, §D.2) ──
 add_test(NAME jpip_http_format COMMAND jpip_http_check)
 
+# ── JPIP sessions/channels: per-cid cache model, transport negotiation,
+#    type lists, qid echo, cclose, comps ranges (§B.2, §C.3, §C.9) ──
+add_test(NAME jpip_session COMMAND jpip_session_check)
+
 # ── TCP socket loopback (Phase 3 transport layer) ──
 add_test(NAME jpip_tcp_loopback COMMAND jpip_tcp_check)
 

--- a/tests/tools/jpip_session_check/CMakeLists.txt
+++ b/tests/tools/jpip_session_check/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_policy(SET CMP0076 NEW)
+target_sources(jpip_session_check
+    PRIVATE
+    main.cpp
+)
+target_include_directories(jpip_session_check PRIVATE ${CMAKE_SOURCE_DIR}/source/core/jpip)

--- a/tests/tools/jpip_session_check/main.cpp
+++ b/tests/tools/jpip_session_check/main.cpp
@@ -1,0 +1,251 @@
+// jpip_session_check: ctest harness for JPIP session/channel support
+// (ISO/IEC 15444-9 §B.2, §C.3, §C.9, §D.2.3, §D.2.4).
+//
+// Covers the interop fixes for session-mode clients:
+//   - ChannelManager: transport negotiation (Table D.1 exact-token rule),
+//     per-cid cache-model continuation, LRU eviction, cclose.
+//   - Request parser: type preference lists + media-type form (§C.4),
+//     qid (§C.3.5), cclose (§C.3.4), comps ranges (§C.4.6).
+//   - CacheModel: ":bytes" partial-bin qualifier and "-" subtractive
+//     statements (§C.9.2).
+//   - Response formatter: JPIP-qid echo via extra headers (§D.2.4).
+//
+// Self-contained — runs every test internally, takes no input.
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "cache_model.hpp"
+#include "channel_manager.hpp"
+#include "data_bin_emitter.hpp"
+#include "jpip_request.hpp"
+#include "jpip_response.hpp"
+#include "jpp_message.hpp"
+
+using open_htj2k::jpip::BinWindow;
+using open_htj2k::jpip::CacheModel;
+using open_htj2k::jpip::ChannelManager;
+using open_htj2k::jpip::emit_metadata_bin_zero;
+using open_htj2k::jpip::MessageHeaderContext;
+using open_htj2k::jpip::format_jpp_response;
+using open_htj2k::jpip::format_jpp_response_headers_chunked;
+using open_htj2k::jpip::JpipRequest;
+using open_htj2k::jpip::kMsgClassMainHeader;
+using open_htj2k::jpip::kMsgClassMetadata;
+using open_htj2k::jpip::kMsgClassPrecinct;
+using open_htj2k::jpip::parse_jpip_query;
+using open_htj2k::jpip::RequestParseStatus;
+
+namespace {
+
+int failures = 0;
+
+#define CHECK(cond, ...)                                            \
+  do {                                                              \
+    if (!(cond)) {                                                  \
+      std::fprintf(stderr, "FAIL [%s:%d] %s — ", __FILE__, __LINE__, #cond); \
+      std::fprintf(stderr, __VA_ARGS__);                            \
+      std::fprintf(stderr, "\n");                                   \
+      ++failures;                                                   \
+    }                                                               \
+  } while (0)
+
+bool contains(const std::vector<uint8_t> &resp, const std::string &needle) {
+  const std::string s(resp.begin(), resp.end());
+  return s.find(needle) != std::string::npos;
+}
+
+}  // namespace
+
+int main() {
+  // ── Transport negotiation (§C.3.3 + Table D.1) ────────────────────────
+  {
+    CHECK(ChannelManager::negotiate_transport("http") == "http", "plain http");
+    CHECK(ChannelManager::negotiate_transport("http-tcp,http") == "http", "list with http");
+    CHECK(ChannelManager::negotiate_transport(" http ") == "http", "whitespace trim");
+    // Table D.1: granted transport shall be one the client supplied —
+    // "http-tcp" alone must NOT be answered with "http".
+    CHECK(ChannelManager::negotiate_transport("http-tcp").empty(), "http-tcp alone");
+    CHECK(ChannelManager::negotiate_transport("http-udp").empty(), "http-udp alone");
+    CHECK(ChannelManager::negotiate_transport("https").empty(), "https unsupported");
+    CHECK(ChannelManager::negotiate_transport("").empty(), "empty list");
+  }
+
+  // ── ChannelManager lifecycle ──────────────────────────────────────────
+  {
+    ChannelManager cm;
+    const std::string cid = cm.open();
+    CHECK(!cid.empty(), "cid issued");
+    CacheModel snap;
+    CHECK(cm.snapshot(cid, &snap), "snapshot known cid");
+    CHECK(snap.size() == 0, "fresh channel model empty");
+    CHECK(!cm.snapshot("bogus", &snap), "snapshot unknown cid");
+
+    // Bins committed after delivery must be visible to the next request.
+    // Partial deliveries record their resume offset; complete ones the flag.
+    cm.commit(cid, {{kMsgClassMetadata, 0, 0, true},
+                    {kMsgClassMainHeader, 0, 142, true},
+                    {kMsgClassPrecinct, 7, 987, false}});
+    CHECK(cm.snapshot(cid, &snap), "snapshot after commit");
+    CHECK(snap.has(kMsgClassMetadata, 0), "metadata committed");
+    CHECK(snap.has(kMsgClassMainHeader, 0), "main header committed");
+    CHECK(!snap.has(kMsgClassPrecinct, 7), "partial precinct not complete");
+    CHECK(snap.received_bytes(kMsgClassPrecinct, 7) == 987, "partial resume offset kept");
+    CHECK(!snap.has(kMsgClassPrecinct, 8), "uncommitted bin absent");
+
+    // Completing the partial bin on a later response upgrades it.
+    cm.commit(cid, {{kMsgClassPrecinct, 7, 1500, true}});
+    CHECK(cm.snapshot(cid, &snap), "snapshot after completion");
+    CHECK(snap.has(kMsgClassPrecinct, 7), "precinct completed");
+
+    // Client-side model updates fold into the channel (§C.9).
+    CHECK(cm.apply_model(cid, "-P7"), "apply subtractive");
+    CHECK(cm.snapshot(cid, &snap), "snapshot after apply");
+    CHECK(!snap.has(kMsgClassPrecinct, 7), "subtractive unmarked precinct");
+
+    CHECK(cm.close(cid), "close known cid");
+    CHECK(!cm.close(cid), "double close");
+    CHECK(!cm.snapshot(cid, &snap), "snapshot after close");
+  }
+
+  // ── LRU eviction at the channel cap ───────────────────────────────────
+  {
+    ChannelManager cm(2);
+    const std::string a = cm.open();
+    const std::string b = cm.open();
+    CacheModel snap;
+    CHECK(cm.snapshot(a, &snap), "touch a (now b is LRU)");
+    const std::string c = cm.open();  // evicts b
+    CHECK(cm.size() == 2, "cap respected");
+    CHECK(cm.snapshot(a, &snap), "a survived");
+    CHECK(cm.snapshot(c, &snap), "c present");
+    CHECK(!cm.snapshot(b, &snap), "b evicted");
+  }
+
+  // ── type preference list + media-type form (§C.4) ─────────────────────
+  {
+    JpipRequest req;
+    CHECK(parse_jpip_query("type=jpp-stream", &req) == RequestParseStatus::Ok, "short token");
+    CHECK(req.type == "jpp-stream", "type stored");
+    CHECK(parse_jpip_query("type=jpp-stream,jpt-stream", &req) == RequestParseStatus::Ok,
+          "list with acceptable first");
+    CHECK(parse_jpip_query("type=jpt-stream,jpp-stream", &req) == RequestParseStatus::Ok,
+          "list with acceptable second");
+    CHECK(req.type == "jpp-stream", "served type is jpp-stream");
+    CHECK(parse_jpip_query("type=image/jpp-stream", &req) == RequestParseStatus::Ok,
+          "media-type form");
+    CHECK(parse_jpip_query("type=jpp-stream;ptype=ext", &req) == RequestParseStatus::Ok,
+          "parameter suffix ignored");
+    CHECK(parse_jpip_query("type=jpt-stream", &req) == RequestParseStatus::UnsupportedType,
+          "jpt only rejected");
+    CHECK(parse_jpip_query("type=raw", &req) == RequestParseStatus::UnsupportedType,
+          "raw rejected");
+  }
+
+  // ── qid (§C.3.5) and cclose (§C.3.4) ──────────────────────────────────
+  {
+    JpipRequest req;
+    CHECK(parse_jpip_query("qid=42&cid=JPH1", &req) == RequestParseStatus::Ok, "qid parse");
+    CHECK(req.has_qid && req.qid == 42, "qid value");
+    CHECK(req.has_cid && req.cid == "JPH1", "cid value");
+    CHECK(parse_jpip_query("qid=x7", &req) == RequestParseStatus::MalformedField, "qid malformed");
+
+    CHECK(parse_jpip_query("cclose=*&cid=JPH2", &req) == RequestParseStatus::Ok, "cclose star");
+    CHECK(req.has_cclose && req.cclose == "*", "cclose star value");
+    CHECK(parse_jpip_query("cclose=JPH3,JPH4", &req) == RequestParseStatus::Ok, "cclose list");
+    CHECK(req.cclose == "JPH3,JPH4", "cclose list value");
+  }
+
+  // ── comps ranges (§C.4.6) ─────────────────────────────────────────────
+  {
+    JpipRequest req;
+    CHECK(parse_jpip_query("comps=0-2", &req) == RequestParseStatus::Ok, "comps range");
+    CHECK(req.view_window.comps.size() == 3 && req.view_window.comps[2] == 2, "range expanded");
+    CHECK(parse_jpip_query("comps=0,3-5", &req) == RequestParseStatus::Ok, "mixed list");
+    CHECK(req.view_window.comps.size() == 4 && req.view_window.comps[3] == 5, "mixed expanded");
+    CHECK(parse_jpip_query("comps=2-1", &req) == RequestParseStatus::MalformedField,
+          "descending range rejected");
+    CHECK(parse_jpip_query("comps=x", &req) == RequestParseStatus::MalformedField,
+          "non-numeric rejected");
+  }
+
+  // ── CacheModel: partial-bin qualifier + subtractive statements (§C.9.2) ─
+  {
+    CacheModel m = CacheModel::parse("Hm,P0-9,-P5");
+    CHECK(m.has(kMsgClassMainHeader, 0), "Hm marked");
+    CHECK(m.has(kMsgClassPrecinct, 4), "P4 marked");
+    CHECK(!m.has(kMsgClassPrecinct, 5), "P5 unmarked by subtractive");
+
+    // A partial holding is not complete (cannot satisfy a whole-bin skip)
+    // but records its byte count so delivery resumes there (§C.9.2).
+    m = CacheModel::parse("P5:1234");
+    CHECK(!m.has(kMsgClassPrecinct, 5), "partial precinct not complete");
+    CHECK(m.received_bytes(kMsgClassPrecinct, 5) == 1234, "partial precinct byte count");
+    m = CacheModel::parse("Hm:20");
+    CHECK(!m.has(kMsgClassMainHeader, 0), "partial main header not complete");
+    CHECK(m.received_bytes(kMsgClassMainHeader, 0) == 20, "partial main header byte count");
+
+    // Holdings only grow; completion wins over any byte count.
+    m = CacheModel::parse("P5:1234");
+    m.mark_partial(kMsgClassPrecinct, 5, 100);
+    CHECK(m.received_bytes(kMsgClassPrecinct, 5) == 1234, "smaller partial is a no-op");
+    m.mark_partial(kMsgClassPrecinct, 5, 2000);
+    CHECK(m.received_bytes(kMsgClassPrecinct, 5) == 2000, "larger partial grows");
+    m.mark(kMsgClassPrecinct, 5);
+    CHECK(m.has(kMsgClassPrecinct, 5), "mark upgrades to complete");
+
+    // format() round-trips partial holdings with the ":bytes" qualifier.
+    m.clear();
+    m.mark_partial(kMsgClassPrecinct, 3, 555);
+    CacheModel rt = CacheModel::parse(m.format());
+    CHECK(!rt.has(kMsgClassPrecinct, 3), "round-trip partial not complete");
+    CHECK(rt.received_bytes(kMsgClassPrecinct, 3) == 555, "round-trip partial bytes");
+
+    // apply() folds updates onto existing state in statement order.
+    m = CacheModel::parse("P0-3");
+    m.apply("-P1,P9");
+    CHECK(!m.has(kMsgClassPrecinct, 1), "apply subtractive");
+    CHECK(m.has(kMsgClassPrecinct, 9), "apply additive");
+    CHECK(m.has(kMsgClassPrecinct, 0), "prior state kept");
+  }
+
+  // ── BinWindow: budget-blocked vs complete (empty metadata bin) ────────
+  {
+    MessageHeaderContext ctx;
+    std::vector<uint8_t> out;
+    BinWindow blocked;
+    blocked.budget = 1;  // smaller than any message header
+    emit_metadata_bin_zero(ctx, out, &blocked);
+    CHECK(out.empty(), "nothing appended under tiny budget");
+    CHECK(blocked.budget_blocked && !blocked.complete, "tiny budget reports blocked");
+
+    MessageHeaderContext ctx2;
+    BinWindow open_window;  // default: no cap
+    emit_metadata_bin_zero(ctx2, out, &open_window);
+    CHECK(!out.empty(), "empty bin emits its is_last message");
+    CHECK(open_window.complete && open_window.payload_sent == 0 && !open_window.budget_blocked,
+          "empty bin completes with zero payload");
+  }
+
+  // ── JPIP-qid echo via extra headers (§D.2.4) ──────────────────────────
+  {
+    const uint8_t body[] = {0x00};
+    auto resp = format_jpp_response(body, sizeof(body), "tid-x", "cid=JPH9,transport=http",
+                                    "JPIP-qid: 7\r\nCache-Control: no-cache\r\n");
+    CHECK(contains(resp, "JPIP-qid: 7\r\n"), "qid echoed");
+    CHECK(contains(resp, "Cache-Control: no-cache\r\n"), "no-cache present");
+    CHECK(contains(resp, "JPIP-cnew: cid=JPH9,transport=http\r\n"), "cnew present");
+
+    auto hdrs = format_jpp_response_headers_chunked("tid-x", "", "JPIP-qid: 3\r\n");
+    CHECK(contains(hdrs, "JPIP-qid: 3\r\n"), "qid echoed (chunked)");
+  }
+
+  if (failures) {
+    std::fprintf(stderr, "%d check(s) FAILED\n", failures);
+    return 1;
+  }
+  std::printf("jpip_session_check: all checks passed\n");
+  return 0;
+}


### PR DESCRIPTION
## Problem

Interop testing with an external interactive JPIP client failed. Root-cause analysis against the 15444-9 3ED text found four protocol violations, each independently fatal depending on client configuration:

1. **Fake channel grant** — the server returned `JPIP-cnew: cid=…` while remaining stateless. §C.3.3: a server unwilling to keep session state *shall not* return the header. Session clients stop sending `model=` once granted a cid, so every follow-up request received a byte-identical response — zero forward progress, the viewer stalls forever.
2. **No `JPIP-qid` echo** — §D.2.4 "shall".
3. **Transport grant mismatch** — `cnew=http-tcp` was answered with `transport=http` via substring match; Table D.1 requires granting only a transport the client offered.
4. **`type` parser over-strict** — §C.4 preference lists (`jpp-stream,jpt-stream`) and the media-type form (`image/jpp-stream`) got HTTP 501.

## Fix

- **`ChannelManager`** (new core module): per-cid cache model, LRU cap (64), `cclose` honoured after the response completes, unknown cid → 404 so clients re-establish. Granted channels never re-send delivered bins.
- **Resumable byte-windowed delivery** (`BinWindow` through the data-bin emitters): a bin larger than the remaining §C.6.1 `len` budget contributes a prefix and resumes at that byte offset on the next request. `CacheModel` now tracks per-bin byte offsets and speaks the §C.9.2 `:bytes` qualifier plus `-` subtractive statements; `len=0` yields an EOR-only response.
- Exact-token transport negotiation, `JPIP-qid` echo, `Cache-Control: no-cache` on session responses, `type` lists + media-type form, `comps` ranges.
- New `jpip_session_check` ctest (transport negotiation, channel lifecycle, LRU, partial-bin model round-trip, BinWindow budget semantics); `docs/jpip.md` updated.

## Verification

- Full ctest suite green (all 21 `jpip_*` tests included).
- curl session replay: byte-limited (`len=64000`) session window completes in 10 requests totalling 622,671 bytes vs 622,615 stateless single-shot (56 bytes resumption overhead), final EOR reason=2 (window-done); repeating the completed window returns the 3-byte EOR-only response with reason=2 as Table D.2 requires; `cnew=http-tcp` alone is refused and served statelessly; closed cids 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)