### PR TITLE
perf(rtp_recv): recvmmsg batching, frame-buffer pool, PBO texture uploads

### DIFF
--- a/source/apps/rtp_recv/frame_handler.cpp
+++ b/source/apps/rtp_recv/frame_handler.cpp
@@ -116,8 +116,14 @@ void FrameHandler::finalize_frame(std::optional<AssembledFrame>& out_frame) {
     f.mat           = frame_mat_;
     out_frame       = std::move(f);
     ++stats_.frames_emitted;
-    accum_.clear();  // std::move left us in a valid but empty state
-    accum_.reserve(kDefaultFrameCapacity);
+    // std::move left accum_ valid but capacity-less; draw the replacement
+    // from the pool when one is wired up so steady state allocates nothing.
+    if (pool_ != nullptr) {
+      accum_ = pool_->acquire(kDefaultFrameCapacity);
+    } else {
+      accum_.clear();
+      accum_.reserve(kDefaultFrameCapacity);
+    }
   } else {
     ++stats_.frames_dropped;
     accum_.clear();

--- a/source/apps/rtp_recv/frame_handler.hpp
+++ b/source/apps/rtp_recv/frame_handler.hpp
@@ -31,12 +31,53 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <mutex>
 #include <optional>
 #include <vector>
 
 #include "rfc9828_parser.hpp"
 
 namespace open_htj2k::rtp_recv {
+
+// Recycles codestream byte buffers across threads.  Without it the
+// receive side re-reserves a fresh multi-MB accumulator for every frame
+// it emits (finalize_frame std::moves the old one out), and the decode
+// thread frees that buffer one frame later — a 4 MB malloc/free pair per
+// frame, 60/s at 4K60, with allocation and deallocation on different
+// threads.  The pool is two uncontended lock acquisitions per frame.
+class BufferPool {
+ public:
+  // Returns an empty vector whose capacity is recycled from a previously
+  // released buffer when one is available, else freshly reserved to
+  // `reserve_hint`.
+  std::vector<uint8_t> acquire(size_t reserve_hint) {
+    {
+      std::lock_guard<std::mutex> lk(mu_);
+      if (!bufs_.empty()) {
+        std::vector<uint8_t> v = std::move(bufs_.back());
+        bufs_.pop_back();
+        v.clear();  // keeps capacity
+        return v;
+      }
+    }
+    std::vector<uint8_t> v;
+    v.reserve(reserve_hint);
+    return v;
+  }
+
+  // Hands a spent buffer back for reuse.  Bounded so a burst can't pin
+  // an unbounded number of multi-MB buffers.
+  void release(std::vector<uint8_t>&& v) {
+    if (v.capacity() == 0) return;
+    std::lock_guard<std::mutex> lk(mu_);
+    if (bufs_.size() < kMaxPooled) bufs_.emplace_back(std::move(v));
+  }
+
+ private:
+  static constexpr size_t kMaxPooled = 4;
+  std::mutex mu_;
+  std::vector<std::vector<uint8_t>> bufs_;
+};
 
 struct AssembledFrame {
   std::vector<uint8_t> bytes;       // complete JPEG 2000 codestream ready for openhtj2k_decoder
@@ -74,6 +115,13 @@ class FrameHandler {
   // Reserve capacity for a worst-case 4K HTJ2K frame.  Optional; resize-on-
   // push handles it regardless.
   void reserve_frame_capacity(size_t bytes);
+
+  // Optional buffer recycling: when set, finalize_frame() draws the next
+  // accumulator from `pool` instead of reserving a fresh one, and the
+  // consumer is expected to release() spent AssembledFrame::bytes back.
+  // The pool must outlive this handler.  Null (default) keeps the
+  // allocate-per-frame behaviour.
+  void set_buffer_pool(BufferPool* pool) { pool_ = pool; }
 
   // Reset every piece of state — invoked when the caller detects an RTP SSRC
   // change, or when it wants to discard a partially-assembled frame.
@@ -117,6 +165,9 @@ class FrameHandler {
 
   // Codestream accumulator.
   std::vector<uint8_t> accum_;
+
+  // Optional recycler for emitted frame buffers (see set_buffer_pool).
+  BufferPool* pool_ = nullptr;
 
   // Cached main header from the last R=1 Main Packet.
   std::vector<uint8_t> cached_main_;

--- a/source/apps/rtp_recv/frame_pipeline.hpp
+++ b/source/apps/rtp_recv/frame_pipeline.hpp
@@ -44,31 +44,31 @@ class LatestSlot {
   LatestSlot& operator=(const LatestSlot&) = delete;
 
   // Producer-side. Atomically replaces any existing item with `value`.
-  // Returns true if a previous item was discarded (and increments
-  // evictions()), false if the slot was empty. Wakes any waiting consumer.
+  // Returns the evicted previous item if the slot was occupied (and
+  // increments evictions()), std::nullopt if it was empty. Wakes any
+  // waiting consumer.
   //
   // The evicted item (if any) is moved out of the slot under the lock
-  // and destroyed *after* the lock is released.  For T = DecodedFrame
-  // that destructor frees multi-megabyte plane buffers, and holding the
-  // mutex across those free() calls would serialize the producer and
-  // consumer for the duration of the deallocation.  Moving the destroy
-  // outside the critical section keeps lock hold time proportional to
-  // the pointer swap, not to T's destructor cost.
-  bool push(T value) {
-    bool             evicted = false;
+  // and returned, so it is destroyed (or recycled — the receive thread
+  // returns evicted AssembledFrame buffers to the BufferPool) *after*
+  // the lock is released.  For T = DecodedFrame that destructor frees
+  // multi-megabyte plane buffers, and holding the mutex across those
+  // free() calls would serialize the producer and consumer for the
+  // duration of the deallocation.  Keeping the destroy outside the
+  // critical section keeps lock hold time proportional to the pointer
+  // swap, not to T's destructor cost.
+  std::optional<T> push(T value) {
     std::optional<T> stale;
     {
       std::lock_guard<std::mutex> lk(mu_);
       if (slot_.has_value()) {
-        evicted = true;
         ++evictions_;
         stale.swap(slot_);
       }
       slot_.emplace(std::move(value));
     }
-    // `stale` destructor runs here, outside the mutex.
     cv_.notify_one();
-    return evicted;
+    return stale;
   }
 
   // Consumer-side. Blocks until an item is available or `stop` becomes

--- a/source/apps/rtp_recv/gl_loader.cpp
+++ b/source/apps/rtp_recv/gl_loader.cpp
@@ -39,6 +39,7 @@ PFNGLDELETEVERTEXARRAYSPROC      DeleteVertexArrays      = nullptr;
 PFNGLGENBUFFERSPROC              GenBuffers              = nullptr;
 PFNGLBINDBUFFERPROC              BindBuffer              = nullptr;
 PFNGLBUFFERDATAPROC              BufferData              = nullptr;
+PFNGLBUFFERSUBDATAPROC           BufferSubData           = nullptr;
 PFNGLDELETEBUFFERSPROC           DeleteBuffers           = nullptr;
 
 PFNGLVERTEXATTRIBPOINTERPROC     VertexAttribPointer     = nullptr;
@@ -92,6 +93,7 @@ bool load_functions() {
   LOAD(GenBuffers,              "glGenBuffers");
   LOAD(BindBuffer,              "glBindBuffer");
   LOAD(BufferData,              "glBufferData");
+  LOAD(BufferSubData,           "glBufferSubData");
   LOAD(DeleteBuffers,           "glDeleteBuffers");
 
   LOAD(VertexAttribPointer,     "glVertexAttribPointer");

--- a/source/apps/rtp_recv/gl_loader.hpp
+++ b/source/apps/rtp_recv/gl_loader.hpp
@@ -43,7 +43,9 @@
 #    define GL_LINK_STATUS            0x8B82
 #    define GL_INFO_LOG_LENGTH        0x8B84
 #    define GL_ARRAY_BUFFER           0x8892
+#    define GL_PIXEL_UNPACK_BUFFER    0x88EC
 #    define GL_STATIC_DRAW            0x88E4
+#    define GL_STREAM_DRAW            0x88E0
 #    define GL_TEXTURE0               0x84C0
 #    define GL_TEXTURE1               0x84C1
 #    define GL_TEXTURE2               0x84C2
@@ -78,6 +80,7 @@
   typedef void    (APIENTRY *PFNGLGENBUFFERSPROC)(GLsizei n, GLuint *buffers);
   typedef void    (APIENTRY *PFNGLBINDBUFFERPROC)(GLenum target, GLuint buffer);
   typedef void    (APIENTRY *PFNGLBUFFERDATAPROC)(GLenum target, GLsizeiptr size, const void *data, GLenum usage);
+  typedef void    (APIENTRY *PFNGLBUFFERSUBDATAPROC)(GLenum target, GLintptr offset, GLsizeiptr size, const void *data);
   typedef void    (APIENTRY *PFNGLDELETEBUFFERSPROC)(GLsizei n, const GLuint *buffers);
   typedef void    (APIENTRY *PFNGLVERTEXATTRIBPOINTERPROC)(GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const void *pointer);
   typedef void    (APIENTRY *PFNGLENABLEVERTEXATTRIBARRAYPROC)(GLuint index);
@@ -117,6 +120,7 @@ extern PFNGLDELETEVERTEXARRAYSPROC      DeleteVertexArrays;
 extern PFNGLGENBUFFERSPROC              GenBuffers;
 extern PFNGLBINDBUFFERPROC              BindBuffer;
 extern PFNGLBUFFERDATAPROC              BufferData;
+extern PFNGLBUFFERSUBDATAPROC           BufferSubData;
 extern PFNGLDELETEBUFFERSPROC           DeleteBuffers;
 
 extern PFNGLVERTEXATTRIBPOINTERPROC     VertexAttribPointer;

--- a/source/apps/rtp_recv/gl_renderer.cpp
+++ b/source/apps/rtp_recv/gl_renderer.cpp
@@ -423,6 +423,13 @@ void GlRenderer::shutdown() {
     gl::DeleteBuffers(1, &b);
     vbo_ = 0;
   }
+  if (pbo_[0] != 0 && gl::DeleteBuffers != nullptr) {
+    const GLuint b[2] = {pbo_[0], pbo_[1]};
+    gl::DeleteBuffers(2, b);
+    pbo_[0] = pbo_[1] = 0;
+  }
+  pbo_next_     = 0;
+  pbo_disabled_ = false;
   if (vao_ != 0 && gl::DeleteVertexArrays != nullptr) {
     const GLuint a = vao_;
     gl::DeleteVertexArrays(1, &a);
@@ -605,6 +612,64 @@ void GlRenderer::upload_and_draw(const uint8_t* rgb, int w, int h) {
   glfwSwapBuffers(window_);
 }
 
+void GlRenderer::upload_planar_textures(const void* y_plane, const void* cb_plane,
+                                        const void* cr_plane, int w_y, int h_y, int w_c,
+                                        int h_c, unsigned int type, int bpp) {
+  const size_t y_bytes = static_cast<size_t>(w_y) * static_cast<size_t>(h_y)
+                         * static_cast<size_t>(bpp);
+  const size_t c_bytes = static_cast<size_t>(w_c) * static_cast<size_t>(h_c)
+                         * static_cast<size_t>(bpp);
+
+  glPixelStorei(GL_UNPACK_ALIGNMENT, bpp);
+
+  if (!pbo_disabled_ && pbo_[0] == 0) {
+    gl::GenBuffers(2, pbo_);
+    if (pbo_[0] == 0 || pbo_[1] == 0) {
+      check_gl_error("glGenBuffers(pbo ring)");
+      pbo_[0] = pbo_[1] = 0;
+      pbo_disabled_     = true;
+    }
+  }
+
+  if (!pbo_disabled_) {
+    const size_t total = y_bytes + 2 * c_bytes;
+    pbo_next_ ^= 1;
+    gl::BindBuffer(GL_PIXEL_UNPACK_BUFFER, pbo_[pbo_next_]);
+    // Orphan, then stage all three planes into the fresh store.  The
+    // subsequent glTexSubImage2D calls source from the PBO (offset in
+    // place of a client pointer) and return without waiting for the
+    // transfer to the textures to complete.
+    gl::BufferData(GL_PIXEL_UNPACK_BUFFER, static_cast<GLsizeiptr>(total), nullptr,
+                   GL_STREAM_DRAW);
+    gl::BufferSubData(GL_PIXEL_UNPACK_BUFFER, 0, static_cast<GLsizeiptr>(y_bytes), y_plane);
+    gl::BufferSubData(GL_PIXEL_UNPACK_BUFFER, static_cast<GLintptr>(y_bytes),
+                      static_cast<GLsizeiptr>(c_bytes), cb_plane);
+    gl::BufferSubData(GL_PIXEL_UNPACK_BUFFER, static_cast<GLintptr>(y_bytes + c_bytes),
+                      static_cast<GLsizeiptr>(c_bytes), cr_plane);
+    glBindTexture(GL_TEXTURE_2D, tex_y_);
+    glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w_y, h_y, GL_RED, type,
+                    reinterpret_cast<const void*>(static_cast<uintptr_t>(0)));
+    glBindTexture(GL_TEXTURE_2D, tex_cb_);
+    glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w_c, h_c, GL_RED, type,
+                    reinterpret_cast<const void*>(static_cast<uintptr_t>(y_bytes)));
+    glBindTexture(GL_TEXTURE_2D, tex_cr_);
+    glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w_c, h_c, GL_RED, type,
+                    reinterpret_cast<const void*>(static_cast<uintptr_t>(y_bytes + c_bytes)));
+    // Unbind so later glTexSubImage2D calls with client pointers (RGB
+    // fallback path) aren't misread as PBO offsets.
+    gl::BindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+    return;
+  }
+
+  // Direct client-memory uploads (PBO unavailable).
+  glBindTexture(GL_TEXTURE_2D, tex_y_);
+  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w_y, h_y, GL_RED, type, y_plane);
+  glBindTexture(GL_TEXTURE_2D, tex_cb_);
+  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w_c, h_c, GL_RED, type, cb_plane);
+  glBindTexture(GL_TEXTURE_2D, tex_cr_);
+  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w_c, h_c, GL_RED, type, cr_plane);
+}
+
 void GlRenderer::upload_planar_and_draw(const uint8_t* y_plane, const uint8_t* cb_plane,
                                         const uint8_t* cr_plane, int w_y, int h_y, int w_c,
                                         int h_c, const ycbcr_coefficients* coeffs,
@@ -614,16 +679,8 @@ void GlRenderer::upload_planar_and_draw(const uint8_t* y_plane, const uint8_t* c
 
   if (!ensure_planar_textures(w_y, h_y, w_c, h_c, /*bpp=*/1)) return;
 
-  // Upload Y.
-  glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-  glBindTexture(GL_TEXTURE_2D, tex_y_);
-  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w_y, h_y, GL_RED, GL_UNSIGNED_BYTE, y_plane);
-  // Upload Cb.
-  glBindTexture(GL_TEXTURE_2D, tex_cb_);
-  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w_c, h_c, GL_RED, GL_UNSIGNED_BYTE, cb_plane);
-  // Upload Cr.
-  glBindTexture(GL_TEXTURE_2D, tex_cr_);
-  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w_c, h_c, GL_RED, GL_UNSIGNED_BYTE, cr_plane);
+  upload_planar_textures(y_plane, cb_plane, cr_plane, w_y, h_y, w_c, h_c,
+                         GL_UNSIGNED_BYTE, /*bpp=*/1);
 
   // 8-bit source: the texture value already lives in the sample's native
   // [0, 1] range, so uNormScale is the identity.
@@ -645,14 +702,8 @@ void GlRenderer::upload_planar_16_and_draw(const uint16_t* y_plane, const uint16
 
   if (!ensure_planar_textures(w_y, h_y, w_c, h_c, /*bpp=*/2)) return;
 
-  // R16 row pitch is 2-byte aligned.
-  glPixelStorei(GL_UNPACK_ALIGNMENT, 2);
-  glBindTexture(GL_TEXTURE_2D, tex_y_);
-  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w_y, h_y, GL_RED, GL_UNSIGNED_SHORT, y_plane);
-  glBindTexture(GL_TEXTURE_2D, tex_cb_);
-  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w_c, h_c, GL_RED, GL_UNSIGNED_SHORT, cb_plane);
-  glBindTexture(GL_TEXTURE_2D, tex_cr_);
-  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w_c, h_c, GL_RED, GL_UNSIGNED_SHORT, cr_plane);
+  upload_planar_textures(y_plane, cb_plane, cr_plane, w_y, h_y, w_c, h_c,
+                         GL_UNSIGNED_SHORT, /*bpp=*/2);
 
   // GL_R16 reads back as (sample / 65535).  Multiply by this factor in the
   // shader to restore the sample's native [0, 1] range so the bias/scale/

