### PR TITLE
perf(rtp_recv): persistent-mapped GL zero-copy plane upload

### DIFF
--- a/source/apps/rtp_recv/frame_pipeline.hpp
+++ b/source/apps/rtp_recv/frame_pipeline.hpp
@@ -178,13 +178,14 @@ struct DecodedFrame {
   // "reference established" flag rather than on source_rtp_ts != 0.
   uint32_t                  source_rtp_ts      = 0;
 
-#ifdef OPENHTJ2K_USE_METAL
-  // Zero-copy Metal path: ring buffer index into MetalRenderer's internal
-  // buffer pool.  When >= 0, the plane data lives in GPU-visible shared
-  // memory and the renderer skips the memcpy upload.  -1 = not used (CPU
-  // vector path).  This field is harmless on non-Metal builds (never set).
-  int                       metal_ring_index   = -1;
-#endif
+  // Zero-copy path: ring buffer index into the renderer's internal buffer
+  // pool (MetalRenderer's MTLBuffer ring on macOS, GlRenderer's
+  // persistently-mapped GL_PIXEL_UNPACK_BUFFER ring elsewhere).  When
+  // >= 0, the plane data already lives in GPU-visible memory: the decoder
+  // wrote it there directly, the plane vectors above are empty, and the
+  // renderer draws via draw_acquired_planes() with no upload memcpy.
+  // -1 = plane-vector path.
+  int                       ring_index         = -1;
 };
 
 }  // namespace open_htj2k::rtp_recv

--- a/source/apps/rtp_recv/gl_loader.cpp
+++ b/source/apps/rtp_recv/gl_loader.cpp
@@ -46,6 +46,14 @@ PFNGLENABLEVERTEXATTRIBARRAYPROC EnableVertexAttribArray = nullptr;
 
 PFNGLACTIVETEXTUREPROC           ActiveTexture           = nullptr;
 
