### PR TITLE
feat(codestream): parse the PRF (profile) marker segment

### DIFF
--- a/source/core/codestream/j2kmarkers.cpp
+++ b/source/core/codestream/j2kmarkers.cpp
@@ -293,6 +293,29 @@ CPF_marker::CPF_marker(j2c_src_memory &in) : j2k_marker_io_base(_CPF) {
 }
 
 /********************************************************************************
+ * PRF_marker
+ *******************************************************************************/
+PRF_marker::PRF_marker() : j2k_marker_io_base(_PRF), PRFnum(0) {}
+
+PRF_marker::PRF_marker(j2c_src_memory &in) : j2k_marker_io_base(_PRF), PRFnum(0) {
+  Lmar = in.get_word();
+  this->set_buf(in.get_buf_pos());
+  in.get_N_byte(this->get_buf(), Lmar - 2U);
+  // Lprf = 2 + 2N; N 16-bit Pprf words follow.  PRFnum is informational only
+  // (no codec processing) — see Rec. ITU-T T.800 | ISO/IEC 15444-1, A.5.3:
+  //   PRFnum = 4095 + sum_{i=1..N} Pprf_i * 2^(16*(i-1)).
+  const size_t n      = static_cast<size_t>(Lmar - 2U) / 2U;
+  uint64_t prfnum     = 4095;
+  for (size_t i = 0; i < n; ++i) {
+    const uint16_t w = get_word();
+    Pprf.push_back(w);
+    if (16U * i < 64U) prfnum += static_cast<uint64_t>(w) << (16U * i);
+  }
+  PRFnum = prfnum;
+  is_set = true;
+}
+
+/********************************************************************************
  * COD_marker
  *******************************************************************************/
 COD_marker::COD_marker(j2c_src_memory &in)
@@ -1780,6 +1803,9 @@ int j2k_main_header::read(j2c_src_memory &in) {
         break;
       case _CAP:
         CAP = MAKE_UNIQUE<CAP_marker>(in);
+        break;
+      case _PRF:
+        PRF = MAKE_UNIQUE<PRF_marker>(in);
         break;
       case _COD:
         COD = MAKE_UNIQUE<COD_marker>(in);

--- a/source/core/codestream/j2kmarkers.hpp
+++ b/source/core/codestream/j2kmarkers.hpp
@@ -134,6 +134,26 @@ class CPF_marker : public j2k_marker_io_base {
 };
 
 /********************************************************************************
+ * PRF_marker
+ *******************************************************************************/
+// Profile marker (Rec. ITU-T T.800 | ISO/IEC 15444-1, A.5.3).  Purely
+// informational: it signals the profile number (PRFnum) the codestream claims
+// to conform to and requires no codec processing.  Parsed here so the main
+// header is consumed correctly (a 15444-2 / 15444-18 codestream may carry it
+// after SIZ/CAP) instead of being skipped byte-by-byte as "unknown markers".
+class PRF_marker : public j2k_marker_io_base {
+ private:
+  std::vector<uint16_t> Pprf;
+  uint64_t PRFnum;
+
+ public:
+  PRF_marker();
+  explicit PRF_marker(j2c_src_memory &in);
+  // Signalled profile number (>= 4096), or 0 if no PRF marker was present.
+  uint64_t get_PRFnum() const { return PRFnum; }
+};
+
+/********************************************************************************
  * COD_marker
  *******************************************************************************/
 class COD_marker : public j2k_marker_io_base {
@@ -469,6 +489,7 @@ class j2k_main_header {
  public:
   std::unique_ptr<SIZ_marker> SIZ;
   std::unique_ptr<CAP_marker> CAP;
+  std::unique_ptr<PRF_marker> PRF;
   std::unique_ptr<COD_marker> COD;
   std::vector<std::unique_ptr<COC_marker>> COC;
   std::unique_ptr<CPF_marker> CPF;


### PR DESCRIPTION
The decoder treated the **PRF marker (`0xFF56`)** as unknown and scanned past it byte-by-byte, emitting "unknown marker" warnings for its `Lprf`/`Pprf` bytes — visible on real Part 18 / ISO/IEC 15444-18 codestreams, which carry PRF after SIZ/CAP. It resynced at the next marker by luck, but the behaviour was fragile and noisy.

## Change

- Add a `PRF_marker` class (mirrors `CPF_marker`) that consumes the segment correctly and decodes the profile number per **Rec. ITU-T T.800 | ISO/IEC 15444-1, A.5.3**: `PRFnum = 4095 + Σ Pprf_i · 2^(16(i−1))`, exposed via `get_PRFnum()`.
- Add `case _PRF:` to the main-header parser; store it on `j2k_main_header::PRF`.

The marker is **purely informational** — no codec processing — so decoding is otherwise unchanged. No profile-conformance *checking* is attempted (that's a much larger, separate effort); this just consumes and exposes the value so a future checker has it.

## Validation
- The Part 18 fixture (`4KuF_H0L1_arri_1bpp.j2c`) now decodes with **no "unknown marker" warnings**; `PRFnum` parses to 4096.
- Covered by the existing `dec_p18_arri` / `comp_p18_rt` round-trip (PAE 0).
- **Full suite 427/427.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)