--- a/source/apps/rtp_recv/gl_renderer.hpp
+++ b/source/apps/rtp_recv/gl_renderer.hpp
@@ -114,6 +114,16 @@ class GlRenderer {
   // silently skip reallocation on the others (same class of bug that
   // bit us when Cb/Cr shared (w, h) tracking in the initial draft).
   bool ensure_planar_textures(int w_y, int h_y, int w_c, int h_c, int bpp);
+  // Upload all three planes into tex_y_/tex_cb_/tex_cr_.  Goes through a
+  // double-buffered GL_PIXEL_UNPACK_BUFFER ring so glTexSubImage2D
+  // returns as soon as the driver has queued the DMA, instead of
+  // synchronously walking client memory three times per frame; the
+  // ping-pong plus per-frame orphaning keeps frame N+1's staging write
+  // from waiting on frame N's in-flight transfer.  Falls back to direct
+  // client-memory uploads if PBO setup fails.  `type` is
+  // GL_UNSIGNED_BYTE or GL_UNSIGNED_SHORT, matching `bpp` 1 or 2.
+  void upload_planar_textures(const void* y_plane, const void* cb_plane, const void* cr_plane,
+                              int w_y, int h_y, int w_c, int h_c, unsigned int type, int bpp);
   void draw_ycbcr_program(int w_y, int h_y, const ycbcr_coefficients* coeffs,
                           const float* norm_scale, const ColorPipelineParams& pipeline);
   void draw_planar_rgb_program(int w_y, int h_y, const float* norm_scale,
@@ -186,6 +196,13 @@ class GlRenderer {
   int          tex_cr_w_         = 0;
   int          tex_cr_h_         = 0;
   int          tex_cr_bpp_       = 0;
+
+  // Pixel-unpack buffer ring for the planar upload path (see
+  // upload_planar_textures).  pbo_disabled_ latches on if buffer
+  // creation ever fails so we don't retry every frame.
+  unsigned int pbo_[2]       = {0, 0};
+  int          pbo_next_     = 0;
+  bool         pbo_disabled_ = false;
 };
 
 }  // namespace open_htj2k::rtp_recv

--- a/source/apps/rtp_recv/pipeline_multi_threaded.cpp
+++ b/source/apps/rtp_recv/pipeline_multi_threaded.cpp
@@ -30,7 +30,16 @@ namespace {
 
 void recv_thread_main(const CliOptions& opts, UdpSocket& sock, FrameHandler& frame_handler,
                       ReceiverState& st) {
-  std::vector<uint8_t> packet_buf(65536);
+  // Batched receive: one buffer slab, one datagram per 64 KB stride (the
+  // UDP maximum, so nothing truncates).  On Linux recv_batch drains up to
+  // kBatch datagrams per recvmmsg syscall — at broadcast packet rates the
+  // receive thread otherwise spends a measurable share of its budget on
+  // syscall entry/exit.  Elsewhere recv_batch degrades to one datagram
+  // per call, identical to the previous loop.
+  constexpr int    kBatch  = 16;
+  constexpr size_t kStride = 65536;
+  std::vector<uint8_t> packet_buf(kBatch * kStride);
+  size_t               pkt_lengths[kBatch];
 
   while (!st.stop_flag.load(std::memory_order_acquire)) {
     const int ready = sock.wait_readable(/*timeout_ms=*/5);
@@ -47,53 +56,59 @@ void recv_thread_main(const CliOptions& opts, UdpSocket& sock, FrameHandler& fra
     // socket never falls behind real time.  No upper bound: with the
     // 32 MB SO_RCVBUF and the dedicated thread, this loop empties the
     // kernel buffer faster than it can fill at 30 fps × 4K.  The socket
-    // is non-blocking (set in run_receiver_threaded), so recv() returns
-    // kAgain immediately when the kernel buffer empties.
+    // is non-blocking (set in run_receiver_threaded), so recv_batch
+    // returns kAgain immediately when the kernel buffer empties.
     while (true) {
-      auto n = sock.recv(packet_buf.data(), packet_buf.size());
-      if (n == UdpSocket::kAgain) break;
-      if (n == UdpSocket::kError) {
+      const int n_msgs = sock.recv_batch(packet_buf.data(), kStride, kBatch, pkt_lengths);
+      if (n_msgs == UdpSocket::kAgain) break;
+      if (n_msgs == UdpSocket::kError) {
         std::fprintf(stderr, "recv error: %s\n", sock.last_error().c_str());
         st.stop_flag.store(true, std::memory_order_release);
         st.decode_slot.notify();
         st.render_slot.notify();
         return;
       }
-      if (n < 12) continue;
-      const auto pkt_len = static_cast<size_t>(n);
 
-      RtpHeader   rtp{};
-      std::string err;
-      if (!parse_rtp_header(packet_buf.data(), pkt_len, rtp, err)) continue;
-      if (rtp.payload_offset >= pkt_len) continue;
+      for (int m = 0; m < n_msgs; ++m) {
+        const uint8_t* pkt     = packet_buf.data() + static_cast<size_t>(m) * kStride;
+        const size_t   pkt_len = pkt_lengths[m];
+        if (pkt_len < 12) continue;
 
-      const uint8_t* payload    = packet_buf.data() + rtp.payload_offset;
-      const size_t   payload_sz = pkt_len - rtp.payload_offset;
-      if (payload_sz < 8) continue;
+        RtpHeader   rtp{};
+        std::string err;
+        if (!parse_rtp_header(pkt, pkt_len, rtp, err)) continue;
+        if (rtp.payload_offset >= pkt_len) continue;
 
-      const uint8_t                  mh = static_cast<uint8_t>(payload[0] >> 6);
-      std::optional<AssembledFrame>  emitted;
+        const uint8_t* payload    = pkt + rtp.payload_offset;
+        const size_t   payload_sz = pkt_len - rtp.payload_offset;
+        if (payload_sz < 8) continue;
 
-      if (mh == MH_BODY) {
-        BodyPacketHeader body{};
-        if (!parse_body_packet_header(payload, payload_sz, body, err)) continue;
-        const uint8_t* cs_bytes = payload + body.codestream_offset;
-        const size_t   cs_len   = payload_sz - body.codestream_offset;
-        frame_handler.push_body_packet(rtp, body, cs_bytes, cs_len, emitted);
-      } else {
-        MainPacketHeader main{};
-        if (!parse_main_packet_header(payload, payload_sz, main, err)) continue;
-        const uint8_t* cs_bytes = payload + main.codestream_offset;
-        const size_t   cs_len   = payload_sz - main.codestream_offset;
-        frame_handler.push_main_packet(rtp, main, cs_bytes, cs_len, emitted);
-      }
+        const uint8_t                  mh = static_cast<uint8_t>(payload[0] >> 6);
+        std::optional<AssembledFrame>  emitted;
 
-      if (emitted.has_value()) {
-        const uint64_t idx = st.frames_emitted_to_decode.fetch_add(1, std::memory_order_relaxed);
-        dump_frame_if_requested(opts, *emitted, idx);
-        // Latest-wins: if the decoder is busy and a previous frame is still
-        // queued, the previous frame is dropped.  Counter inside the slot.
-        st.decode_slot.push(std::move(*emitted));
+        if (mh == MH_BODY) {
+          BodyPacketHeader body{};
+          if (!parse_body_packet_header(payload, payload_sz, body, err)) continue;
+          const uint8_t* cs_bytes = payload + body.codestream_offset;
+          const size_t   cs_len   = payload_sz - body.codestream_offset;
+          frame_handler.push_body_packet(rtp, body, cs_bytes, cs_len, emitted);
+        } else {
+          MainPacketHeader main{};
+          if (!parse_main_packet_header(payload, payload_sz, main, err)) continue;
+          const uint8_t* cs_bytes = payload + main.codestream_offset;
+          const size_t   cs_len   = payload_sz - main.codestream_offset;
+          frame_handler.push_main_packet(rtp, main, cs_bytes, cs_len, emitted);
+        }
+
+        if (emitted.has_value()) {
+          const uint64_t idx = st.frames_emitted_to_decode.fetch_add(1, std::memory_order_relaxed);
+          dump_frame_if_requested(opts, *emitted, idx);
+          // Latest-wins: if the decoder is busy and a previous frame is still
+          // queued, the previous frame is dropped.  Counter inside the slot.
+          // Its buffer goes back to the pool instead of the heap.
+          auto evicted = st.decode_slot.push(std::move(*emitted));
+          if (evicted.has_value()) st.frame_buf_pool.release(std::move(evicted->bytes));
+        }
       }
     }
   }
@@ -277,6 +292,12 @@ void decode_thread_main(const CliOptions& opts, ReceiverState& st) {
         st.frames_decoded.fetch_add(1, std::memory_order_relaxed) + 1;
     first_frame = false;
 
+    // Decode is finished with the borrowed codestream bytes — recycle the
+    // buffer so the receive thread's next finalize_frame() reuses its
+    // capacity instead of allocating a fresh multi-MB vector.  (Failure
+    // paths above skip this and just free; drops are rare.)
+    st.frame_buf_pool.release(std::move(frame.bytes));
+
     // Hand the decoded RGB to the renderer.  If main hasn't picked up the
     // previous decoded frame yet (e.g. blocked in vsync), it gets dropped
     // here — latest-wins keeps motion-to-photon minimal.
@@ -357,6 +378,7 @@ int run_receiver_threaded(const CliOptions& opts) {
 
   FrameHandler  frame_handler;
   ReceiverState state;
+  frame_handler.set_buffer_pool(&state.frame_buf_pool);
 #ifdef OPENHTJ2K_USE_METAL
   state.renderer_ptr = renderer_ptr;
 #endif

--- a/source/apps/rtp_recv/pipeline_multi_threaded.hpp
+++ b/source/apps/rtp_recv/pipeline_multi_threaded.hpp
@@ -23,6 +23,12 @@ struct ReceiverState {
   LatestSlot<AssembledFrame>  decode_slot;
   LatestSlot<DecodedFrame>    render_slot;
 
+  // Recycles AssembledFrame codestream buffers: the decode thread (and
+  // the receive thread, on decode_slot eviction) releases spent buffers;
+  // the FrameHandler acquires its next accumulator from here.  Removes a
+  // per-frame multi-MB malloc/free pair split across the two threads.
+  BufferPool frame_buf_pool;
+
   // Counters (atomic for thread-safe summary at exit).
   std::atomic<uint64_t> frames_emitted_to_decode{0};  // dump index, increments per frame_handler emission
   std::atomic<uint64_t> frames_decoded{0};

--- a/source/apps/rtp_recv/rtp_socket.cpp
+++ b/source/apps/rtp_recv/rtp_socket.cpp
@@ -3,6 +3,12 @@
 //
 // Licensed under the same BSD 3-Clause terms as the rest of OpenHTJ2K.
 
+// recvmmsg(2) is a GNU extension; the feature-test macro must precede the
+// first libc include.
+#if defined(__linux__) && !defined(_GNU_SOURCE)
+  #define _GNU_SOURCE
+#endif
+
 #include "rtp_socket.hpp"
 
 #ifdef _WIN32
@@ -241,6 +247,42 @@ ptrdiff_t UdpSocket::recv(void* buf, size_t buf_size) {
   }
 #endif
   return static_cast<ptrdiff_t>(n);
+}
+
+int UdpSocket::recv_batch(uint8_t* bufs, size_t buf_stride, int max_msgs, size_t* lengths) {
+#if defined(__linux__)
+  if (fd_ == kInvalidSocket) {
+    last_error_ = "recv_batch(): socket not open";
+    return kError;
+  }
+  if (max_msgs < 1) return kAgain;
+  if (max_msgs > kMaxBatch) max_msgs = kMaxBatch;
+  mmsghdr msgs[kMaxBatch];
+  iovec   iovs[kMaxBatch];
+  std::memset(msgs, 0, sizeof(mmsghdr) * static_cast<size_t>(max_msgs));
+  for (int i = 0; i < max_msgs; ++i) {
+    iovs[i].iov_base           = bufs + static_cast<size_t>(i) * buf_stride;
+    iovs[i].iov_len            = buf_stride;
+    msgs[i].msg_hdr.msg_iov    = &iovs[i];
+    msgs[i].msg_hdr.msg_iovlen = 1;
+  }
+  const int n = ::recvmmsg(fd_, msgs, static_cast<unsigned>(max_msgs), 0, nullptr);
+  if (n < 0) {
+    if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) return kAgain;
+    last_error_ = socket_error_message("recvmmsg()");
+    return kError;
+  }
+  if (n == 0) return kAgain;
+  for (int i = 0; i < n; ++i) lengths[i] = msgs[i].msg_len;
+  return n;
+#else
+  // No batched receive on this platform — deliver one datagram per call.
+  (void)max_msgs;
+  const ptrdiff_t n = recv(bufs, buf_stride);
+  if (n == kAgain || n == kError) return static_cast<int>(n);
+  lengths[0] = static_cast<size_t>(n);
+  return 1;
+#endif
 }
 
 }  // namespace open_htj2k::rtp_recv

--- a/source/apps/rtp_recv/rtp_socket.hpp
+++ b/source/apps/rtp_recv/rtp_socket.hpp
@@ -72,6 +72,19 @@ class UdpSocket {
   // Safe to call in a tight receive loop; no allocation.
   ptrdiff_t recv(void* buf, size_t buf_size);
 
+  // Receive up to `max_msgs` datagrams in one call.  Datagram i lands at
+  // bufs + i * buf_stride (each truncated to buf_stride bytes, like recv)
+  // and its length is written to lengths[i].  Returns the number of
+  // datagrams received (>= 1), kAgain, or kError.
+  //
+  // On Linux this is one recvmmsg(2) syscall — at broadcast packet rates
+  // (thousands of packets/sec) batching cuts the receive thread's syscall
+  // count by the batch factor.  Other platforms have no batched receive,
+  // so the fallback delivers a single datagram per call; callers need no
+  // platform-specific handling.  max_msgs is clamped to kMaxBatch.
+  static constexpr int kMaxBatch = 32;
+  int recv_batch(uint8_t* bufs, size_t buf_stride, int max_msgs, size_t* lengths);
+
   // Set SO_RCVBUF hint (best-effort).  Useful for 4K streams at high bitrate.
   // On Linux the kernel doubles the value and clamps to net.core.rmem_max;
   // on Windows the default limit is typically generous (8 MB+).


### PR DESCRIPTION
## Summary
Three independent hot-path optimizations for the RFC 9828 receiver:

1. **Batched socket drain** — the receive thread now drains the kernel buffer via `UdpSocket::recv_batch()`, which on Linux is one `recvmmsg(2)` syscall per up-to-16 datagrams (previously one syscall per packet — thousands/sec at broadcast rates). Non-Linux platforms fall back to one datagram per call, so behaviour there is identical to the old loop.

2. **Frame-buffer recycling** — a `BufferPool` recycles `AssembledFrame` codestream buffers between the decode thread (release after decode) and `FrameHandler` (acquire in `finalize_frame`). Previously every emitted frame reserved a fresh 4 MB accumulator and the spent one was freed on the decode thread: a cross-thread malloc/free pair per frame, 60/s at 4K60. `LatestSlot::push` now returns the evicted item (still destroyed outside the lock, preserving the short-critical-section property) so the receive thread recycles eviction victims too.

3. **PBO texture uploads** — the GL renderer's planar upload path goes through a double-buffered `GL_PIXEL_UNPACK_BUFFER` ring (orphan + stage + offset-sourced `glTexSubImage2D`), so the three per-frame plane uploads queue as DMA instead of synchronously walking client memory. Falls back to direct uploads if PBO setup fails. This mainly benefits the Linux GL path; macOS defaults to the zero-copy Metal renderer.

## Testing
- Clean Release build on macOS (NEON), `--smoke-test` all green.
- Paced 30-frame multi-packet loopback (Main + Body packets, 180 datagrams): 30/30 emitted/pushed/decoded, 0 drops, 0 sequence gaps.
- Unpaced 180-packet blast exercising the latest-wins eviction → pool-recycle path: no crashes, evictions accounted.
- Linux `recvmmsg` branch compiled with gcc 13 (`-Wall -Wextra`, zero warnings) and functionally tested in a container: 100 varied-size datagrams round-trip byte-exact, 7 batches, max batch 16. (CI does not build `-DOPENHTJ2K_RTP=ON`, hence the container check.)
- PBO path compiles on macOS/Linux; recommend an A/B run on the Ryzen/Linux box (`--color-path shader`) before relying on it, per the usual measure-first practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)