### PR TITLE
fix(decoder): replay the quality layer in the single-tile reuse traversal

### DIFF
--- a/source/core/codestream/codestream.hpp
+++ b/source/core/codestream/codestream.hpp
@@ -146,9 +146,11 @@ class buf_chain {
 
   uint8_t *current_buf;
   uint32_t current_length;
-  uint8_t tmp_byte;
-  uint8_t last_byte;
-  uint8_t bits;
+  // Default-initialised so a default-constructed buf_chain (e.g. the PPT
+  // packet_header chain) never bit-reads from uninitialised state.
+  uint8_t tmp_byte  = 0;
+  uint8_t last_byte = 0;
+  uint8_t bits      = 0;
 
  public:
   buf_chain() = default;
@@ -234,6 +236,7 @@ class buf_chain {
     node_pos       = 0;
     current_buf    = node_buf[0];
     current_length = node_length[0];
+    reset_bit_state();
   }
   void activate(size_t n) {
     assert(n < this->node_buf.size());
@@ -241,6 +244,18 @@ class buf_chain {
     node_pos       = n;
     current_buf    = node_buf[node_pos];
     current_length = node_length[node_pos];
+    reset_bit_state();
+  }
+  // Reset the bit-reader accumulator.  activate() begins a fresh read at a byte
+  // boundary, so any partial-byte / 0xFF-stuffing state left over from a
+  // previous decode must be cleared — otherwise the single-tile reuse path
+  // re-reads packet headers from a stale bit position (the PPM/PPT packet_header
+  // buf_chains are only positioned via activate(), and the PPT one is built with
+  // the default ctor, so its bit state would otherwise be uninitialized).
+  void reset_bit_state() {
+    tmp_byte  = 0;
+    last_byte = 0;
+    bits      = 0;
   }
   void flush_bits() { bits = 0; }
   void check_last_FF() {

--- a/source/core/coding/coding_units.cpp
+++ b/source/core/coding/coding_units.cpp
@@ -4104,11 +4104,11 @@ void j2k_tile::create_tile_buf(j2k_main_header &main_header) {
       j2k_resolution *cr           = this->tcomp[e.c].access_resolution(e.r);
       j2k_precinct *cp             = cr->access_precinct(e.p);
       const bool skip              = precinct_filter_ && !precinct_filter_(e.c, e.r, e.p);
-      this->packet[packet_count++] = j2c_packet(0, e.r, e.c, e.p, packet_header, tile_buf.get());
+      this->packet[packet_count++] = j2c_packet(e.l, e.r, e.c, e.p, packet_header, tile_buf.get());
       const uint64_t _pk_off       = packet_observer_ ? tile_buf->get_total_position() : 0u;
-      this->read_packet(cp, 0, cr->num_bands, skip);
+      this->read_packet(cp, e.l, cr->num_bands, skip);
       if (packet_observer_) {
-        packet_observer_(static_cast<uint16_t>(e.c), e.r, e.p, /*layer=*/0, _pk_off,
+        packet_observer_(static_cast<uint16_t>(e.c), e.r, e.p, /*layer=*/e.l, _pk_off,
                          tile_buf->get_total_position() - _pk_off);
       }
     }
@@ -4158,7 +4158,7 @@ void j2k_tile::create_tile_buf(j2k_main_header &main_header) {
                     for (p = 0; p < cr->npw * cr->nph; p++) {
                       cp = cr->access_precinct(p);
                       if (!is_packet_read[l][r][c][p]) {
-                        cached_crp_.push_back({static_cast<uint8_t>(c), r, static_cast<uint16_t>(p)});
+                        cached_crp_.push_back({static_cast<uint8_t>(c), r, static_cast<uint16_t>(p), l});
                         this->packet[packet_count++] =
                             j2c_packet(l, r, c, p, packet_header, tile_buf.get());
                         {
@@ -4191,7 +4191,7 @@ void j2k_tile::create_tile_buf(j2k_main_header &main_header) {
                     for (p = 0; p < cr->npw * cr->nph; p++) {
                       cp = cr->access_precinct(p);
                       if (!is_packet_read[l][r][c][p]) {
-                        cached_crp_.push_back({static_cast<uint8_t>(c), r, static_cast<uint16_t>(p)});
+                        cached_crp_.push_back({static_cast<uint8_t>(c), r, static_cast<uint16_t>(p), l});
                         this->packet[packet_count++] =
                             j2c_packet(l, r, c, p, packet_header, tile_buf.get());
                         {
@@ -4256,7 +4256,8 @@ void j2k_tile::create_tile_buf(j2k_main_header &main_header) {
                         cp = cr->access_precinct(p);
                         for (l = 0; l < LYE; l++) {
                           if (!is_packet_read[l][r][c][p]) {
-                            cached_crp_.push_back({static_cast<uint8_t>(c), r, static_cast<uint16_t>(p)});
+                            cached_crp_.push_back(
+                                {static_cast<uint8_t>(c), r, static_cast<uint16_t>(p), l});
                             this->packet[packet_count++] =
                                 j2c_packet(l, r, c, p, packet_header, tile_buf.get());
                             {
@@ -4327,7 +4328,7 @@ void j2k_tile::create_tile_buf(j2k_main_header &main_header) {
                       cp = cr->access_precinct(p);
                       for (l = 0; l < LYE; l++) {
                         if (!is_packet_read[l][r][c][p]) {
-                          cached_crp_.push_back({static_cast<uint8_t>(c), r, static_cast<uint16_t>(p)});
+                          cached_crp_.push_back({static_cast<uint8_t>(c), r, static_cast<uint16_t>(p), l});
                           this->packet[packet_count++] =
                               j2c_packet(l, r, c, p, packet_header, tile_buf.get());
                           {
@@ -4396,7 +4397,7 @@ void j2k_tile::create_tile_buf(j2k_main_header &main_header) {
                       cp = cr->access_precinct(p);
                       for (l = 0; l < LYE; l++) {
                         if (!is_packet_read[l][r][c][p]) {
-                          cached_crp_.push_back({static_cast<uint8_t>(c), r, static_cast<uint16_t>(p)});
+                          cached_crp_.push_back({static_cast<uint8_t>(c), r, static_cast<uint16_t>(p), l});
                           this->packet[packet_count++] =
                               j2c_packet(l, r, c, p, packet_header, tile_buf.get());
                           {
@@ -4469,7 +4470,8 @@ void j2k_tile::create_tile_buf(j2k_main_header &main_header) {
                         cp = cr->access_precinct(p);
                         for (l = 0; l < LYE; l++) {
                           if (!is_packet_read[l][r][c][p]) {
-                            cached_crp_.push_back({static_cast<uint8_t>(c), r, static_cast<uint16_t>(p)});
+                            cached_crp_.push_back(
+                                {static_cast<uint8_t>(c), r, static_cast<uint16_t>(p), l});
                             this->packet[packet_count++] =
                                 j2c_packet(l, r, c, p, packet_header, tile_buf.get());
                             {

--- a/source/core/coding/coding_units.hpp
+++ b/source/core/coding/coding_units.hpp
@@ -718,6 +718,7 @@ class j2k_tile : public j2k_tile_base {
     uint8_t c;   // component index
     uint8_t r;   // resolution level
     uint16_t p;  // precinct index
+    uint16_t l;  // quality layer (packets of the same precinct differ by layer)
   };
   std::vector<CRP> cached_crp_;
   bool crp_cached_ = false;

--- a/tests/col_range_validation.cmake
+++ b/tests/col_range_validation.cmake
@@ -17,13 +17,10 @@ add_test(NAME cr_p0_ht_08_11 COMMAND col_range_compare ${CONFORMANCE_DATA_DIR}/d
 add_test(NAME cr_p1_ht_02_11 COMMAND col_range_compare ${CONFORMANCE_DATA_DIR}/ds1_ht_02_b11.j2k)
 add_test(NAME cr_p1_ht_03_11 COMMAND col_range_compare ${CONFORMANCE_DATA_DIR}/ds1_ht_03_b11.j2k)
 
-# NOTE: a reuse-path (-reuse) variant that exercises the SIMD sub-range kernel
-# is intentionally NOT a CI test here.  The single-tile reuse machinery has a
-# pre-existing, uninitialized-state codestream re-parse issue that makes a
-# repeated-decode reuse run non-deterministic on some platforms (observed flaky
-# on Windows/MSVC and under WASM — a 1-LSB mismatch from a corrupted cached
-# second decode, not the horizontal IDWT), so it is unsuitable as a CI gate.
-# The default-mode cases above validate the set_col_range output path
-# deterministically; the SIMD sub-range kernels are covered by the bit-exact
-# developer checks (col_range_compare -reuse / run_wasm.cjs) until the reuse
-# re-parse issue is fixed.
+# Reuse-path variant — exercises the SIMD sub-range planar IDWT kernel on the
+# single-tile reuse path (the path the WASM JPIP viewer uses).  This was briefly
+# removed as flaky: the cached single-tile-reuse progression traversal dropped
+# the quality layer, so multi-layer streams re-parsed every packet as layer 0,
+# which was non-deterministic across platforms.  With that fixed, a
+# repeated-decode reuse run is deterministic, so the test is restored.
+add_test(NAME cr_ht_06_reuse COMMAND col_range_compare ${CONFORMANCE_DATA_DIR}/ds0_ht_06_b11.j2k -reuse)


### PR DESCRIPTION
## Summary

Fixes a single-tile-reuse decode bug where the cached 2nd+ frame of a **multi-layer** codestream is corrupted — tier-2 `"codeblock layer length exceeds remaining bytes" / "malformed input"` warnings and 1-LSB (or larger) output errors.

## Root cause

The reuse path caches the progression-order traversal on the first frame (`cached_crp_`) and replays it on subsequent frames to skip re-running the progression-order switch. The cached `CRP` tuple stored only `{component, resolution, precinct}`, and the **replay hardcoded layer 0** for every packet:

```cpp
this->packet[...] = j2c_packet(0, e.r, e.c, e.p, ...);   // layer 0
this->read_packet(cp, 0, cr->num_bands, skip);           // layer 0
```

— while the first-frame build path uses the real layer `l`. On a multi-layer stream, every reuse frame therefore parsed every packet as layer 0, so the tier-2 packet-header parse read inclusion / num-passes / length bits at the wrong layer and corrupted `pass_length[]`.

This was **deterministic per platform but varied across platforms/fixtures** — single-layer streams replay fine, so a reuse test could pass on Linux x86 yet fail on Windows/MSVC and WASM (which is exactly what happened to `cr_ht_06_reuse`).

## Fix

- Add `uint16_t l` to the `CRP` struct; push the layer at all six progression-order build sites; replay `e.l` in `j2c_packet`, `read_packet`, and the packet observer.
- Defensive hardening of the packet-header bit reader: `buf_chain::activate()` now resets the bit accumulator (`tmp_byte`/`last_byte`/`bits`), and those fields are default-initialised. `activate()` begins a fresh byte-aligned read, so stale partial-byte / 0xFF-stuffing state (PPM) or uninitialised state from a default-constructed chain (PPT) must not carry over. No current conformance fixture uses PPM/PPT with reuse, but this is correct by inspection.

## Verification

- **Full conformance suite: 449/449.**
- The malformed-input corruption is gone on every fixture. Single-tile reuse of multi-layer fixtures (`p0_04`, `ds0_ht_04`, `ds0_ht_06`, `ds1_ht_02`) now decodes bit-exact.
- The remaining `col_range_compare -reuse` mismatches (`p0_05`, `ds0_ht_05`, `ds1_ht_03`) emit **no** malformed warnings (parse is correct) and are a known limitation of that dev tool: it compares the same `[col_lo,col_hi)` window for **subsampled chroma** (comp 2 is 512 vs 1024), i.e. columns outside the chroma component's valid decoded window — not a decoder bug.

## Note

This was the bug behind the flaky `cr_ht_06_reuse` test removed in #440. With this fix, single-tile reuse decode is deterministic across platforms, so a reuse-path CI test can be restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
