### PR TITLE
chore(web/perf): add 2997 UNIFIED fixtures to bench picker

### DIFF
--- a/web/perf/index.html
+++ b/web/perf/index.html
@@ -27,6 +27,10 @@
     <label><input type="radio" name="fix" value="2160p5994-1200frames.rtp"> 4K@59.94</label>
     <label><input type="radio" name="fix" value="2160p_5994fps_422_10bit.rtp"> 4K@59.94 4:2:2 10-bit</label>
   </div>
+  <div class="row">
+    <label><input type="radio" name="fix" value="1080p2997_660frames.rtp"> FHD 2997 4:2:2 10b <small>(1080p UNIFIED)</small></label>
+    <label><input type="radio" name="fix" value="2160p2997_660frames.rtp"> 4K 2997 4:2:2 10b <small>(2160p UNIFIED)</small></label>
+  </div>
 </fieldset>
 
 <fieldset>


### PR DESCRIPTION
Add FHD/4K 2997 4:2:2 10-bit (UNIFIED) fixtures to the WASM decode bench radio list, matching the canonical 2997 benchmark fixture used in the VCIP-2026 campaign.

- `1080p2997_660frames.rtp` — FHD 2997 4:2:2 10b (1080p UNIFIED)
- `2160p2997_660frames.rtp` — 4K 2997 4:2:2 10b (2160p UNIFIED)

UI-only change (two radio buttons); no benchmark logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)