### PR TITLE
revert(rtp_recv): drop PBO texture-upload ring — A/B shows regression

### DIFF
--- a/source/apps/rtp_recv/gl_loader.cpp
+++ b/source/apps/rtp_recv/gl_loader.cpp
@@ -39,7 +39,6 @@ PFNGLDELETEVERTEXARRAYSPROC      DeleteVertexArrays      = nullptr;
 PFNGLGENBUFFERSPROC              GenBuffers              = nullptr;
 PFNGLBINDBUFFERPROC              BindBuffer              = nullptr;
 PFNGLBUFFERDATAPROC              BufferData              = nullptr;
-PFNGLBUFFERSUBDATAPROC           BufferSubData           = nullptr;
 PFNGLDELETEBUFFERSPROC           DeleteBuffers           = nullptr;
 
 PFNGLVERTEXATTRIBPOINTERPROC     VertexAttribPointer     = nullptr;
@@ -93,7 +92,6 @@ bool load_functions() {
   LOAD(GenBuffers,              "glGenBuffers");
   LOAD(BindBuffer,              "glBindBuffer");
   LOAD(BufferData,              "glBufferData");
-  LOAD(BufferSubData,           "glBufferSubData");
   LOAD(DeleteBuffers,           "glDeleteBuffers");
 
   LOAD(VertexAttribPointer,     "glVertexAttribPointer");

--- a/source/apps/rtp_recv/gl_loader.hpp
+++ b/source/apps/rtp_recv/gl_loader.hpp
@@ -43,9 +43,7 @@
 #    define GL_LINK_STATUS            0x8B82
 #    define GL_INFO_LOG_LENGTH        0x8B84
 #    define GL_ARRAY_BUFFER           0x8892
-#    define GL_PIXEL_UNPACK_BUFFER    0x88EC
 #    define GL_STATIC_DRAW            0x88E4
-#    define GL_STREAM_DRAW            0x88E0
 #    define GL_TEXTURE0               0x84C0
 #    define GL_TEXTURE1               0x84C1
 #    define GL_TEXTURE2               0x84C2
@@ -80,7 +78,6 @@
   typedef void    (APIENTRY *PFNGLGENBUFFERSPROC)(GLsizei n, GLuint *buffers);
   typedef void    (APIENTRY *PFNGLBINDBUFFERPROC)(GLenum target, GLuint buffer);
   typedef void    (APIENTRY *PFNGLBUFFERDATAPROC)(GLenum target, GLsizeiptr size, const void *data, GLenum usage);
-  typedef void    (APIENTRY *PFNGLBUFFERSUBDATAPROC)(GLenum target, GLintptr offset, GLsizeiptr size, const void *data);
   typedef void    (APIENTRY *PFNGLDELETEBUFFERSPROC)(GLsizei n, const GLuint *buffers);
   typedef void    (APIENTRY *PFNGLVERTEXATTRIBPOINTERPROC)(GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const void *pointer);
   typedef void    (APIENTRY *PFNGLENABLEVERTEXATTRIBARRAYPROC)(GLuint index);
@@ -120,7 +117,6 @@ extern PFNGLDELETEVERTEXARRAYSPROC      DeleteVertexArrays;
 extern PFNGLGENBUFFERSPROC              GenBuffers;
 extern PFNGLBINDBUFFERPROC              BindBuffer;
 extern PFNGLBUFFERDATAPROC              BufferData;
-extern PFNGLBUFFERSUBDATAPROC           BufferSubData;
 extern PFNGLDELETEBUFFERSPROC           DeleteBuffers;
 
 extern PFNGLVERTEXATTRIBPOINTERPROC     VertexAttribPointer;

--- a/source/apps/rtp_recv/gl_renderer.cpp
+++ b/source/apps/rtp_recv/gl_renderer.cpp
@@ -423,13 +423,6 @@ void GlRenderer::shutdown() {
     gl::DeleteBuffers(1, &b);
     vbo_ = 0;
   }
-  if (pbo_[0] != 0 && gl::DeleteBuffers != nullptr) {
-    const GLuint b[2] = {pbo_[0], pbo_[1]};
-    gl::DeleteBuffers(2, b);
-    pbo_[0] = pbo_[1] = 0;
-  }
-  pbo_next_     = 0;
-  pbo_disabled_ = false;
   if (vao_ != 0 && gl::DeleteVertexArrays != nullptr) {
     const GLuint a = vao_;
     gl::DeleteVertexArrays(1, &a);
@@ -615,53 +608,18 @@ void GlRenderer::upload_and_draw(const uint8_t* rgb, int w, int h) {
 void GlRenderer::upload_planar_textures(const void* y_plane, const void* cb_plane,
                                         const void* cr_plane, int w_y, int h_y, int w_c,
                                         int h_c, unsigned int type, int bpp) {
-  const size_t y_bytes = static_cast<size_t>(w_y) * static_cast<size_t>(h_y)
-                         * static_cast<size_t>(bpp);
-  const size_t c_bytes = static_cast<size_t>(w_c) * static_cast<size_t>(h_c)
-                         * static_cast<size_t>(bpp);
-
+  // Deliberately direct client-memory uploads, NOT a pixel-unpack-buffer
+  // ring.  A glBufferData(orphan) + glBufferSubData PBO ring was A/B
+  // tested on the 4K59.94 4:2:2 1.7 bpp reference stream (Ryzen 9 9950X
+  // + RTX 4070 SUPER, driver 595.71.05, 2026-06-13) and lost decisively:
+  // 46.7 vs 54.0 fps, main-thread CPU 55% vs 33%, and the extra ~17
+  // MB/frame staging memcpy slowed the decode threads too (avg 10.8 ms
+  // vs 8.0 ms).  The driver's direct glTexSubImage2D path already does
+  // pinned-buffer DMA; staging through BufferSubData just adds a copy.
+  // A PBO design can only win here if the decoder writes straight into
+  // a persistently-mapped buffer (as the Metal path does) — anything
+  // that re-copies an existing client buffer is net negative.
   glPixelStorei(GL_UNPACK_ALIGNMENT, bpp);
-
-  if (!pbo_disabled_ && pbo_[0] == 0) {
-    gl::GenBuffers(2, pbo_);
-    if (pbo_[0] == 0 || pbo_[1] == 0) {
-      check_gl_error("glGenBuffers(pbo ring)");
-      pbo_[0] = pbo_[1] = 0;
-      pbo_disabled_     = true;
-    }
-  }
-
-  if (!pbo_disabled_) {
-    const size_t total = y_bytes + 2 * c_bytes;
-    pbo_next_ ^= 1;
-    gl::BindBuffer(GL_PIXEL_UNPACK_BUFFER, pbo_[pbo_next_]);
-    // Orphan, then stage all three planes into the fresh store.  The
-    // subsequent glTexSubImage2D calls source from the PBO (offset in
-    // place of a client pointer) and return without waiting for the
-    // transfer to the textures to complete.
-    gl::BufferData(GL_PIXEL_UNPACK_BUFFER, static_cast<GLsizeiptr>(total), nullptr,
-                   GL_STREAM_DRAW);
-    gl::BufferSubData(GL_PIXEL_UNPACK_BUFFER, 0, static_cast<GLsizeiptr>(y_bytes), y_plane);
-    gl::BufferSubData(GL_PIXEL_UNPACK_BUFFER, static_cast<GLintptr>(y_bytes),
-                      static_cast<GLsizeiptr>(c_bytes), cb_plane);
-    gl::BufferSubData(GL_PIXEL_UNPACK_BUFFER, static_cast<GLintptr>(y_bytes + c_bytes),
-                      static_cast<GLsizeiptr>(c_bytes), cr_plane);
-    glBindTexture(GL_TEXTURE_2D, tex_y_);
-    glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w_y, h_y, GL_RED, type,
-                    reinterpret_cast<const void*>(static_cast<uintptr_t>(0)));
-    glBindTexture(GL_TEXTURE_2D, tex_cb_);
-    glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w_c, h_c, GL_RED, type,
-                    reinterpret_cast<const void*>(static_cast<uintptr_t>(y_bytes)));
-    glBindTexture(GL_TEXTURE_2D, tex_cr_);
-    glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w_c, h_c, GL_RED, type,
-                    reinterpret_cast<const void*>(static_cast<uintptr_t>(y_bytes + c_bytes)));
-    // Unbind so later glTexSubImage2D calls with client pointers (RGB
-    // fallback path) aren't misread as PBO offsets.
-    gl::BindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
-    return;
-  }
-
-  // Direct client-memory uploads (PBO unavailable).
   glBindTexture(GL_TEXTURE_2D, tex_y_);
   glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w_y, h_y, GL_RED, type, y_plane);
   glBindTexture(GL_TEXTURE_2D, tex_cb_);