+const GLubyte* (APIENTRY *GetStringi)(GLenum, GLuint)                                  = nullptr;
+void           (APIENTRY *BufferStorage)(GLenum, GLsizeiptr, const void*, GLbitfield)  = nullptr;
+void*          (APIENTRY *MapBufferRange)(GLenum, GLintptr, GLsizeiptr, GLbitfield)    = nullptr;
+GLboolean      (APIENTRY *UnmapBuffer)(GLenum)                                         = nullptr;
+GLsync         (APIENTRY *FenceSync)(GLenum, GLbitfield)                               = nullptr;
+GLenum         (APIENTRY *ClientWaitSync)(GLsync, GLbitfield, GLuint64)                = nullptr;
+void           (APIENTRY *DeleteSync)(GLsync)                                          = nullptr;
+
 namespace {
 template <typename T>
 bool resolve(T& out, const char* name) {
@@ -100,6 +108,24 @@ bool load_functions() {
   LOAD(ActiveTexture,           "glActiveTexture");
 #undef LOAD
   return true;
+}
+
+bool load_zero_copy_functions() {
+  // Quiet resolution: nulls are an expected outcome on GL < 4.4 (macOS).
+  auto get = [](const char* name) { return glfwGetProcAddress(name); };
+  GetStringi     = reinterpret_cast<const GLubyte* (APIENTRY*)(GLenum, GLuint)>(get("glGetStringi"));
+  BufferStorage  = reinterpret_cast<void (APIENTRY*)(GLenum, GLsizeiptr, const void*, GLbitfield)>(
+      get("glBufferStorage"));
+  MapBufferRange = reinterpret_cast<void* (APIENTRY*)(GLenum, GLintptr, GLsizeiptr, GLbitfield)>(
+      get("glMapBufferRange"));
+  UnmapBuffer    = reinterpret_cast<GLboolean (APIENTRY*)(GLenum)>(get("glUnmapBuffer"));
+  FenceSync      = reinterpret_cast<GLsync (APIENTRY*)(GLenum, GLbitfield)>(get("glFenceSync"));
+  ClientWaitSync = reinterpret_cast<GLenum (APIENTRY*)(GLsync, GLbitfield, GLuint64)>(
+      get("glClientWaitSync"));
+  DeleteSync     = reinterpret_cast<void (APIENTRY*)(GLsync)>(get("glDeleteSync"));
+  return GetStringi != nullptr && BufferStorage != nullptr && MapBufferRange != nullptr &&
+         UnmapBuffer != nullptr && FenceSync != nullptr && ClientWaitSync != nullptr &&
+         DeleteSync != nullptr;
 }
 
 }  // namespace open_htj2k::rtp_recv::gl

--- a/source/apps/rtp_recv/gl_loader.hpp
+++ b/source/apps/rtp_recv/gl_loader.hpp
@@ -34,6 +34,8 @@
   typedef char         GLchar;
   typedef ptrdiff_t    GLsizeiptr;
   typedef ptrdiff_t    GLintptr;
+  typedef struct __GLsync* GLsync;
+  typedef unsigned long long GLuint64;
 
   // GL constants not in Windows GL 1.1 headers:
 #  ifndef GL_FRAGMENT_SHADER
@@ -51,6 +53,13 @@
 #    define GL_R16                    0x822A
 #    define GL_RED                    0x1903
 #    define GL_CLAMP_TO_EDGE          0x812F
+#    define GL_NUM_EXTENSIONS         0x821D
+#    define GL_MAP_WRITE_BIT          0x0002
+#    define GL_SYNC_GPU_COMMANDS_COMPLETE 0x9117
+#    define GL_ALREADY_SIGNALED       0x911A
+#    define GL_TIMEOUT_EXPIRED        0x911B
+#    define GL_CONDITION_SATISFIED    0x911C
+#    define GL_WAIT_FAILED            0x911D
 #  endif
 
   // GL 2.0+ function-pointer typedefs:
@@ -85,6 +94,20 @@
 #else
 #  include <GL/gl.h>
 #  include <GL/glext.h>
+#endif
+
+// ARB_buffer_storage (GL 4.4) tokens are absent from the macOS headers
+// (Apple GL stops at 4.1) and from our minimal Windows block above.
+#ifndef GL_PIXEL_UNPACK_BUFFER
+#  define GL_PIXEL_UNPACK_BUFFER     0x88EC
+#endif
+#ifndef GL_MAP_PERSISTENT_BIT
+#  define GL_MAP_PERSISTENT_BIT      0x0040
+#  define GL_MAP_COHERENT_BIT        0x0080
+#endif
+
+#ifndef APIENTRY
+#  define APIENTRY
 #endif
 
 namespace open_htj2k::rtp_recv::gl {
@@ -124,10 +147,30 @@ extern PFNGLENABLEVERTEXATTRIBARRAYPROC EnableVertexAttribArray;
 
 extern PFNGLACTIVETEXTUREPROC           ActiveTexture;
 
+// ── Optional zero-copy upload symbols ───────────────────────────────────
+// GetStringi is GL 3.0, the sync trio is GL 3.2, MapBufferRange/UnmapBuffer
+// are GL 3.0, and BufferStorage is GL 4.4 / ARB_buffer_storage.  Declared
+// with inline function-pointer types (not PFNGL*PROC names) because the
+// macOS headers don't ship typedefs past 4.1.  Resolved separately by
+// load_zero_copy_functions(); any of these may legitimately stay null
+// (the renderer then keeps its plane-vector upload path).
+extern const GLubyte* (APIENTRY *GetStringi)(GLenum name, GLuint index);
+extern void           (APIENTRY *BufferStorage)(GLenum target, GLsizeiptr size, const void* data, GLbitfield flags);
+extern void*          (APIENTRY *MapBufferRange)(GLenum target, GLintptr offset, GLsizeiptr length, GLbitfield access);
+extern GLboolean      (APIENTRY *UnmapBuffer)(GLenum target);
+extern GLsync         (APIENTRY *FenceSync)(GLenum condition, GLbitfield flags);
+extern GLenum         (APIENTRY *ClientWaitSync)(GLsync sync, GLbitfield flags, GLuint64 timeout);
+extern void           (APIENTRY *DeleteSync)(GLsync sync);
+
 // Resolve every pointer above via glfwGetProcAddress.  On success returns
 // true; on the first failure logs the missing symbol to stderr and returns
 // false (leaving the already-resolved pointers populated, since the caller
 // is expected to treat this as fatal for the shader path).
 bool load_functions();
+
+// Resolve the optional zero-copy symbols.  Returns true only if ALL of
+// them resolved; never fatal — callers treat false as "feature absent".
+// Does not log: missing 4.4 entry points are expected on macOS.
+bool load_zero_copy_functions();
 
 }  // namespace open_htj2k::rtp_recv::gl

--- a/source/apps/rtp_recv/gl_renderer.cpp
+++ b/source/apps/rtp_recv/gl_renderer.cpp
@@ -11,6 +11,7 @@
 #include <GLFW/glfw3.h>
 
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 
 namespace open_htj2k::rtp_recv {
@@ -207,6 +208,18 @@ void main() {
 }
 )glsl";
 
+bool has_gl_extension(const char* name) {
+  if (gl::GetStringi == nullptr) return false;
+  GLint n = 0;
+  glGetIntegerv(GL_NUM_EXTENSIONS, &n);
+  for (GLint i = 0; i < n; ++i) {
+    const char* e =
+        reinterpret_cast<const char*>(gl::GetStringi(GL_EXTENSIONS, static_cast<GLuint>(i)));
+    if (e != nullptr && std::strcmp(e, name) == 0) return true;
+  }
+  return false;
+}
+
 GLuint compile_one_shader(GLenum kind, const char* const* srcs, int count, const char* label) {
   GLuint sh = gl::CreateShader(kind);
   gl::ShaderSource(sh, count, srcs, nullptr);
@@ -273,6 +286,19 @@ bool GlRenderer::init(int window_w, int window_h, const char* title, bool vsync)
     shutdown();
     return false;
   }
+
+  // Optional zero-copy upload capability (ARB_buffer_storage).  Absence
+  // is normal — macOS GL stops at 4.1 — and only means uploads go through
+  // the plane-vector path instead of decoder-written persistent buffers.
+  // OPENHTJ2K_GL_NO_ZEROCOPY=1 forces the vector path; kept as a runtime
+  // escape hatch and for single-binary A/B measurements.
+  const char* no_zc    = std::getenv("OPENHTJ2K_GL_NO_ZEROCOPY");
+  const bool  disabled = (no_zc != nullptr && no_zc[0] != '\0' && no_zc[0] != '0');
+  zero_copy_supported_ =
+      !disabled && gl::load_zero_copy_functions() && has_gl_extension("GL_ARB_buffer_storage");
+  std::fprintf(stderr, "gl_renderer: zero-copy plane upload %s%s\n",
+               zero_copy_supported_ ? "available" : "unavailable",
+               disabled ? " (disabled by OPENHTJ2K_GL_NO_ZEROCOPY)" : " (ARB_buffer_storage)");
 
   if (!compile_shader_programs()) {
     shutdown();
@@ -398,6 +424,10 @@ bool GlRenderer::compile_shader_programs() {
 }
 
 void GlRenderer::shutdown() {
+  // Ring teardown needs the context (still current — the window is
+  // destroyed at the end of this function).  Threads using the ring are
+  // joined before shutdown() per run_receiver_threaded's ordering.
+  destroy_ring();
   if (tex_rgb_ != 0) {
     const GLuint t = tex_rgb_;
     glDeleteTextures(1, &t);
@@ -473,7 +503,14 @@ bool GlRenderer::should_close() const {
 }
 
 void GlRenderer::poll_events() {
-  if (window_) glfwPollEvents();
+  if (!window_) return;
+  glfwPollEvents();
+  // Ring housekeeping runs here because poll_events() is the one renderer
+  // entry point the main loop hits every iteration with the GL context
+  // current — buffer creation and fence retirement both need GL calls,
+  // which the decode-thread side of the ring API must never make.
+  service_ring_request();
+  poll_ring_fences();
 }
 
 bool GlRenderer::ensure_rgb_texture(int w, int h) {
@@ -626,6 +663,225 @@ void GlRenderer::upload_planar_textures(const void* y_plane, const void* cb_plan
   glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w_c, h_c, GL_RED, type, cb_plane);
   glBindTexture(GL_TEXTURE_2D, tex_cr_);
   glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w_c, h_c, GL_RED, type, cr_plane);
+}
+
+// ── Zero-copy ring ──────────────────────────────────────────────────────
+
+GlRenderer::PlanePointers GlRenderer::acquire_plane_buffers(uint32_t w_y, uint32_t h_y,
+                                                            uint32_t w_c, uint32_t h_c,
+                                                            int bpp) {
+  PlanePointers pp;
+  if (!zero_copy_supported_ || window_ == nullptr) return pp;
+  if (w_y == 0 || h_y == 0 || w_c == 0 || h_c == 0 || (bpp != 1 && bpp != 2)) return pp;
+
+  if (!ring_ready_.load(std::memory_order_acquire) || w_y != ring_w_y_ || h_y != ring_h_y_ ||
+      w_c != ring_w_c_ || h_c != ring_h_c_ || bpp != ring_bpp_) {
+    // Ring absent or built for different geometry.  Publish a build
+    // request for the main thread and use the vector path this frame.
+    std::lock_guard<std::mutex> lk(ring_req_mu_);
+    req_w_y_ = w_y;
+    req_h_y_ = h_y;
+    req_w_c_ = w_c;
+    req_h_c_ = h_c;
+    req_bpp_ = bpp;
+    return pp;
+  }
+
+  for (int i = 0; i < kRingDepth; ++i) {
+    int expected = kSlotFree;
+    if (ring_[i].state.compare_exchange_strong(expected, kSlotInUse,
+                                               std::memory_order_acq_rel)) {
+      pp.y          = ring_[i].mapped;
+      pp.cb         = ring_[i].mapped + ring_y_bytes_;
+      pp.cr         = ring_[i].mapped + ring_y_bytes_ + ring_c_bytes_;
+      pp.stride_y   = w_y;
+      pp.stride_c   = w_c;
+      pp.ring_index = i;
+      return pp;
+    }
+  }
+  return pp;  // every slot busy (GPU behind) — vector path this frame
+}
+
+void GlRenderer::release_plane_buffers(int ring_index) {
+  if (ring_index < 0 || ring_index >= kRingDepth) return;
+  // Only an acquired-but-never-drawn slot may be freed from off-thread;
+  // AwaitFence slots belong to the fence poller.
+  int expected = kSlotInUse;
+  ring_[ring_index].state.compare_exchange_strong(expected, kSlotFree,
+                                                  std::memory_order_acq_rel);
+}
+
+void GlRenderer::draw_acquired_planes(int ring_index, int w_y, int h_y, int w_c, int h_c,
+                                      int bpp, int bit_depth,
+                                      const ycbcr_coefficients* coeffs,
+                                      bool components_are_rgb,
+                                      const ColorPipelineParams& pipeline) {
+  if (!window_ || ring_index < 0 || ring_index >= kRingDepth) return;
+  RingSlot& slot = ring_[ring_index];
+  if (slot.state.load(std::memory_order_acquire) != kSlotInUse) return;
+  if (!ensure_planar_textures(w_y, h_y, w_c, h_c, bpp)) {
+    slot.state.store(kSlotFree, std::memory_order_release);
+    return;
+  }
+
+  // Texture uploads source from the slot's buffer — offsets, not client
+  // pointers — so the only CPU write of the plane bytes was the decoder's.
+  const GLenum type = (bpp == 2) ? GL_UNSIGNED_SHORT : GL_UNSIGNED_BYTE;
+  glPixelStorei(GL_UNPACK_ALIGNMENT, bpp);
+  gl::BindBuffer(GL_PIXEL_UNPACK_BUFFER, slot.pbo);
+  glBindTexture(GL_TEXTURE_2D, tex_y_);
+  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w_y, h_y, GL_RED, type,
+                  reinterpret_cast<const void*>(static_cast<uintptr_t>(0)));
+  glBindTexture(GL_TEXTURE_2D, tex_cb_);
+  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w_c, h_c, GL_RED, type,
+                  reinterpret_cast<const void*>(static_cast<uintptr_t>(ring_y_bytes_)));
+  glBindTexture(GL_TEXTURE_2D, tex_cr_);
+  glTexSubImage2D(
+      GL_TEXTURE_2D, 0, 0, 0, w_c, h_c, GL_RED, type,
+      reinterpret_cast<const void*>(static_cast<uintptr_t>(ring_y_bytes_ + ring_c_bytes_)));
+  gl::BindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+
+  // The slot is reusable once the GPU has copied buffer → textures; the
+  // fence covers exactly that.  poll_ring_fences() retires it to Free.
+  slot.fence = gl::FenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+  slot.state.store(kSlotAwaitFence, std::memory_order_release);
+
+  const float k = (bpp == 2 && bit_depth >= 9 && bit_depth <= 16)
+                      ? 65535.0f / static_cast<float>((1 << bit_depth) - 1)
+                      : 1.0f;
+  const float norm_scale[3] = {k, k, k};
+  if (components_are_rgb)
+    draw_planar_rgb_program(w_y, h_y, norm_scale, pipeline);
+  else
+    draw_ycbcr_program(w_y, h_y, coeffs, norm_scale, pipeline);
+}
+
+void GlRenderer::service_ring_request() {
+  if (!zero_copy_supported_) return;
+  uint32_t w_y = 0, h_y = 0, w_c = 0, h_c = 0;
+  int      bpp = 0;
+  {
+    std::lock_guard<std::mutex> lk(ring_req_mu_);
+    if (req_w_y_ == 0) return;  // no pending request
+    w_y = req_w_y_;
+    h_y = req_h_y_;
+    w_c = req_w_c_;
+    h_c = req_h_c_;
+    bpp = req_bpp_;
+  }
+  if (ring_ready_.load(std::memory_order_relaxed) && w_y == ring_w_y_ && h_y == ring_h_y_ &&
+      w_c == ring_w_c_ && h_c == ring_h_c_ && bpp == ring_bpp_) {
+    // Duplicate request raced with the build — nothing to do.
+    std::lock_guard<std::mutex> lk(ring_req_mu_);
+    req_w_y_ = 0;
+    return;
+  }
+
+  // Block new acquires, then wait until in-flight slots drain.  A slot
+  // claimed in the acquire/ready race stays valid — we simply retry on a
+  // later poll_events() tick; the old buffers are not touched until every
+  // slot is Free again.
+  ring_ready_.store(false, std::memory_order_release);
+  for (int i = 0; i < kRingDepth; ++i) {
+    if (ring_[i].state.load(std::memory_order_acquire) != kSlotFree) return;
+  }
+  destroy_ring();
+
+  const size_t y_bytes = static_cast<size_t>(w_y) * h_y * static_cast<size_t>(bpp);
+  const size_t c_bytes = static_cast<size_t>(w_c) * h_c * static_cast<size_t>(bpp);
+  const size_t total   = y_bytes + 2 * c_bytes;
+  const GLbitfield storage_flags =
+      GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT;
+  bool ok = true;
+  for (int i = 0; i < kRingDepth && ok; ++i) {
+    GLuint pbo = 0;
+    gl::GenBuffers(1, &pbo);
+    if (pbo == 0) {
+      ok = false;
+      break;
+    }
+    ring_[i].pbo = pbo;
+    gl::BindBuffer(GL_PIXEL_UNPACK_BUFFER, pbo);
+    gl::BufferStorage(GL_PIXEL_UNPACK_BUFFER, static_cast<GLsizeiptr>(total), nullptr,
+                      storage_flags);
+    void* mapped = gl::MapBufferRange(GL_PIXEL_UNPACK_BUFFER, 0,
+                                      static_cast<GLsizeiptr>(total), storage_flags);
+    ring_[i].mapped = static_cast<uint8_t*>(mapped);
+    if (mapped == nullptr || !check_gl_error("zero-copy ring slot")) ok = false;
+  }
+  gl::BindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+  if (!ok) {
+    // Driver said no — permanently fall back to the vector upload path.
+    destroy_ring();
+    zero_copy_supported_ = false;
+    std::fprintf(stderr, "gl_renderer: zero-copy ring allocation failed; using vector path\n");
+    std::lock_guard<std::mutex> lk(ring_req_mu_);
+    req_w_y_ = 0;
+    return;
+  }
+
+  ring_w_y_     = w_y;
+  ring_h_y_     = h_y;
+  ring_w_c_     = w_c;
+  ring_h_c_     = h_c;
+  ring_bpp_     = bpp;
+  ring_y_bytes_ = y_bytes;
+  ring_c_bytes_ = c_bytes;
+  {
+    std::lock_guard<std::mutex> lk(ring_req_mu_);
+    req_w_y_ = 0;
+  }
+  ring_ready_.store(true, std::memory_order_release);
+  std::fprintf(stderr,
+               "gl_renderer: zero-copy ring ready (%d x %.1f MB persistent-mapped, "
+               "%ux%u Y / %ux%u C, %d bpp)\n",
+               kRingDepth, static_cast<double>(total) / (1024.0 * 1024.0), w_y, h_y, w_c, h_c,
+               bpp);
+}
+
+void GlRenderer::poll_ring_fences() {
+  for (int i = 0; i < kRingDepth; ++i) {
+    RingSlot& slot = ring_[i];
+    if (slot.state.load(std::memory_order_acquire) != kSlotAwaitFence) continue;
+    if (slot.fence == nullptr) {  // FenceSync failed at draw time — free defensively
+      slot.state.store(kSlotFree, std::memory_order_release);
+      continue;
+    }
+    const GLenum r =
+        gl::ClientWaitSync(static_cast<GLsync>(slot.fence), 0, /*timeout_ns=*/0);
+    if (r == GL_ALREADY_SIGNALED || r == GL_CONDITION_SATISFIED || r == GL_WAIT_FAILED) {
+      gl::DeleteSync(static_cast<GLsync>(slot.fence));
+      slot.fence = nullptr;
+      slot.state.store(kSlotFree, std::memory_order_release);
+    }
+    // GL_TIMEOUT_EXPIRED: still in flight — try again next tick.
+  }
+}
+
+void GlRenderer::destroy_ring() {
+  ring_ready_.store(false, std::memory_order_release);
+  for (int i = 0; i < kRingDepth; ++i) {
+    RingSlot& slot = ring_[i];
+    if (slot.fence != nullptr && gl::DeleteSync != nullptr) {
+      gl::DeleteSync(static_cast<GLsync>(slot.fence));
+      slot.fence = nullptr;
+    }
+    if (slot.pbo != 0) {
+      if (slot.mapped != nullptr && gl::UnmapBuffer != nullptr) {
+        gl::BindBuffer(GL_PIXEL_UNPACK_BUFFER, slot.pbo);
+        gl::UnmapBuffer(GL_PIXEL_UNPACK_BUFFER);
+        gl::BindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+      }
+      if (gl::DeleteBuffers != nullptr) {
+        const GLuint b = slot.pbo;
+        gl::DeleteBuffers(1, &b);
+      }
+      slot.pbo = 0;
+    }
+    slot.mapped = nullptr;
+    slot.state.store(kSlotFree, std::memory_order_release);
+  }
 }
 
 void GlRenderer::upload_planar_and_draw(const uint8_t* y_plane, const uint8_t* cb_plane,

--- a/source/apps/rtp_recv/gl_renderer.hpp
+++ b/source/apps/rtp_recv/gl_renderer.hpp
@@ -29,7 +29,10 @@
 // --no-render.  load_functions() resolves GL >=2.0 entry points via
 // glfwGetProcAddress in gl_loader.cpp.
 
+#include <atomic>
+#include <cstddef>
 #include <cstdint>
+#include <mutex>
 
 struct GLFWwindow;
 
@@ -103,6 +106,46 @@ class GlRenderer {
                                  int bit_depth, const ycbcr_coefficients* coeffs,
                                  bool components_are_rgb,
                                  const ColorPipelineParams& pipeline);
+
+  // ── Zero-copy plane buffer API (mirrors MetalRenderer) ─────────────────
+  // The decode thread calls acquire_plane_buffers() to get raw pointers
+  // into a persistently-mapped GL buffer (ARB_buffer_storage, GL 4.4) and
+  // writes decoded samples straight into it via PlanarOutputDesc.  The
+  // main thread then calls draw_acquired_planes(), whose glTexSubImage2D
+  // sources from the bound buffer — a driver-side DMA with no CPU copy on
+  // either thread.  This is the staging-free design the BufferSubData PBO
+  // ring (reverted in PR #428) was not: the decoder's plane write, which
+  // must happen anyway, IS the upload write.
+  //
+  // Ring discipline (3 slots): acquire() claims a Free slot (atomic CAS,
+  // no GL calls — safe on the decode thread).  draw_acquired_planes()
+  // inserts a fence after the texture uploads; poll_events() retires
+  // signalled fences back to Free.  If no slot is free, or the ring is
+  // not built yet (buffer creation needs the GL context, so the first
+  // acquire only *requests* dimensions and poll_events() builds the ring
+  // on the main thread), acquire returns null pointers and the caller
+  // falls back to the plane-vector upload path for that frame.
+  struct PlanePointers {
+    void    *y = nullptr, *cb = nullptr, *cr = nullptr;
+    uint32_t stride_y   = 0;  // row stride in samples (= width, packed)
+    uint32_t stride_c   = 0;
+    int      ring_index = -1;  // opaque — pass back to draw_acquired_planes
+  };
+
+  // Thread-safe: may be called from the decode thread.  Null .y => use
+  // the vector fallback for this frame.
+  PlanePointers acquire_plane_buffers(uint32_t w_y, uint32_t h_y, uint32_t w_c, uint32_t h_c,
+                                      int bpp);
+
+  // Thread-safe, no GL calls: returns an acquired-but-never-drawn slot
+  // (e.g. its DecodedFrame was evicted from the render slot, or decode
+  // failed mid-frame) to the Free state.
+  void release_plane_buffers(int ring_index);
+
+  // Must be called from the main (render) thread.
+  void draw_acquired_planes(int ring_index, int w_y, int h_y, int w_c, int h_c, int bpp,
+                            int bit_depth, const ycbcr_coefficients* coeffs,
+                            bool components_are_rgb, const ColorPipelineParams& pipeline);
 
  private:
   bool compile_shader_programs();
@@ -192,6 +235,40 @@ class GlRenderer {
   int          tex_cr_w_         = 0;
   int          tex_cr_h_         = 0;
   int          tex_cr_bpp_       = 0;
+
+  // ── Zero-copy ring state ────────────────────────────────────────────────
+  // Slot lifecycle: Free → (acquire, decode thread) InUse → (draw, main
+  // thread) AwaitFence → (fence signalled, poll_events) Free.  InUse slots
+  // whose frame never reaches the renderer go back to Free via
+  // release_plane_buffers.  All GL calls stay on the main thread; the
+  // decode thread only touches the mapped pointer and the atomics.
+  static constexpr int kRingDepth = 3;
+  enum SlotState : int { kSlotFree = 0, kSlotInUse = 1, kSlotAwaitFence = 2 };
+  struct RingSlot {
+    unsigned int     pbo    = 0;
+    uint8_t*         mapped = nullptr;
+    void*            fence  = nullptr;  // GLsync, opaque here
+    std::atomic<int> state{kSlotFree};
+  };
+  RingSlot ring_[kRingDepth];
+  // Geometry the ring was built for (main thread writes, decode thread
+  // reads only when ring_ready_ is true — release/acquire ordering below).
+  uint32_t ring_w_y_ = 0, ring_h_y_ = 0, ring_w_c_ = 0, ring_h_c_ = 0;
+  int      ring_bpp_     = 0;
+  size_t   ring_y_bytes_ = 0;
+  size_t   ring_c_bytes_ = 0;
+  std::atomic<bool> ring_ready_{false};
+  // Pending build/rebuild request from the decode thread (guarded by
+  // ring_req_mu_): zero w_y means "no request".
+  std::mutex ring_req_mu_;
+  uint32_t   req_w_y_ = 0, req_h_y_ = 0, req_w_c_ = 0, req_h_c_ = 0;
+  int        req_bpp_ = 0;
+  bool zero_copy_supported_ = false;  // ARB_buffer_storage present at init
+
+  // Main-thread ring plumbing.
+  void service_ring_request();  // called from poll_events()
+  void poll_ring_fences();      // called from poll_events()
+  void destroy_ring();          // shutdown / rebuild
 };
 
 }  // namespace open_htj2k::rtp_recv

--- a/source/apps/rtp_recv/metal_renderer.hpp
+++ b/source/apps/rtp_recv/metal_renderer.hpp
@@ -83,6 +83,11 @@ class MetalRenderer {
   PlanePointers acquire_plane_buffers(uint32_t w_y, uint32_t h_y,
                                       uint32_t w_c, uint32_t h_c, int bpp);
 
+  // Interface parity with GlRenderer's slot-tracked ring: the Metal ring
+  // is plain round-robin (no per-slot ownership), so an undrawn frame
+  // needs no explicit release.  No-op.
+  void release_plane_buffers(int /*ring_index*/) {}
+
   // Must be called from the main (render) thread.
   void draw_acquired_planes(int ring_index, int w_y, int h_y, int w_c, int h_c,
                             int bpp, int bit_depth,

--- a/source/apps/rtp_recv/pipeline_multi_threaded.cpp
+++ b/source/apps/rtp_recv/pipeline_multi_threaded.cpp
@@ -195,8 +195,11 @@ void decode_thread_main(const CliOptions& opts, ReceiverState& st) {
     df.pipeline           = pipeline;
     df.source_rtp_ts      = frame.rtp_timestamp;
     if (opts.color_path == CliOptions::ColorPath::Shader) {
-#ifdef OPENHTJ2K_USE_METAL
-      // Zero-copy Metal path: decode directly into GPU-visible shared memory.
+      // Zero-copy path: decode directly into GPU-visible memory (Metal
+      // shared buffers on macOS, persistently-mapped GL buffers
+      // elsewhere).  acquire_plane_buffers returns null pointers when the
+      // backend can't do it (ring not built yet, GL < 4.4, all slots in
+      // flight) and the plane-vector fallback below handles the frame.
       if (st.renderer_ptr != nullptr) {
         const uint16_t nc = decoder.get_num_component();
         if (nc < 1) { st.frames_failed.fetch_add(1, std::memory_order_relaxed); continue; }
@@ -211,7 +214,7 @@ void decode_thread_main(const CliOptions& opts, ReceiverState& st) {
 
         auto pp = st.renderer_ptr->acquire_plane_buffers(luma_w, luma_h, chroma_w, chroma_h, bpp);
         if (pp.y) {
-          // Build PlanarOutputDesc pointing at Metal shared memory.
+          // Build PlanarOutputDesc pointing at the GPU-visible buffers.
           const uint16_t desc_nc = std::min(nc, static_cast<uint16_t>(3));
           open_htj2k::PlanarOutputDesc descs[3] = {};
           for (uint16_t c = 0; c < desc_nc; ++c) {
@@ -237,8 +240,12 @@ void decode_thread_main(const CliOptions& opts, ReceiverState& st) {
           try {
             decoder.invoke_line_based_direct(descs, desc_nc, widths, heights, depths, signeds);
           } catch (std::exception& e) {
-            std::fprintf(stderr, "decoder.invoke_line_based_direct (metal) failed: %s\n", e.what());
+            std::fprintf(stderr, "decoder.invoke_line_based_direct (zero-copy) failed: %s\n",
+                         e.what());
             st.frames_failed.fetch_add(1, std::memory_order_relaxed);
+            // The slot was claimed but its frame will never be drawn —
+            // hand it back so the ring doesn't leak down to zero slots.
+            st.renderer_ptr->release_plane_buffers(pp.ring_index);
             continue;
           }
           df.width         = luma_w;
@@ -247,7 +254,8 @@ void decode_thread_main(const CliOptions& opts, ReceiverState& st) {
           df.chroma_height = chroma_h;
           df.bit_depth     = depth_y;
           df.kind          = components_are_rgb ? DecodedFrame::PLANAR_RGB : DecodedFrame::PLANAR_YCBCR;
-          df.metal_ring_index = pp.ring_index;
+          df.ring_index    = pp.ring_index;
+          st.frames_zero_copy.fetch_add(1, std::memory_order_relaxed);
         } else {
           // Fallback: renderer not ready or alloc failed.
           if (!decode_to_planar_buffers_direct(decoder, components_are_rgb, df)) {
@@ -255,9 +263,7 @@ void decode_thread_main(const CliOptions& opts, ReceiverState& st) {
             continue;
           }
         }
-      } else
-#endif
-      if (!decode_to_planar_buffers_direct(decoder, components_are_rgb, df)) {
+      } else if (!decode_to_planar_buffers_direct(decoder, components_are_rgb, df)) {
         std::fprintf(stderr, "frame: unable to determine dimensions; dropping\n");
         st.frames_failed.fetch_add(1, std::memory_order_relaxed);
         continue;
@@ -300,9 +306,14 @@ void decode_thread_main(const CliOptions& opts, ReceiverState& st) {
 
     // Hand the decoded RGB to the renderer.  If main hasn't picked up the
     // previous decoded frame yet (e.g. blocked in vsync), it gets dropped
-    // here — latest-wins keeps motion-to-photon minimal.
+    // here — latest-wins keeps motion-to-photon minimal.  An evicted
+    // zero-copy frame holds a ring slot that will never be drawn; return
+    // it so acquire doesn't run out of slots.
     t_prev_end = Clock::now();
-    st.render_slot.push(std::move(df));
+    auto evicted_df = st.render_slot.push(std::move(df));
+    if (evicted_df.has_value() && evicted_df->ring_index >= 0 && st.renderer_ptr != nullptr) {
+      st.renderer_ptr->release_plane_buffers(evicted_df->ring_index);
+    }
 
     if (opts.max_frames > 0 && decoded >= static_cast<uint64_t>(opts.max_frames)) {
       st.stop_flag.store(true, std::memory_order_release);
@@ -379,9 +390,7 @@ int run_receiver_threaded(const CliOptions& opts) {
   FrameHandler  frame_handler;
   ReceiverState state;
   frame_handler.set_buffer_pool(&state.frame_buf_pool);
-#ifdef OPENHTJ2K_USE_METAL
   state.renderer_ptr = renderer_ptr;
-#endif
 
   using Clock         = std::chrono::steady_clock;
   const auto run_start_tp = Clock::now();
@@ -485,17 +494,15 @@ int run_receiver_threaded(const CliOptions& opts) {
         renderer_ptr->upload_and_draw(df->rgb.data(), static_cast<int>(df->width),
                                       static_cast<int>(df->height));
       }
-#ifdef OPENHTJ2K_USE_METAL
-      else if (df->metal_ring_index >= 0) {
-        // Zero-copy Metal path: data is already in GPU-visible shared memory.
+      else if (df->ring_index >= 0) {
+        // Zero-copy path: data is already in GPU-visible memory.
         renderer_ptr->draw_acquired_planes(
-            df->metal_ring_index,
+            df->ring_index,
             static_cast<int>(df->width), static_cast<int>(df->height),
             static_cast<int>(df->chroma_width), static_cast<int>(df->chroma_height),
             df->bit_depth > 8 ? 2 : 1, static_cast<int>(df->bit_depth),
             df->shader_coeffs, df->components_are_rgb, df->pipeline);
       }
-#endif
       else if (df->bit_depth > 8) {
         renderer_ptr->upload_planar_16_and_draw(
             df->plane_y_16.data(), df->plane_cb_16.data(), df->plane_cr_16.data(),
@@ -547,6 +554,7 @@ int run_receiver_threaded(const CliOptions& opts) {
 
   const uint64_t decoded         = state.frames_decoded.load();
   const uint64_t failed          = state.frames_failed.load();
+  const uint64_t zero_copy       = state.frames_zero_copy.load();
   const uint64_t emitted_to_dec  = state.frames_emitted_to_decode.load();
   const double   avg_fps         = decoded > 0 ? static_cast<double>(decoded) / run_secs : 0.0;
   const uint64_t us_sum          = state.decode_us_sum.load();
@@ -565,6 +573,7 @@ int run_receiver_threaded(const CliOptions& opts) {
                "  frames emitted:      %llu (frame_handler)\n"
                "  frames pushed:       %llu (to decode slot)\n"
                "  frames decoded:      %llu\n"
+               "  frames zero-copy:    %llu (decoded into GPU buffer; rest used vector upload)\n"
                "  frames failed:       %llu\n"
                "  frames dropped:      %llu (mid-frame seq gap)\n"
                "  tail-loss drops:     %llu (frame ended w/o RTP M=1)\n"
@@ -579,6 +588,7 @@ int run_receiver_threaded(const CliOptions& opts) {
                static_cast<unsigned long long>(s.frames_emitted),
                static_cast<unsigned long long>(emitted_to_dec),
                static_cast<unsigned long long>(decoded),
+               static_cast<unsigned long long>(zero_copy),
                static_cast<unsigned long long>(failed),
                static_cast<unsigned long long>(s.frames_dropped),
                static_cast<unsigned long long>(s.tail_loss_drops),

--- a/source/apps/rtp_recv/pipeline_multi_threaded.hpp
+++ b/source/apps/rtp_recv/pipeline_multi_threaded.hpp
@@ -33,17 +33,22 @@ struct ReceiverState {
   std::atomic<uint64_t> frames_emitted_to_decode{0};  // dump index, increments per frame_handler emission
   std::atomic<uint64_t> frames_decoded{0};
   std::atomic<uint64_t> frames_failed{0};
+  // Frames that decoded straight into a renderer-owned GPU buffer (the
+  // zero-copy path).  The gap to frames_decoded is frames that fell back
+  // to the plane-vector upload (ring not yet built, all slots in flight,
+  // or zero-copy unsupported).  Proves the path is actually exercised.
+  std::atomic<uint64_t> frames_zero_copy{0};
 
   // Decode timing — written only by the decode thread, read by main at exit.
   std::atomic<uint64_t> decode_us_sum{0};
   std::atomic<uint64_t> decode_us_min{UINT64_MAX};
   std::atomic<uint64_t> decode_us_max{0};
 
-#ifdef OPENHTJ2K_USE_METAL
-  // Renderer pointer for zero-copy Metal decode.  Set before the decode
-  // thread is launched; read (not written) by the decode thread.
+  // Renderer pointer for the zero-copy decode path (Metal on macOS, the
+  // persistently-mapped GL ring elsewhere).  Set before the decode thread
+  // is launched; the decode thread only calls the renderer's thread-safe
+  // acquire/release_plane_buffers entry points through it.
   Renderer* renderer_ptr = nullptr;
-#endif
 };
 
 // v2 multi-threaded main loop (--threading=on, default).


### PR DESCRIPTION
## Summary
Generalizes the zero-copy decode path — previously Metal-only — to the GL renderer, using an `ARB_buffer_storage` (GL 4.4) ring of **persistently-mapped** `GL_PIXEL_UNPACK_BUFFER`s. The decode thread writes decoded planes straight into the mapped buffer via `invoke_line_based_direct`; `draw_acquired_planes()` then uploads buffer→texture with **no CPU copy on either thread**, fenced so the decode thread can't overwrite a buffer the GPU is still reading.

This is the staging-free design the reverted `BufferSubData` PBO ring (#428) was *not*: there, staging added a ~17 MB/frame copy and lost the A/B. Here the decoder's plane write **is** the upload write, so a copy is removed rather than added — the GL equivalent of the existing zero-copy Metal path.

## Design
- **gl_loader**: optional GL 4.4 entry points (`glBufferStorage`, `glMapBufferRange`, fence sync) resolved separately via `load_zero_copy_functions()`. Absence simply disables the feature — normal on macOS (GL 4.1) — and the renderer keeps its plane-vector upload path.
- **3-slot ring**, `Free`/`InUse`/`AwaitFence` state machine. All GL calls stay on the main thread (ring build + fence retirement in `poll_events()`); the decode thread only touches the mapped pointer and slot atomics, posting a geometry-change request the main thread services. Geometry changes serialize on the decode thread, so buffers are never freed under an in-flight write.
- **Backend-generic**: `DecodedFrame.metal_ring_index` → `ring_index`; `MetalRenderer` gains a no-op `release_plane_buffers` for parity. Evicted/failed zero-copy frames release their slot so the ring can't drain to zero.
- `frames_zero_copy` counter in the summary proves the path is active; `OPENHTJ2K_GL_NO_ZEROCOPY=1` forces the vector path (A/B + escape hatch).

## Validation
Ryzen 9 9950X + RTX 4070 SUPER, driver 595.71.05.

1. **Standalone GL round-trip test** on the real driver: `BufferStorage` persistent-coherent map + 3-plane PBO-sourced `glTexSubImage2D` reads back **byte-exact** for R8 and R16 across two reuse passes of the same buffer (validates the offset arithmetic + persistent-map reuse + fence ordering).
2. **Live** 4K59.94 4:2:2 10-bit 1.7 bpp replay, `--color-path shader`: ring builds (3×31.6 MB), `frames_zero_copy = 599/600` (only the pre-build first frame falls back), zero failures, no GL errors.
3. **A/B** — same binary toggled by `OPENHTJ2K_GL_NO_ZEROCOPY`, 3 interleaved trials each, 600 frames:

| metric | zero-copy | vector |
|---|---|---|
| avg FPS | 53.97 | 53.69 |
| decode avg | **6.10 ms** | 7.72 ms (−21%) |
| total process CPU | **~140%** | ~162% (−22%) |

Same framerate at materially lower CPU and decode latency. (Framerate is capped below 60 here by upstream packet drops — the box's `net.core.rmem_max` is at the 212 kB default — so the win shows up as headroom, not fps; that headroom is what matters for higher-res/higher-fps streams.)

- macOS build + `--smoke-test` green; Metal path unchanged.
- Linux build warning-clean (`-Wall -Wextra`).
- CI does not build `-DOPENHTJ2K_RTP=ON`, hence the on-box validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)