### PR TITLE
docs: add Website / Live demo / Docs links row to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ across x86-64, AArch64, and WebAssembly, a built-in multi-threaded
 pipeline, and a live RFC 9828 RTP receiver that sustains **4K @ 60 fps
 on modern x86-64**.
 
+**Links:** [🌐 Website](https://osamu620.github.io/OpenHTJ2K/) · [▶ Live demo](https://htj2k-demo.pages.dev/) · [📖 Docs](docs/README.md)
+
 ## Highlights
 
 **Standards compliance**


### PR DESCRIPTION
The repo's About "Website" field only accepts one URL (kept as the live demo). This adds a compact links row near the top of the README so the new GitHub Pages landing page is also surfaced on the repo landing page.

`🌐 Website` → https://osamu620.github.io/OpenHTJ2K/ · `▶ Live demo` → https://htj2k-demo.pages.dev/ · `📖 Docs` → `docs/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)