--- a/source/apps/rtp_recv/gl_renderer.hpp
+++ b/source/apps/rtp_recv/gl_renderer.hpp
@@ -114,13 +114,9 @@ class GlRenderer {
   // silently skip reallocation on the others (same class of bug that
   // bit us when Cb/Cr shared (w, h) tracking in the initial draft).
   bool ensure_planar_textures(int w_y, int h_y, int w_c, int h_c, int bpp);
-  // Upload all three planes into tex_y_/tex_cb_/tex_cr_.  Goes through a
-  // double-buffered GL_PIXEL_UNPACK_BUFFER ring so glTexSubImage2D
-  // returns as soon as the driver has queued the DMA, instead of
-  // synchronously walking client memory three times per frame; the
-  // ping-pong plus per-frame orphaning keeps frame N+1's staging write
-  // from waiting on frame N's in-flight transfer.  Falls back to direct
-  // client-memory uploads if PBO setup fails.  `type` is
+  // Upload all three planes into tex_y_/tex_cb_/tex_cr_ via direct
+  // client-memory glTexSubImage2D (see the comment in the definition for
+  // why a PBO staging ring was tried and rejected).  `type` is
   // GL_UNSIGNED_BYTE or GL_UNSIGNED_SHORT, matching `bpp` 1 or 2.
   void upload_planar_textures(const void* y_plane, const void* cb_plane, const void* cr_plane,
                               int w_y, int h_y, int w_c, int h_c, unsigned int type, int bpp);
@@ -196,13 +192,6 @@ class GlRenderer {
   int          tex_cr_w_         = 0;
   int          tex_cr_h_         = 0;
   int          tex_cr_bpp_       = 0;
-
-  // Pixel-unpack buffer ring for the planar upload path (see
-  // upload_planar_textures).  pbo_disabled_ latches on if buffer
-  // creation ever fails so we don't retry every frame.
-  unsigned int pbo_[2]       = {0, 0};
-  int          pbo_next_     = 0;
-  bool         pbo_disabled_ = false;
 };
 
 }  // namespace open_htj2k::rtp_recv


