### PR TITLE
fix(qfactor): correct 1/√2 offset scaling and LL-band visual weight

### DIFF
--- a/source/apps/estimate_qfactor/main.cpp
+++ b/source/apps/estimate_qfactor/main.cpp
@@ -282,13 +282,14 @@ std::vector<Band> predict_bands(uint8_t qfactor, uint8_t dwt_levels, uint8_t RI,
     alpha_Q = alpha_T1 * std::pow(alpha_T0 / alpha_T1, qpower);
   }
   const double eps0 = std::sqrt(0.5) / static_cast<double>(1u << RI);
-  const double delta_Q = alpha_Q * M_Q;
-  const double delta_ref = delta_Q * G_c_sqrt[0] + eps0;
+  const double delta_Q = alpha_Q * M_Q + eps0;
+  const double delta_ref = delta_Q * G_c_sqrt[0];
   const double G_c = G_c_sqrt[Cqcc];
 
   std::vector<Band> out(num_bands);
   for (size_t i = 0; i < num_bands; ++i) {
-    double w_b = (i >= weights.size()) ? 1.0 : std::pow(weights[i], qpower);
+    // LL band (last entry, always weight 1.0) and any extra low-freq bands beyond the 5-level table
+    double w_b = (i == num_bands - 1 || i >= weights.size()) ? 1.0 : std::pow(weights[i], qpower);
     double fval = delta_ref / (std::sqrt(wmse[i]) * w_b * G_c);
     int32_t exponent = 0;
     while (fval < 1.0) {

--- a/source/core/codestream/j2kmarkers.cpp
+++ b/source/core/codestream/j2kmarkers.cpp
@@ -835,14 +835,15 @@ QCD_marker::QCD_marker(uint8_t number_of_guardbits, uint8_t dwt_levels, uint8_t 
       }
 
       const double eps0 = sqrt(0.5) / static_cast<double>(1 << RI);
-      double delta_Q    = alpha_Q * M_Q;
-      double delta_ref  = delta_Q * G_c_sqrt[0] + eps0;
+      double delta_Q    = alpha_Q * M_Q + eps0;
+      double delta_ref  = delta_Q * G_c_sqrt[0];
       double G_c        = G_c_sqrt[0];  // gain of color transform
       for (size_t i = 0; i < epsilon.size(); ++i) {
         int32_t exponent, mantissa;
         double w_b;
-        // w_b for LL band shall be 1.0
-        w_b = (i >= W_b_Y.size()) ? 1.0 : pow(W_b_Y[i], qfactor_power);
+        // w_b for the LL band (always the last entry) shall be 1.0, as must any extra
+        // low-frequency bands beyond the 5-level table when dwt_levels > 5.
+        w_b = (i == epsilon.size() - 1 || i >= W_b_Y.size()) ? 1.0 : pow(W_b_Y[i], qfactor_power);
 
         double fval = (qfactor != 0xFF) ? delta_ref / (sqrt(wmse_or_BIBO[i]) * w_b * G_c)
                                         : basestep / sqrt(wmse_or_BIBO[i]);
@@ -1139,15 +1140,17 @@ QCC_marker::QCC_marker(uint16_t Csiz, uint16_t c, uint8_t number_of_guardbits, u
     }
 
     const double eps0 = sqrt(0.5) / static_cast<double>(1 << RI);
-    double delta_Q    = alpha_Q * M_Q;
-    double delta_ref  = delta_Q * G_c_sqrt[0] + eps0;
+    double delta_Q    = alpha_Q * M_Q + eps0;
+    double delta_ref  = delta_Q * G_c_sqrt[0];
     double G_c        = G_c_sqrt[Cqcc];  // gain of color transform
 
     for (size_t i = 0; i < epsilon.size(); ++i) {
       int32_t exponent, mantissa;
       double w_b;
-      // w_b for LL band shall be 1.0
-      w_b = (i >= W_b_sqrt[Cqcc].size()) ? 1.0 : pow(W_b_sqrt[Cqcc][i], qfactor_power);
+      // w_b for the LL band (always the last entry) shall be 1.0, as must any extra
+      // low-frequency bands beyond the 5-level table when dwt_levels > 5.
+      w_b = (i == epsilon.size() - 1 || i >= W_b_sqrt[Cqcc].size()) ? 1.0
+                                                                    : pow(W_b_sqrt[Cqcc][i], qfactor_power);
 
       double fval = delta_ref / (sqrt(wmse_or_BIBO[i]) * w_b * G_c);
       for (exponent = 0; fval < 1.0; exponent++) {

--- a/source/core/codestream/j2kmarkers.cpp
+++ b/source/core/codestream/j2kmarkers.cpp
@@ -845,8 +845,8 @@ QCD_marker::QCD_marker(uint8_t number_of_guardbits, uint8_t dwt_levels, uint8_t 
         // low-frequency bands beyond the 5-level table when dwt_levels > 5.
         w_b = (i == epsilon.size() - 1 || i >= W_b_Y.size()) ? 1.0 : pow(W_b_Y[i], qfactor_power);
 
-        double fval = (qfactor != 0xFF) ? delta_ref / (sqrt(wmse_or_BIBO[i]) * w_b * G_c)
-                                        : basestep / sqrt(wmse_or_BIBO[i]);
+        // qfactor == 0xFF is handled by the branch above, so it is always != 0xFF here.
+        double fval = delta_ref / (sqrt(wmse_or_BIBO[i]) * w_b * G_c);
         for (exponent = 0; fval < 1.0; exponent++) {
           fval *= 2.0;
         }


### PR DESCRIPTION
## Summary

Two related correctness fixes to the Qfactor quantization path, validated against the WG1 guideline **N100430** (*Controlling JPEG 2000 image quality using a single parameter*). Applied symmetrically to `QCD_marker`, `QCC_marker`, and the `estimate_qfactor` inverse predictor.

### 1. `1/√2` offset scaling

The guideline applies the constant offset as part of `Δ_Q`, **before** the `√G_Y` scaling:

```
Δ_Q   = 2^P0 · α_Q · M_Q + 1/√2
Δ_ref = Δ_Q · √G_Y
```

The code added `eps0` (the normalized `1/√2`) **outside** the `√G_Y` multiply, so the offset term was too small by a factor of `√G_Y ≈ 1.73`. The deviation is largest at high Qfactor, where the offset dominates as `M_Q → 0` (the best-quality regime).

```diff
-      double delta_Q    = alpha_Q * M_Q;
-      double delta_ref  = delta_Q * G_c_sqrt[0] + eps0;
+      double delta_Q    = alpha_Q * M_Q + eps0;
+      double delta_ref  = delta_Q * G_c_sqrt[0];
```

### 2. LL-band visual weight at `dwt_levels < 5`

The guideline states the LL sub-band is assigned visual weight `1.0` *in all cases*. The old `(i >= W_b.size())` guard only catches the LL band when `dwt_levels == 5` (LL index == 15 == table size). For fewer levels the LL band picked up a stray detail-band weight — wrong for chroma (QCC) at `<5` levels. Now the last band (always LL) is forced to `1.0`, while the `i >= size` clause still covers extra low-freq bands when `dwt_levels > 5`.

### 3. `estimate_qfactor` kept in lock-step

The tool inverts the same formula, so it carried both bugs. Fixed identically so it stays exact against streams from the corrected encoder.

## Verification

- Emitted QCC step sizes match the guideline formula **bit-for-bit** (independent Python reference), across all 16 subbands of both chroma components.
- Confirmed empirically that anchoring `Δ_ref` to `√G_Y` (not the per-component `√G_c`) is correct: swapping to `G_c_sqrt[Cqcc]` collapses all components' LL bands to the identical luminance value, dropping the per-component color weighting.
- `estimate_qfactor` recovers the true Q with **0.0000 residual** across `Q ∈ {10,30,50,65,80,90,97,100}` (all piecewise branches) and `dwt_levels ∈ {2,3,4}` (exercises the LL-weight fix). Before the fix it estimated Q=79 for a true-Q=80 stream.
- Builds clean; `ctest -R "^enc_"` and the Part 18 round-trip chain pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
