### PR TITLE
perf(jpip): per-tile precinct buckets + allocation-free model= parse

### DIFF
--- a/source/core/jpip/cache_model.cpp
+++ b/source/core/jpip/cache_model.cpp
@@ -6,7 +6,7 @@
 
 #include <algorithm>
 #include <cstdlib>
-#include <sstream>
+#include <cstring>
 #include <vector>
 
 namespace open_htj2k {
@@ -52,18 +52,18 @@ static const char *class_prefix(uint8_t cls) {
   }
 }
 
-static uint8_t prefix_to_class(const std::string &s, size_t &pos) {
+static uint8_t prefix_to_class(const char *&p, const char *end) {
   // Order matters — "Hm" and "Ht" must be tried before bare "H".  Accept
   // legacy "Hp" / "Ht" forms too so old clients (and our own pre-fix
   // serialiser output that may be cached anywhere) round-trip cleanly.
-  if (pos + 2 <= s.size()) {
-    if (s[pos] == 'H' && s[pos + 1] == 'm') { pos += 2; return kMsgClassMainHeader; }
-    if (s[pos] == 'H' && s[pos + 1] == 't') { pos += 2; return kMsgClassTileHeader; }
-    if (s[pos] == 'H' && s[pos + 1] == 'p') { pos += 2; return kMsgClassPrecinct; }
+  if (p + 2 <= end) {
+    if (p[0] == 'H' && p[1] == 'm') { p += 2; return kMsgClassMainHeader; }
+    if (p[0] == 'H' && p[1] == 't') { p += 2; return kMsgClassTileHeader; }
+    if (p[0] == 'H' && p[1] == 'p') { p += 2; return kMsgClassPrecinct; }
   }
-  if (pos < s.size() && s[pos] == 'P') { pos += 1; return kMsgClassPrecinct; }
-  if (pos < s.size() && s[pos] == 'H') { pos += 1; return kMsgClassTileHeader; }
-  if (pos < s.size() && s[pos] == 'M') { pos += 1; return kMsgClassMetadata; }
+  if (p < end && *p == 'P') { p += 1; return kMsgClassPrecinct; }
+  if (p < end && *p == 'H') { p += 1; return kMsgClassTileHeader; }
+  if (p < end && *p == 'M') { p += 1; return kMsgClassMetadata; }
   return 0xFF;
 }
 
@@ -148,26 +148,37 @@ void CacheModel::apply(const std::string &model_str) {
   CacheModel &m = *this;
   if (model_str.empty()) return;
 
-  // Split by comma
-  std::istringstream ss(model_str);
-  std::string token;
-  while (std::getline(ss, token, ',')) {
-    size_t pos = 0;
+  // Walk comma-separated tokens in place.  Viewers on gigapixel sessions
+  // send model strings that grow with their cache, so this runs on every
+  // stateless request with potentially long input — no per-token string
+  // or stringstream allocations.  strtoull naturally stops at ',' / '\0',
+  // so number parses never need a bounded copy; only character searches
+  // (memchr) are clamped to the token.
+  const char *p         = model_str.c_str();
+  const char *const end = p + model_str.size();
+  while (p < end) {
+    const char *tok_end =
+        static_cast<const char *>(std::memchr(p, ',', static_cast<size_t>(end - p)));
+    if (tok_end == nullptr) tok_end = end;
+    const char *q = p;
+    p             = (tok_end < end) ? tok_end + 1 : end;  // advance for next iteration
+
     // §C.9.2: a "-" prefix makes the statement subtractive — the client
     // has discarded the bin and the server must forget it was sent.
     bool subtractive = false;
-    if (pos < token.size() && token[pos] == '-') { subtractive = true; ++pos; }
-    uint8_t cls = prefix_to_class(token, pos);
+    if (q < tok_end && *q == '-') { subtractive = true; ++q; }
+    uint8_t cls = prefix_to_class(q, tok_end);
     if (cls == 0xFF) continue;
 
     // Main header: just "Hm" with no ID.  A ":bytes" qualifier (§C.9.2,
     // partial holding) can still follow.
     if (cls == kMsgClassMainHeader) {
-      const std::size_t colon = token.find(':', pos);
+      const char *colon =
+          static_cast<const char *>(std::memchr(q, ':', static_cast<size_t>(tok_end - q)));
       if (subtractive) {
         m.unmark(cls, 0);
-      } else if (colon != std::string::npos) {
-        m.mark_partial(cls, 0, std::strtoull(token.c_str() + colon + 1, nullptr, 10));
+      } else if (colon != nullptr) {
+        m.mark_partial(cls, 0, std::strtoull(colon + 1, nullptr, 10));
       } else {
         m.mark(cls, 0);
       }
@@ -180,21 +191,20 @@ void CacheModel::apply(const std::string &model_str) {
     // delivery (BinWindow skip).  Subtractive statements discard the
     // holding entirely — conservative for "-P5:1234" too, so the whole
     // bin is re-sent rather than risking a withheld tail.
-    if (pos >= token.size()) continue;
-    const char *numstart = token.c_str() + pos;
-    char *numend = nullptr;
-    uint64_t start = std::strtoull(numstart, &numend, 10);
-    if (numend == numstart) continue;
-    uint64_t end = start;
-    if (numend && *numend == '-') {
+    if (q >= tok_end) continue;
+    char *numend   = nullptr;
+    uint64_t start = std::strtoull(q, &numend, 10);
+    if (numend == q) continue;
+    uint64_t end_id = start;
+    if (numend < tok_end && *numend == '-') {
       const char *hs = numend + 1;
-      end = std::strtoull(hs, &numend, 10);
-      if (numend == hs || end < start) continue;
+      end_id = std::strtoull(hs, &numend, 10);
+      if (numend == hs || end_id < start) continue;
     }
     uint64_t partial_bytes = 0;
-    const bool partial = (numend && *numend == ':');
+    const bool partial     = (numend < tok_end && *numend == ':');
     if (partial) partial_bytes = std::strtoull(numend + 1, nullptr, 10);
-    for (uint64_t id = start; id <= end; ++id) {
+    for (uint64_t id = start; id <= end_id; ++id) {
       if (subtractive) m.unmark(cls, id);
       else if (partial) m.mark_partial(cls, id, partial_bytes);
       else m.mark(cls, id);

--- a/source/core/jpip/codestream_assembler.cpp
+++ b/source/core/jpip/codestream_assembler.cpp
@@ -77,7 +77,7 @@ ReassembleStatus reassemble_codestream(const uint8_t *codestream, std::size_t le
     std::vector<uint8_t> body;
 
     // Walk precincts in the order the source codestream visited them.
-    const auto order = locator.precincts_of_tile(static_cast<uint16_t>(t));
+    const auto &order = locator.precincts_of_tile(static_cast<uint16_t>(t));
     for (const auto &pk : order) {
       const uint64_t I = idx.I(pk.t, pk.c, pk.r, pk.p_rc);
       if (set.contains(kMsgClassPrecinct, I)) {

--- a/source/core/jpip/packet_locator.cpp
+++ b/source/core/jpip/packet_locator.cpp
@@ -22,6 +22,11 @@ const std::vector<PacketByteRange> &empty_ranges() {
   return v;
 }
 
+const std::vector<PrecinctKey> &empty_keys() {
+  static const std::vector<PrecinctKey> v;
+  return v;
+}
+
 // Translate a tile_buf-relative offset to an absolute codestream offset,
 // given the tile-part bodies that make up this tile's concatenated data.
 // Returns UINT64_MAX if the offset does not map into any tile-part body
@@ -84,7 +89,7 @@ std::unique_ptr<PacketLocator> PacketLocator::build(const uint8_t *codestream,
       pk.c    = c;
       pk.r    = r;
       pk.p_rc = p_rc;
-      self_raw->precinct_visit_order_.push_back(pk);
+      self_raw->precincts_by_tile_[t].push_back(pk);
     }
     entry.push_back(PacketByteRange{abs_off, length});
     ++self_raw->total_packets_;
@@ -124,12 +129,10 @@ const std::vector<PacketByteRange> &PacketLocator::packets_of(uint16_t t, uint16
   return it->second;
 }
 
-std::vector<PrecinctKey> PacketLocator::precincts_of_tile(uint16_t t) const {
-  std::vector<PrecinctKey> out;
-  for (const auto &pk : precinct_visit_order_) {
-    if (pk.t == t) out.push_back(pk);
-  }
-  return out;
+const std::vector<PrecinctKey> &PacketLocator::precincts_of_tile(uint16_t t) const {
+  auto it = precincts_by_tile_.find(t);
+  if (it == precincts_by_tile_.end()) return empty_keys();
+  return it->second;
 }
 
 }  // namespace jpip

--- a/source/core/jpip/packet_locator.hpp
+++ b/source/core/jpip/packet_locator.hpp
@@ -20,6 +20,7 @@
 #include <map>
 #include <memory>
 #include <tuple>
+#include <unordered_map>
 #include <vector>
 
 #include "codestream_walker.hpp"
@@ -68,17 +69,18 @@ class OPENHTJ2K_JPIP_EXPORT PacketLocator {
   // form a contiguous run in the codestream.  The returned keys all
   // share the requested tile index; an unknown tile returns an empty
   // vector.
-  std::vector<PrecinctKey> precincts_of_tile(uint16_t t) const;
+  const std::vector<PrecinctKey> &precincts_of_tile(uint16_t t) const;
 
  private:
   PacketLocator() = default;
 
   using Key = std::tuple<uint16_t, uint16_t, uint8_t, uint32_t>;
   std::map<Key, std::vector<PacketByteRange>> packets_;
-  // Precincts in first-appearance order, flat across all tiles.  The
-  // tile index on each PrecinctKey distinguishes them; precincts_of_tile()
-  // applies the obvious per-tile filter.
-  std::vector<PrecinctKey> precinct_visit_order_;
+  // Precincts in first-appearance order, bucketed by tile so per-tile
+  // lookups don't scan every precinct in the image (the reassembler
+  // walks tiles in declaration order, which on multi-tile codestreams
+  // made the flat-vector filter O(num_tiles × total_precincts)).
+  std::unordered_map<uint16_t, std::vector<PrecinctKey>> precincts_by_tile_;
   std::size_t total_packets_ = 0;
 };
 


### PR DESCRIPTION
## Summary
- `PacketLocator::precincts_of_tile()` previously filtered a flat visit-order vector of *all* precincts, so the codestream reassembler's per-tile walk was O(num_tiles × total_precincts) — significant on multi-tile codestreams (~41k tiles on heic2501a), and it runs per decode in the WASM viewer. Precincts are now bucketed by tile at build time; lookup is a hash find returning a const ref (the assembler call site now binds by reference, removing the per-tile copy too).
- `CacheModel::apply()` parsed `model=` with `istringstream` + per-token `std::string` copies on every stateless request. Model strings grow with the client cache on gigapixel sessions. The parser now walks the string in place with `memchr`/`strtoull`; token semantics (legacy `Hp`/`Ht` prefixes, subtractive `-`, ranges, `:bytes` partial qualifiers) are unchanged.

## Testing
- `ctest -R "^jpip_"` — 21/21 passed (wire format, server/client, assembler, partial-delivery identity/empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)