### PR DESCRIPTION
## Summary
Removes the PBO upload ring introduced in #427, keeping the consolidated `upload_planar_textures()` helper as a direct `glTexSubImage2D` path. The recvmmsg batching and BufferPool changes from #427 are untouched.

## A/B results (the follow-up promised in #427)
Workload: `From_camera_4K_5994_422_1.7bpp.rtp` replayed at ~900 Mbps over loopback; receiver `--threads 4 --color-path shader --no-vsync --pace-fps 0 --frames 600`, GL window on the Ryzen 9 9950X + RTX 4070 SUPER (driver 595.71.05). Three interleaved trials per variant; snapshotted binaries differing only in the PBO default.

| metric | PBO ring | direct upload |
|---|---|---|
| avg FPS | 47.5 / 46.2 / 46.3 | 54.0 / 53.9 / 53.9 |
| decode avg (ms) | 10.8 / 10.9 / 11.3 | 8.0 / 8.2 / 8.9 |
| main-thread CPU | 55.4% | 33.0% |
| render-slot evicts | 0 | 0 |

Diagnosis: `glBufferData(orphan)` + `glBufferSubData` stages a full extra CPU copy (~17 MB/frame at 4K 4:2:2) through driver memory on the main thread, and the added DRAM traffic slows the decode threads too. NVIDIA's direct `glTexSubImage2D` already does pinned-buffer DMA. A retained comment documents that a PBO approach is only viable if the decoder writes directly into a persistently-mapped buffer (like the zero-copy Metal path) — re-copying an existing client buffer is net negative.

Note: the test runs also surfaced that the box's `net.core.rmem_max` is back at the 212 kB default (kernel granted only 416 KB of the requested 32 MB SO_RCVBUF), causing packet drops at 900 Mbps — worth re-persisting `sysctl -w net.core.rmem_max=33554432`.

## Testing
- Clean Release build on macOS; `--smoke-test` all green.
- The "direct" A/B variant above is byte-for-byte this code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)