### PR TITLE
Add region_decode_bench: HTJ2K region-decode latency/throughput benchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,6 +301,12 @@ add_subdirectory(tests/tools/col_range_compare)
 target_include_directories(col_range_compare PUBLIC source/core/interface)
 target_link_libraries(col_range_compare PUBLIC open_htj2k)
 
+# region_decode_bench: M1 region-decode latency/throughput benchmark (OSD eval)
+add_executable(region_decode_bench)
+add_subdirectory(tests/tools/region_decode_bench)
+target_include_directories(region_decode_bench PUBLIC source/core/interface)
+target_link_libraries(region_decode_bench PUBLIC open_htj2k)
+
 # Estimates the Qfactor used at encode time from a J2C codestream's QCD/QCC.
 add_executable(estimate_qfactor)
 add_subdirectory(source/apps/estimate_qfactor)

--- a/tests/tools/region_decode_bench/CMakeLists.txt
+++ b/tests/tools/region_decode_bench/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_policy(SET CMP0076 NEW)
+target_sources(region_decode_bench
+    PRIVATE
+    main_rdbench.cpp
+)

--- a/tests/tools/region_decode_bench/build_wasm.sh
+++ b/tests/tools/region_decode_bench/build_wasm.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# build_wasm.sh — build the WASM modules for region_decode_bench.
+#
+# Produces single-thread+SIMD and multi-thread+SIMD modules that the
+# run_wasm.cjs runner drives via ccall.  Requires the web core libs to be built
+# first (web/build/libopen_htj2k_simd_lib.a and *_mt_simd_lib.a) — those are the
+# core decoder compiled for Wasm; this just links the benchmark entry point.
+#
+# Usage:  tests/tools/region_decode_bench/build_wasm.sh [out_dir]   (default /tmp)
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+OUT="${1:-/tmp}"
+SRC=tests/tools/region_decode_bench/main_rdbench.cpp
+INCS=(-Isource/core/common -Isource/core/transform -Isource/core/codestream
+      -Isource/core/coding -Isource/core/interface -Isource/core/jph -Isource/core/jpip)
+COMMON=(-O3 -flto -msimd128 -mnontrapping-fptoint -mbulk-memory -std=c++17
+        -DOPENHTJ2K_ENABLE_WASM_SIMD "${INCS[@]}" "$SRC"
+        -sMODULARIZE=1 -sENVIRONMENT=node -sINVOKE_RUN=0
+        -sEXPORTED_FUNCTIONS=_rdbench_region,_malloc,_free
+        -sEXPORTED_RUNTIME_METHODS=ccall,HEAPU8,HEAPF64
+        -sALLOW_MEMORY_GROWTH=1 -sMAXIMUM_MEMORY=2GB -sNO_DISABLE_EXCEPTION_CATCHING -sSINGLE_FILE=1)
+
+ST_LIB=web/build/libopen_htj2k_simd_lib.a
+MT_LIB=web/build/libopen_htj2k_mt_simd_lib.a
+[[ -f "$ST_LIB" ]] || { echo "ERROR: $ST_LIB missing — build the web libs first" >&2; exit 1; }
+
+echo "=== building st_simd -> $OUT/rdbench_st.js ==="
+emcc "${COMMON[@]}" "$ST_LIB" -o "$OUT/rdbench_st.js"
+
+if [[ -f "$MT_LIB" ]]; then
+  echo "=== building mt_simd -> $OUT/rdbench_mt.js ==="
+  # PTHREAD_POOL_SIZE pre-creates the worker pool; run_wasm.cjs clamps -threads
+  # to <= this (min(hwc,16)).  pthreads + ENVIRONMENT must include 'worker'.
+  emcc "${COMMON[@]/-sENVIRONMENT=node/-sENVIRONMENT=node,worker}" \
+    -pthread -sUSE_PTHREADS=1 \
+    -sPTHREAD_POOL_SIZE='Math.min((typeof navigator!=="undefined"?navigator.hardwareConcurrency:require("os").cpus().length),16)' \
+    "$MT_LIB" -o "$OUT/rdbench_mt.js"
+else
+  echo "(skip mt_simd: $MT_LIB missing)"
+fi
+echo "done."

--- a/tests/tools/region_decode_bench/main_rdbench.cpp
+++ b/tests/tools/region_decode_bench/main_rdbench.cpp
@@ -54,6 +54,22 @@
 #include <string>
 #include <vector>
 #include "decoder.hpp"
+#ifdef __EMSCRIPTEN__
+  #include <emscripten/emscripten.h>
+#endif
+
+// Monotonic wall clock in milliseconds.  Under Emscripten use
+// emscripten_get_now() (= performance.now(), high-resolution) instead of
+// std::chrono::steady_clock, which can be coarse / zero-resolution in a
+// non-threaded Wasm build.  Keeps the timed code path identical native/Wasm.
+static inline double now_ms() {
+#ifdef __EMSCRIPTEN__
+  return emscripten_get_now();
+#else
+  return std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now().time_since_epoch())
+      .count();
+#endif
+}
 
 struct Args {
   std::string infile;
@@ -150,15 +166,15 @@ struct Timing {
 static Timing decode_region(open_htj2k::openhtj2k_decoder &dec, const uint8_t *data, size_t len,
                             uint8_t reduce_NL, uint32_t threads, bool restrict_region, uint32_t x0,
                             uint32_t y0, uint32_t w, uint32_t h, bool store, DecodeBufs &b) {
-  auto t0 = std::chrono::steady_clock::now();
+  const double t0 = now_ms();
   dec.init(data, len, reduce_NL, threads);
   dec.parse();
   if (restrict_region) {
     dec.set_col_range(x0, x0 + w);
     dec.set_row_range(y0, y0 + h);
   }
-  auto t1 = std::chrono::steady_clock::now();
-  auto cb = [&](uint32_t y, int32_t *const *rows, uint16_t nc) {
+  const double t1 = now_ms();
+  auto cb         = [&](uint32_t y, int32_t *const *rows, uint16_t nc) {
     if (!store) return;
     if (y < y0 || y >= y0 + h) return;  // row_range should already clip; guard anyway
     if (b.out.size() < nc) b.out.resize(nc);
@@ -170,45 +186,59 @@ static Timing decode_region(open_htj2k::openhtj2k_decoder &dec, const uint8_t *d
       const uint32_t xe = std::min(x0 + w, cw);
       if (xe > xs)
         std::memcpy(b.out[c].data() + static_cast<size_t>(ly) * w, rows[c] + xs,
-                    (xe - xs) * sizeof(int32_t));
+                            (xe - xs) * sizeof(int32_t));
     }
   };
   dec.invoke_line_based_stream_reuse(cb, b.widths, b.heights, b.depths, b.is_signed);
-  auto t2 = std::chrono::steady_clock::now();
+  const double t2 = now_ms();
   Timing tm;
-  tm.setup  = std::chrono::duration<double, std::milli>(t1 - t0).count();
-  tm.decode = std::chrono::duration<double, std::milli>(t2 - t1).count();
+  tm.setup  = t1 - t0;
+  tm.decode = t2 - t1;
   return tm;
 }
 
+// Full non-reuse decode that retains ONLY the [x0,x0+w) x [y0,y0+h) window of
+// each component (windowed reference).  Storing just the window — not the whole
+// canvas — keeps memory at window size, so this works at level 0 of a gigapixel
+// image even under the 2 GB Wasm cap (a full int32 canvas there is multi-GB).
+// The decode itself is full-width/full-work, so the retained window is the true
+// reference for that region.  Returns false on decode error / no output.
+static bool decode_full_reference_window(const uint8_t *data, size_t len, uint8_t reduce_NL,
+                                         uint32_t threads, uint32_t x0, uint32_t y0, uint32_t w, uint32_t h,
+                                         std::vector<std::vector<int32_t>> &refwin,
+                                         std::vector<uint32_t> &rw, std::vector<uint32_t> &rh) {
+  std::vector<uint8_t> rd;
+  std::vector<bool> rs;
+  open_htj2k::openhtj2k_decoder dec;  // reuse disabled (independent reference)
+  dec.init(data, len, reduce_NL, threads);
+  dec.parse();
+  auto cb = [&](uint32_t y, int32_t *const *rows, uint16_t nc) {
+    if (y < y0 || y >= y0 + h) return;
+    if (refwin.size() < nc) refwin.resize(nc);
+    const uint32_t ly = y - y0;
+    for (uint16_t c = 0; c < nc; ++c) {
+      const uint32_t cw = rw[c];
+      if (refwin[c].size() < static_cast<size_t>(w) * h) refwin[c].assign(static_cast<size_t>(w) * h, 0);
+      const uint32_t xs = std::min(x0, cw), xe = std::min(x0 + w, cw);
+      if (xe > xs)
+        std::memcpy(refwin[c].data() + static_cast<size_t>(ly) * w, rows[c] + xs,
+                    (xe - xs) * sizeof(int32_t));
+    }
+  };
+  dec.invoke_line_based_stream(cb, rw, rh, rd, rs);
+  return !refwin.empty() && !rw.empty();
+}
+
 // Byte-exact check of the timed path: decode the centred window through the
-// reuse path (col_range + row_range together) and compare against a full-level
-// reference produced by the independent, reuse-disabled non-reuse line-based
-// path.  col_range_compare and row_range_compare each validate only one axis;
-// this is the only check of the 2D combination the benchmark actually times.
-// Returns true on exact match within the window.
+// reuse path (col_range + row_range together) and compare against an
+// independent full non-reuse decode of the same window.  col_range_compare and
+// row_range_compare each validate only one axis; this is the only check of the
+// 2D combination the benchmark actually times.  Returns true on exact match.
 static bool verify_window(const uint8_t *data, size_t len, uint8_t reduce_NL, uint32_t threads, uint32_t x0,
                           uint32_t y0, uint32_t w, uint32_t h) {
   std::vector<std::vector<int32_t>> ref;
   std::vector<uint32_t> rw, rh;
-  std::vector<uint8_t> rd;
-  std::vector<bool> rs;
-  {
-    open_htj2k::openhtj2k_decoder dec;  // reuse disabled (independent reference)
-    dec.init(data, len, reduce_NL, threads);
-    dec.parse();
-    auto cb = [&](uint32_t y, int32_t *const *rows, uint16_t nc) {
-      if (ref.empty()) {
-        ref.resize(nc);
-        for (uint16_t c = 0; c < nc; ++c) ref[c].assign(static_cast<size_t>(rw[c]) * rh[c], 0);
-      }
-      for (uint16_t c = 0; c < nc; ++c)
-        if (y < rh[c])
-          std::memcpy(ref[c].data() + static_cast<size_t>(y) * rw[c], rows[c], rw[c] * sizeof(int32_t));
-    };
-    dec.invoke_line_based_stream(cb, rw, rh, rd, rs);
-  }
-  if (ref.empty()) return false;
+  if (!decode_full_reference_window(data, len, reduce_NL, threads, x0, y0, w, h, ref, rw, rh)) return false;
 
   DecodeBufs b;
   open_htj2k::openhtj2k_decoder dec;
@@ -222,7 +252,7 @@ static bool verify_window(const uint8_t *data, size_t len, uint8_t reduce_NL, ui
       for (uint32_t lx = 0; lx < w; ++lx) {
         const uint32_t gx = x0 + lx, gy = y0 + ly;
         if (gx >= cw || gy >= rh[c]) continue;
-        const int32_t r = ref[c][static_cast<size_t>(gy) * cw + gx];
+        const int32_t r = ref[c][static_cast<size_t>(ly) * w + lx];
         const int32_t g = b.out[c][static_cast<size_t>(ly) * w + lx];
         if (r != g) {
           printf("# VERIFY FAIL level %u comp %zu pixel (%u,%u): ref=%d got=%d\n", reduce_NL, c, gx, gy, r,
@@ -260,6 +290,138 @@ static void print_row(const Args &a, int li, uint32_t W, uint32_t H, const char 
   }
   fflush(stdout);
 }
+
+#ifdef __EMSCRIPTEN__
+// JS-callable benchmark entry point for the Wasm runtime (the native main()
+// does not run under Node for this build; the runner drives this via ccall,
+// like web/open_htj2k_dec.mjs and col_range_compare's crc_validate).
+//
+// Times `iter` centred-window reuse decodes at one reduce level / window edge,
+// after `warmup` untimed decodes.  The window is min(win,levelW) x
+// min(win,levelH), centred — identical geometry to the native sweep.  Writes
+// six doubles to out[0..5]:
+//   [0]=median total ms  [1]=median decode ms  [2]=median setup ms
+//   [3]=min total ms     [4]=level width       [5]=level height
+// Returns 0 on success, 1 on decode error / empty output.
+extern "C" EMSCRIPTEN_KEEPALIVE int rdbench_region(const uint8_t *data, int len, int reduce_NL, int win,
+                                                   int threads, int iter, int warmup, double *out) {
+  for (int i = 0; i < 6; ++i) out[i] = 0.0;
+  try {
+    open_htj2k::openhtj2k_decoder dec;
+    dec.enable_single_tile_reuse(true);
+    DecodeBufs b;
+    // Probe reduced-level dims via a 1x1 decode (also warms the reuse cache);
+    // get_component_width() ignores reduce_NL, so dims must come from the cb.
+    decode_region(dec, data, static_cast<size_t>(len), static_cast<uint8_t>(reduce_NL),
+                  static_cast<uint32_t>(threads), true, 0, 0, 1, 1, false, b);
+    if (b.widths.empty() || b.widths[0] == 0 || b.heights[0] == 0) return 1;
+    const uint32_t W = b.widths[0], H = b.heights[0];
+    const uint32_t w = std::min<uint32_t>(win, W), h = std::min<uint32_t>(win, H);
+    const uint32_t x0 = (W > w) ? (W - w) / 2 : 0, y0 = (H > h) ? (H - h) / 2 : 0;
+
+    b.out.clear();
+    for (int i = 0; i < warmup; ++i)
+      decode_region(dec, data, static_cast<size_t>(len), static_cast<uint8_t>(reduce_NL),
+                    static_cast<uint32_t>(threads), true, x0, y0, w, h, true, b);
+    std::vector<double> tot, dc, st;
+    tot.reserve(iter);
+    dc.reserve(iter);
+    st.reserve(iter);
+    for (int i = 0; i < iter; ++i) {
+      Timing t = decode_region(dec, data, static_cast<size_t>(len), static_cast<uint8_t>(reduce_NL),
+                               static_cast<uint32_t>(threads), true, x0, y0, w, h, true, b);
+      tot.push_back(t.total());
+      dc.push_back(t.decode);
+      st.push_back(t.setup);
+    }
+    if (tot.empty()) return 1;
+    out[0] = median(tot);
+    out[1] = median(dc);
+    out[2] = median(st);
+    out[3] = minimum(tot);
+    out[4] = static_cast<double>(W);
+    out[5] = static_cast<double>(H);
+    return 0;
+  } catch (std::exception &e) {
+    printf("rdbench_region error: %s\n", e.what());
+    return 1;
+  }
+}
+
+// JS-callable correctness gate for the Wasm timing path.  Decodes the centred
+// window through the reuse + col_range + row_range path (what rdbench_region
+// times) and compares it, within the window, against an independent full
+// non-reuse decode.  This is the Wasm analogue of the native -verify, and the
+// only at-scale runtime check of the Wasm SIMD sub-range IDWT (its runtime test
+// was deferred when the kernel landed).  Writes six doubles to out[0..5]:
+//   [0]=mismatch count  [1]=first mismatch x  [2]=first mismatch y
+//   [3]=max |ref-got|   [4]=level width        [5]=level height
+// Returns 0 if byte-exact, 1 if any mismatch, 2 on decode error.
+extern "C" EMSCRIPTEN_KEEPALIVE int rdbench_verify(const uint8_t *data, int len, int reduce_NL, int win,
+                                                   int threads, double *out) {
+  for (int i = 0; i < 6; ++i) out[i] = 0.0;
+  try {
+    const size_t L   = static_cast<size_t>(len);
+    const uint8_t r  = static_cast<uint8_t>(reduce_NL);
+    const uint32_t t = static_cast<uint32_t>(threads);
+
+    // First learn the level dims via a cheap 1x1 windowed reference.
+    std::vector<std::vector<int32_t>> probe;
+    std::vector<uint32_t> rw, rh;
+    if (!decode_full_reference_window(data, L, r, t, 0, 0, 1, 1, probe, rw, rh)) return 2;
+    const uint32_t W = rw[0], H = rh[0];
+    const uint32_t w = std::min<uint32_t>(win, W), h = std::min<uint32_t>(win, H);
+    const uint32_t x0 = (W > w) ? (W - w) / 2 : 0, y0 = (H > h) ? (H - h) / 2 : 0;
+    out[4] = static_cast<double>(W);
+    out[5] = static_cast<double>(H);
+
+    // Independent full-work reference, retaining only the window (memory-safe at
+    // level 0 of a gigapixel image under the 2 GB Wasm cap).
+    std::vector<std::vector<int32_t>> ref;
+    std::vector<uint32_t> rw2, rh2;
+    if (!decode_full_reference_window(data, L, r, t, x0, y0, w, h, ref, rw2, rh2)) return 2;
+
+    // Windowed reuse decode (the timed path).
+    open_htj2k::openhtj2k_decoder dec;
+    dec.enable_single_tile_reuse(true);
+    DecodeBufs b;
+    decode_region(dec, data, L, r, t, true, x0, y0, w, h, true, b);  // warm
+    b.out.clear();
+    decode_region(dec, data, L, r, t, true, x0, y0, w, h, true, b);  // compared
+
+    uint64_t nmis  = 0;
+    int32_t maxabs = 0;
+    uint32_t fx = 0, fy = 0;
+    for (size_t c = 0; c < ref.size() && c < b.out.size(); ++c) {
+      const uint32_t cw = rw2[c];
+      for (uint32_t ly = 0; ly < h; ++ly)
+        for (uint32_t lx = 0; lx < w; ++lx) {
+          const uint32_t gx = x0 + lx, gy = y0 + ly;
+          if (gx >= cw || gy >= rh2[c]) continue;
+          const int32_t rr = ref[c][static_cast<size_t>(ly) * w + lx];
+          const int32_t gg = b.out[c][static_cast<size_t>(ly) * w + lx];
+          if (rr != gg) {
+            if (nmis == 0) {
+              fx = gx;
+              fy = gy;
+            }
+            const int32_t d = rr > gg ? rr - gg : gg - rr;
+            if (d > maxabs) maxabs = d;
+            ++nmis;
+          }
+        }
+    }
+    out[0] = static_cast<double>(nmis);
+    out[1] = static_cast<double>(fx);
+    out[2] = static_cast<double>(fy);
+    out[3] = static_cast<double>(maxabs);
+    return nmis ? 1 : 0;
+  } catch (std::exception &e) {
+    printf("rdbench_verify error: %s\n", e.what());
+    return 2;
+  }
+}
+#endif  // __EMSCRIPTEN__
 
 int main(int argc, char *argv[]) {
   Args a;

--- a/tests/tools/region_decode_bench/main_rdbench.cpp
+++ b/tests/tools/region_decode_bench/main_rdbench.cpp
@@ -1,0 +1,397 @@
+// region_decode_bench: measure HTJ2K region-decode latency / throughput at
+// OpenSeadragon tile cadence, via the single-tile reuse path.
+//
+// For each pyramid level (reduce_NL) and each square window size, it decodes a
+// centred window using exactly the path the WASM viewer (and a future
+// OpenSeadragon HTJ2KTileSource) uses:
+//
+//     dec.enable_single_tile_reuse(true);
+//     dec.set_col_range(x0, x0 + w);
+//     dec.set_row_range(y0, y0 + h);
+//     dec.invoke_line_based_stream_reuse(cb, ...);
+//
+// and reports ms/region (median / min) and regions/s.  This is the M1
+// deliverable for the OpenSeadragon-integration evaluation: the make-or-break
+// number is region-decode latency, used to build an Iris-style comparison
+// table (region decode vs DZI tile fetch).
+//
+// Why init() and not init_borrow(): the scalar HT cleanup decode mutates the
+// codeblock bytes in place (modDcup writes Dcup[Lcup-1]=0xFF, Dcup[Lcup-2]|=0x0F
+// at ht_block_decoding.cpp:1196).  With a *borrowed* buffer those writes corrupt
+// the source, so the 2nd+ reuse decode recomputes Scup=4095 and aborts every
+// block ("WARNING: cleanup pass suffix length 4095 is invalid").  init() copies
+// the codestream per call, giving each decode pristine bytes — the same path
+// col_range_compare validates byte-exact.  The copy is therefore a real,
+// measured component of the per-tile cost; the timing is split into:
+//   setup  = init (codestream copy) + parse (header walk) + set ranges
+//   decode = invoke_line_based_stream_reuse (packet replay + block + IDWT)
+// so we can see whether the headline is dominated by the whole-codestream copy
+// /parse (→ M2 byte-range precinct selection is the lever) or by region decode.
+//
+// Threading is a process-global singleton (ThreadPool::instance is
+// first-call-wins), so the thread count is fixed per process via -threads;
+// sweep it with run_bench.sh.  One decoder is created per level (reduce_NL is
+// bound at init) and reused across window sizes / iterations so the single-tile
+// reuse cache stays warm.
+//
+// Usage:
+//   region_decode_bench <input.j2k|.jph> [-threads T] [-iter K] [-warmup W]
+//                       [-win 256,512,1024] [-maxlevel L] [-full] [-verify]
+//                       [-fullcap MP] [-csv]
+//
+// -verify byte-exact-checks the col+row windowed reuse decode against an
+// independent full non-reuse decode (where the reduced level fits under
+// -fullcap MP); exits 2 on any mismatch.
+//
+// Defaults: -threads 1  -iter 25  -warmup 3  -win 256,512,1024
+//           -maxlevel <get_max_safe_reduce_NL()>  -fullcap 16 (MP)
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+#include "decoder.hpp"
+
+struct Args {
+  std::string infile;
+  uint32_t threads = 1;
+  int iter         = 25;
+  int warmup       = 3;
+  std::vector<uint32_t> wins;  // square window edge lengths
+  int maxlevel      = -1;      // -1 => get_max_safe_reduce_NL()
+  bool full         = false;
+  bool verify       = false;
+  double fullcap_mp = 16.0;
+  bool csv          = false;
+};
+
+static std::vector<uint32_t> parse_csv_uints(const char *s) {
+  std::vector<uint32_t> v;
+  const char *p = s;
+  while (*p) {
+    char *end       = nullptr;
+    unsigned long n = strtoul(p, &end, 10);
+    if (end == p) break;
+    if (n > 0) v.push_back(static_cast<uint32_t>(n));
+    p = (*end == ',') ? end + 1 : end;
+  }
+  return v;
+}
+
+static bool parse_args(int argc, char *argv[], Args &a) {
+  for (int i = 1; i < argc; ++i) {
+    if (!strcmp(argv[i], "-threads") && i + 1 < argc) {
+      a.threads = static_cast<uint32_t>(strtoul(argv[++i], nullptr, 10));
+    } else if (!strcmp(argv[i], "-iter") && i + 1 < argc) {
+      a.iter = atoi(argv[++i]);
+    } else if (!strcmp(argv[i], "-warmup") && i + 1 < argc) {
+      a.warmup = atoi(argv[++i]);
+    } else if (!strcmp(argv[i], "-win") && i + 1 < argc) {
+      a.wins = parse_csv_uints(argv[++i]);
+    } else if (!strcmp(argv[i], "-maxlevel") && i + 1 < argc) {
+      a.maxlevel = atoi(argv[++i]);
+    } else if (!strcmp(argv[i], "-full")) {
+      a.full = true;
+    } else if (!strcmp(argv[i], "-verify")) {
+      a.verify = true;
+    } else if (!strcmp(argv[i], "-fullcap") && i + 1 < argc) {
+      a.fullcap_mp = atof(argv[++i]);
+    } else if (!strcmp(argv[i], "-csv")) {
+      a.csv = true;
+    } else {
+      a.infile = argv[i];
+    }
+  }
+  if (a.wins.empty()) a.wins = {256, 512, 1024};
+  std::sort(a.wins.begin(), a.wins.end());  // monotonic so the clamp-dedupe is adjacent
+  return !a.infile.empty();
+}
+
+static std::vector<uint8_t> read_file(const char *path) {
+  FILE *f = fopen(path, "rb");
+  if (!f) {
+    printf("ERROR: cannot open %s\n", path);
+    return {};
+  }
+  fseek(f, 0, SEEK_END);
+  size_t sz = static_cast<size_t>(ftell(f));
+  fseek(f, 0, SEEK_SET);
+  std::vector<uint8_t> buf(sz);
+  size_t rd = fread(buf.data(), 1, sz, f);
+  fclose(f);
+  if (rd != sz) {
+    printf("ERROR: partial read of %s\n", path);
+    return {};
+  }
+  return buf;
+}
+
+// Reused scratch for one decode (output rows + decoder-populated metadata).
+struct DecodeBufs {
+  std::vector<std::vector<int32_t>> out;  // extracted window, one plane/component
+  std::vector<uint32_t> widths, heights;  // full reduced-level component dims
+  std::vector<uint8_t> depths;
+  std::vector<bool> is_signed;
+};
+
+struct Timing {
+  double setup;   // init (copy) + parse + set ranges
+  double decode;  // invoke_line_based_stream_reuse
+  double total() const { return setup + decode; }
+};
+
+// One reuse-path region decode.  When store is true the centred
+// [x0,x0+w) x [y0,y0+h) window is copied out of the full-width rows (the work a
+// tile source actually does); the full-level baseline passes store=false to
+// avoid allocating a multi-GB canvas.
+static Timing decode_region(open_htj2k::openhtj2k_decoder &dec, const uint8_t *data, size_t len,
+                            uint8_t reduce_NL, uint32_t threads, bool restrict_region, uint32_t x0,
+                            uint32_t y0, uint32_t w, uint32_t h, bool store, DecodeBufs &b) {
+  auto t0 = std::chrono::steady_clock::now();
+  dec.init(data, len, reduce_NL, threads);
+  dec.parse();
+  if (restrict_region) {
+    dec.set_col_range(x0, x0 + w);
+    dec.set_row_range(y0, y0 + h);
+  }
+  auto t1 = std::chrono::steady_clock::now();
+  auto cb = [&](uint32_t y, int32_t *const *rows, uint16_t nc) {
+    if (!store) return;
+    if (y < y0 || y >= y0 + h) return;  // row_range should already clip; guard anyway
+    if (b.out.size() < nc) b.out.resize(nc);
+    const uint32_t ly = y - y0;
+    for (uint16_t c = 0; c < nc; ++c) {
+      if (b.out[c].size() < static_cast<size_t>(w) * h) b.out[c].assign(static_cast<size_t>(w) * h, 0);
+      const uint32_t cw = (c < b.widths.size()) ? b.widths[c] : 0;
+      const uint32_t xs = std::min(x0, cw);
+      const uint32_t xe = std::min(x0 + w, cw);
+      if (xe > xs)
+        std::memcpy(b.out[c].data() + static_cast<size_t>(ly) * w, rows[c] + xs,
+                    (xe - xs) * sizeof(int32_t));
+    }
+  };
+  dec.invoke_line_based_stream_reuse(cb, b.widths, b.heights, b.depths, b.is_signed);
+  auto t2 = std::chrono::steady_clock::now();
+  Timing tm;
+  tm.setup  = std::chrono::duration<double, std::milli>(t1 - t0).count();
+  tm.decode = std::chrono::duration<double, std::milli>(t2 - t1).count();
+  return tm;
+}
+
+// Byte-exact check of the timed path: decode the centred window through the
+// reuse path (col_range + row_range together) and compare against a full-level
+// reference produced by the independent, reuse-disabled non-reuse line-based
+// path.  col_range_compare and row_range_compare each validate only one axis;
+// this is the only check of the 2D combination the benchmark actually times.
+// Returns true on exact match within the window.
+static bool verify_window(const uint8_t *data, size_t len, uint8_t reduce_NL, uint32_t threads, uint32_t x0,
+                          uint32_t y0, uint32_t w, uint32_t h) {
+  std::vector<std::vector<int32_t>> ref;
+  std::vector<uint32_t> rw, rh;
+  std::vector<uint8_t> rd;
+  std::vector<bool> rs;
+  {
+    open_htj2k::openhtj2k_decoder dec;  // reuse disabled (independent reference)
+    dec.init(data, len, reduce_NL, threads);
+    dec.parse();
+    auto cb = [&](uint32_t y, int32_t *const *rows, uint16_t nc) {
+      if (ref.empty()) {
+        ref.resize(nc);
+        for (uint16_t c = 0; c < nc; ++c) ref[c].assign(static_cast<size_t>(rw[c]) * rh[c], 0);
+      }
+      for (uint16_t c = 0; c < nc; ++c)
+        if (y < rh[c])
+          std::memcpy(ref[c].data() + static_cast<size_t>(y) * rw[c], rows[c], rw[c] * sizeof(int32_t));
+    };
+    dec.invoke_line_based_stream(cb, rw, rh, rd, rs);
+  }
+  if (ref.empty()) return false;
+
+  DecodeBufs b;
+  open_htj2k::openhtj2k_decoder dec;
+  dec.enable_single_tile_reuse(true);
+  decode_region(dec, data, len, reduce_NL, threads, true, x0, y0, w, h, true, b);  // warm
+  b.out.clear();
+  decode_region(dec, data, len, reduce_NL, threads, true, x0, y0, w, h, true, b);  // measured-equivalent
+  for (size_t c = 0; c < ref.size() && c < b.out.size(); ++c) {
+    const uint32_t cw = rw[c];
+    for (uint32_t ly = 0; ly < h; ++ly) {
+      for (uint32_t lx = 0; lx < w; ++lx) {
+        const uint32_t gx = x0 + lx, gy = y0 + ly;
+        if (gx >= cw || gy >= rh[c]) continue;
+        const int32_t r = ref[c][static_cast<size_t>(gy) * cw + gx];
+        const int32_t g = b.out[c][static_cast<size_t>(ly) * w + lx];
+        if (r != g) {
+          printf("# VERIFY FAIL level %u comp %zu pixel (%u,%u): ref=%d got=%d\n", reduce_NL, c, gx, gy, r,
+                 g);
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+
+static double median(std::vector<double> v) {
+  std::sort(v.begin(), v.end());
+  return v[v.size() / 2];
+}
+static double minimum(const std::vector<double> &v) { return *std::min_element(v.begin(), v.end()); }
+
+// Print one measured row (total = setup + decode).
+static void print_row(const Args &a, int li, uint32_t W, uint32_t H, const char *winlbl, uint32_t winw,
+                      uint32_t winh, int iters, const std::vector<double> &tot,
+                      const std::vector<double> &dec, const std::vector<double> &set) {
+  const double med_tot = median(tot), min_tot = minimum(tot);
+  const double med_dec = median(dec), med_set = median(set);
+  const double rps    = 1000.0 / med_tot;
+  const double mpixps = static_cast<double>(winw) * winh / med_tot / 1000.0;
+  if (a.csv) {
+    printf("%d,%u,%u,%s,%u,%u,%llu,%u,%d,%.4f,%.4f,%.4f,%.4f,%.1f,%.1f\n", li, W, H, winlbl, winw, winh,
+           (unsigned long long)winw * winh, a.threads, iters, med_tot, med_dec, med_set, min_tot, rps,
+           mpixps);
+  } else {
+    printf("%-5d  %5ux%-7u  %-11s  %-9llu  %-5d  %-9.4f  %-9.4f  %-9.4f  %-9.4f  %-10.1f  %-8.1f\n", li, W,
+           H, winlbl, (unsigned long long)winw * winh, iters, med_tot, med_dec, med_set, min_tot, rps,
+           mpixps);
+  }
+  fflush(stdout);
+}
+
+int main(int argc, char *argv[]) {
+  Args a;
+  if (!parse_args(argc, argv, a)) {
+    printf(
+        "Usage: region_decode_bench <input.j2k|.jph> [-threads T] [-iter K] [-warmup W]\n"
+        "                           [-win 256,512,1024] [-maxlevel L] [-full] [-verify] [-fullcap MP] "
+        "[-csv]\n");
+    return 1;
+  }
+
+  std::vector<uint8_t> file = read_file(a.infile.c_str());
+  if (file.empty()) return 1;
+  const uint8_t *data = file.data();
+  const size_t len    = file.size();
+
+  // ── Banner: query stream geometry from a level-0 parse ──────────────────
+  uint16_t nc     = 0;
+  uint32_t full_w = 0, full_h = 0, cs = 0;
+  uint8_t depth = 0, mct = 0, max_reduce = 0;
+  try {
+    open_htj2k::openhtj2k_decoder probe;
+    probe.init(data, len, 0, a.threads);
+    probe.parse();
+    nc         = probe.get_num_component();
+    full_w     = probe.get_component_width(0);
+    full_h     = probe.get_component_height(0);
+    depth      = probe.get_component_depth(0);
+    mct        = probe.get_mct();
+    cs         = probe.get_colorspace();
+    max_reduce = probe.get_max_safe_reduce_NL();
+  } catch (std::exception &e) {
+    printf("ERROR: parse failed: %s\n", e.what());
+    return 1;
+  }
+  const int maxlevel = (a.maxlevel >= 0) ? std::min<int>(a.maxlevel, max_reduce) : max_reduce;
+
+  if (a.csv) {
+    printf(
+        "level,level_w,level_h,window,win_w,win_h,win_px,threads,iters,med_ms,dec_ms,set_ms,min_ms,"
+        "regions_s,mpix_s\n");
+  } else {
+    printf("# region_decode_bench  file=%s  (%zu bytes)\n", a.infile.c_str(), len);
+    printf("# full=%ux%u  comps=%u  depth=%u  mct=%u  colorspace=%u  max_safe_reduce=%u\n", full_w, full_h,
+           nc, depth, mct, cs, max_reduce);
+    printf(
+        "# threads=%u  iter=%d  warmup=%d  levels=0..%d   reuse path; per-tile = setup(copy+parse) + "
+        "decode(invoke)\n",
+        a.threads, a.iter, a.warmup, maxlevel);
+    printf("%-5s  %-13s  %-11s  %-9s  %-5s  %-9s  %-9s  %-9s  %-9s  %-10s  %-8s\n", "level", "level_dims",
+           "window", "win_px", "iters", "med_ms", "dec_ms", "set_ms", "min_ms", "regions/s", "Mpix/s");
+  }
+
+  int verify_fail = 0;
+  for (int li = 0; li <= maxlevel; ++li) {
+    open_htj2k::openhtj2k_decoder dec;
+    dec.enable_single_tile_reuse(true);
+    DecodeBufs b;
+    uint32_t W = 0, H = 0;
+    try {
+      // Reduced-level dims: get_component_width() returns FULL-res dims (it
+      // ignores reduce_NL), so query them the way col_range_compare does — from
+      // the decoder callback.  A 1x1 restricted decode is cheap (it still emits
+      // full-width metadata) and doubles as the reuse-cache warm-up.
+      decode_region(dec, data, len, static_cast<uint8_t>(li), a.threads, true, 0, 0, 1, 1, false, b);
+      if (!b.widths.empty()) {
+        W = b.widths[0];
+        H = b.heights[0];
+      }
+    } catch (std::exception &e) {
+      printf("level %d: probe failed: %s\n", li, e.what());
+      continue;
+    }
+    if (W == 0 || H == 0) continue;
+
+    // Optional full-level baseline (no region restriction, no store).
+    if (a.full) {
+      const double mp = static_cast<double>(W) * H / 1e6;
+      if (mp <= a.fullcap_mp) {
+        decode_region(dec, data, len, li, a.threads, false, 0, 0, 0, 0, false, b);  // warm
+        const int it = std::max(1, a.iter / 4);  // full decode is dear; fewer iters
+        std::vector<double> tot, dc, st;
+        for (int i = 0; i < it; ++i) {
+          Timing t = decode_region(dec, data, len, li, a.threads, false, 0, 0, 0, 0, false, b);
+          tot.push_back(t.total());
+          dc.push_back(t.decode);
+          st.push_back(t.setup);
+        }
+        print_row(a, li, W, H, "full", W, H, it, tot, dc, st);
+      } else if (!a.csv) {
+        printf("%-5d  %5ux%-7u  %-11s  (%.0f MP > fullcap %.0f MP, skipped)\n", li, W, H, "full", mp,
+               a.fullcap_mp);
+      }
+    }
+
+    uint64_t seen_win = 0;  // skip window sizes that clamp to the same WxH at this level
+    for (uint32_t S : a.wins) {
+      const uint32_t w   = std::min(S, W);
+      const uint32_t h   = std::min(S, H);
+      const uint64_t key = (static_cast<uint64_t>(w) << 32) | h;
+      if (key == seen_win) continue;  // e.g. 512 and 1024 both clamp to a small level
+      seen_win          = key;
+      const uint32_t x0 = (W > w) ? (W - w) / 2 : 0;
+      const uint32_t y0 = (H > h) ? (H - h) / 2 : 0;
+
+      // Optional byte-exact correctness check of the col+row windowed path
+      // (only where the full reference canvas is affordable).
+      if (a.verify && static_cast<double>(W) * H / 1e6 <= a.fullcap_mp) {
+        const bool ok = verify_window(data, len, static_cast<uint8_t>(li), a.threads, x0, y0, w, h);
+        if (!ok) ++verify_fail;
+        printf("# verify  level %d  %ux%u  -> %s\n", li, w, h, ok ? "PASS (byte-exact vs full)" : "FAIL");
+        fflush(stdout);
+      }
+
+      b.out.clear();  // fresh sizing for this window stride
+      for (int i = 0; i < a.warmup; ++i)
+        decode_region(dec, data, len, li, a.threads, true, x0, y0, w, h, true, b);
+      std::vector<double> tot, dc, st;
+      tot.reserve(a.iter);
+      dc.reserve(a.iter);
+      st.reserve(a.iter);
+      for (int i = 0; i < a.iter; ++i) {
+        Timing t = decode_region(dec, data, len, li, a.threads, true, x0, y0, w, h, true, b);
+        tot.push_back(t.total());
+        dc.push_back(t.decode);
+        st.push_back(t.setup);
+      }
+      char winlbl[24];
+      snprintf(winlbl, sizeof(winlbl), "%ux%u", w, h);
+      print_row(a, li, W, H, winlbl, w, h, a.iter, tot, dc, st);
+    }
+  }
+  if (a.verify) printf("# verify summary: %s (%d failures)\n", verify_fail ? "FAIL" : "PASS", verify_fail);
+  return verify_fail ? 2 : 0;
+}

--- a/tests/tools/region_decode_bench/run_bench.sh
+++ b/tests/tools/region_decode_bench/run_bench.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Driver for region_decode_bench: sweeps thread counts as SEPARATE processes,
+# because the decoder's ThreadPool is a first-call-wins process-global singleton
+# (you cannot change the thread count within one process).
+#
+# Usage:
+#   run_bench.sh <input.j2k|.jph> [bin] [threads_csv] [extra args...]
+# e.g.
+#   run_bench.sh ~/Downloads/heic0602a.j2c
+#   run_bench.sh ~/Downloads/heic0602a.j2c build/bin/region_decode_bench "1,2,4,6" -full
+set -euo pipefail
+
+IN="${1:?usage: run_bench.sh <input> [bin] [threads_csv] [extra...]}"
+BIN="${2:-build/bin/region_decode_bench}"
+THREADS_CSV="${3:-1,4}"
+shift || true; shift || true; shift || true
+EXTRA=("$@")
+
+if [[ ! -x "$BIN" ]]; then echo "ERROR: $BIN not found/executable" >&2; exit 1; fi
+if [[ ! -f "$IN" ]]; then echo "ERROR: input $IN not found" >&2; exit 1; fi
+
+IFS=',' read -r -a THREADS <<< "$THREADS_CSV"
+for T in "${THREADS[@]}"; do
+  echo "==================== threads=$T ===================="
+  "$BIN" "$IN" -threads "$T" "${EXTRA[@]}"
+  echo
+done

--- a/tests/tools/region_decode_bench/run_wasm.cjs
+++ b/tests/tools/region_decode_bench/run_wasm.cjs
@@ -1,0 +1,122 @@
+// run_wasm.cjs — Node.js runner for the WASM build of region_decode_bench.
+//
+// Drives the module's exported rdbench_region() via ccall over a sweep of
+// reduce levels x square window sizes, and prints the same table shape as the
+// native tool — so the WASM column can sit next to the native one in the M1
+// (OpenSeadragon region-decode) comparison.  main() is not used: emscripten's
+// main()-on-load path is unreliable under recent Node, so we call an exported C
+// function instead (exactly like web/open_htj2k_dec.mjs).
+//
+// Build the module (from the repo root, after the web libs are built so that
+// libopen_htj2k_simd_lib.a / libopen_htj2k_mt_simd_lib.a exist):
+//
+//   # single-thread + SIMD
+//   emcc -O3 -flto -msimd128 -mnontrapping-fptoint -mbulk-memory -std=c++17 \
+//     -DOPENHTJ2K_ENABLE_WASM_SIMD \
+//     -Isource/core/common -Isource/core/transform -Isource/core/codestream \
+//     -Isource/core/coding -Isource/core/interface -Isource/core/jph -Isource/core/jpip \
+//     tests/tools/region_decode_bench/main_rdbench.cpp web/build/libopen_htj2k_simd_lib.a \
+//     -sMODULARIZE=1 -sENVIRONMENT=node -sINVOKE_RUN=0 \
+//     -sEXPORTED_FUNCTIONS=_rdbench_region,_malloc,_free \
+//     -sEXPORTED_RUNTIME_METHODS=ccall,HEAPU8,HEAPF64 \
+//     -sALLOW_MEMORY_GROWTH=1 -sMAXIMUM_MEMORY=2GB -sSINGLE_FILE=1 \
+//     -o /tmp/rdbench_st.js
+//
+//   # multi-thread + SIMD (note PTHREAD_POOL_SIZE; pass -threads <= pool size)
+//   emcc ... -pthread -sUSE_PTHREADS=1 \
+//     -sPTHREAD_POOL_SIZE='Math.min(require("os").cpus().length,16)' \
+//     tests/tools/region_decode_bench/main_rdbench.cpp web/build/libopen_htj2k_mt_simd_lib.a \
+//     ... -o /tmp/rdbench_mt.js   (build_wasm.sh does this for you)
+//
+// Run:
+//   node tests/tools/region_decode_bench/run_wasm.cjs <module.js> <input.j2k> \
+//        [-threads T] [-iter K] [-warmup W] [-win 256,512,1024] [-maxlevel L] [-csv]
+const { readFileSync } = require('fs');
+const os = require('os');
+
+const argv = process.argv.slice(2);
+if (argv.length < 2) {
+  console.error(
+    'usage: node run_wasm.cjs <module.js> <input.j2k> [-threads T] [-iter K] [-warmup W] [-win L1,L2,..] [-maxlevel L] [-csv]');
+  process.exit(2);
+}
+const modulePath = argv[0];
+const rest = argv.slice(1);
+const input = rest.find((a) => !a.startsWith('-') && a !== modulePath);
+
+function optInt(name, def) {
+  const i = rest.indexOf(name);
+  return i >= 0 && i + 1 < rest.length ? parseInt(rest[i + 1], 10) : def;
+}
+let threads = optInt('-threads', 1);
+const iter = optInt('-iter', 21);
+const warmup = optInt('-warmup', 3);
+const maxlevel = optInt('-maxlevel', 5);
+const csv = rest.includes('-csv');
+let wins = [256, 512, 1024];
+{
+  const i = rest.indexOf('-win');
+  if (i >= 0 && i + 1 < rest.length) wins = rest[i + 1].split(',').map((x) => parseInt(x, 10)).filter((x) => x > 0);
+}
+wins.sort((a, b) => a - b);
+
+// HARD RULE: WASM num_threads must be <= PTHREAD_POOL_SIZE (pool sizes to
+// min(hwc,16)); passing more forces a dynamic Worker spawn that hangs silently
+// on multi-core.  Clamp here exactly like every other caller in this repo.
+const POOL = Math.min(os.cpus().length, 16);
+if (threads > POOL) {
+  console.error(`# clamping -threads ${threads} -> ${POOL} (PTHREAD_POOL_SIZE)`);
+  threads = POOL;
+}
+
+const factory = require(modulePath);
+(async () => {
+  const m = await factory();
+  const bytes = readFileSync(input);
+  const ptr = m._malloc(bytes.length);
+  m.HEAPU8.set(bytes, ptr);
+  const outPtr = m._malloc(6 * 8);  // six doubles
+
+  if (csv) {
+    console.log('level,level_w,level_h,window,win_w,win_h,win_px,threads,iters,med_ms,dec_ms,set_ms,min_ms,regions_s,mpix_s');
+  } else {
+    console.log(`# region_decode_bench (WASM)  file=${input}  (${bytes.length} bytes)`);
+    console.log(`# module=${modulePath}  threads=${threads} (pool ${POOL})  iter=${iter}  warmup=${warmup}`);
+    console.log(
+      ['level', 'level_dims'.padEnd(13), 'window'.padEnd(11), 'win_px'.padEnd(9), 'iters'.padEnd(5),
+       'med_ms'.padEnd(9), 'dec_ms'.padEnd(9), 'set_ms'.padEnd(9), 'min_ms'.padEnd(9),
+       'regions/s'.padEnd(10), 'Mpix/s'].join('  '));
+  }
+
+  for (let li = 0; li <= maxlevel; li++) {
+    let prevKey = '';
+    for (const S of wins) {
+      const rc = m.ccall('rdbench_region', 'number',
+        ['number', 'number', 'number', 'number', 'number', 'number', 'number', 'number'],
+        [ptr, bytes.length, li, S, threads, iter, warmup, outPtr]);
+      if (rc !== 0) { console.error(`# level ${li} win ${S}: decode error (rc=${rc})`); continue; }
+      const o = (k) => m.HEAPF64[(outPtr >> 3) + k];
+      const medTot = o(0), medDec = o(1), medSet = o(2), minTot = o(3), W = o(4) | 0, H = o(5) | 0;
+      const w = Math.min(S, W), h = Math.min(S, H);
+      const key = `${w}x${h}`;
+      if (key === prevKey) continue;  // window clamped to same dims as previous (small level)
+      prevKey = key;
+      const winpx = w * h;
+      const rps = 1000 / medTot, mpixps = winpx / medTot / 1000;
+      if (csv) {
+        console.log([li, W, H, key, w, h, winpx, threads, iter,
+          medTot.toFixed(4), medDec.toFixed(4), medSet.toFixed(4), minTot.toFixed(4),
+          rps.toFixed(1), mpixps.toFixed(1)].join(','));
+      } else {
+        console.log([
+          String(li).padEnd(5), `${W}x${H}`.padEnd(13), key.padEnd(11), String(winpx).padEnd(9),
+          String(iter).padEnd(5), medTot.toFixed(4).padEnd(9), medDec.toFixed(4).padEnd(9),
+          medSet.toFixed(4).padEnd(9), minTot.toFixed(4).padEnd(9), rps.toFixed(1).padEnd(10),
+          mpixps.toFixed(1)].join('  '));
+      }
+    }
+  }
+  m._free(outPtr);
+  m._free(ptr);
+  process.exit(0);
+})();


### PR DESCRIPTION
## What

A new benchmark tool, `tests/tools/region_decode_bench`, that measures **region (viewport) decode latency/throughput** — the decode pattern a tiled / deep-zoom viewer issues: *decode one window at one pyramid level*, repeatedly. It complements `col_range_compare` / `row_range_compare` (which validate correctness of one axis each) with a timing + 2D-correctness harness.

For each reduce level and each square window size it decodes a centred window through the single-tile reuse path:

```cpp
dec.enable_single_tile_reuse(true);
dec.set_col_range(x0, x0 + w);
dec.set_row_range(y0, y0 + h);
dec.invoke_line_based_stream_reuse(cb, ...);
```

and reports median ms/region **split into setup (init copy + parse) vs decode (invoke)**, plus regions/s and Mpix/s.

## Why these implementation choices
- **`init()` (per-call copy), not `init_borrow()`** — the HT cleanup decode mutates codeblock bytes in place (`modDcup` at `ht_block_decoding.cpp:1196` writes `0xFF,0xFF`). With a *borrowed* buffer the 2nd reuse decode re-reads those bytes, recomputes `Scup=4095`, and aborts every block (`WARNING: cleanup pass suffix length 4095 is invalid` — a silent fast-but-wrong decode). The copy is therefore reported as a real per-tile cost.
- **Reduced-level dims come from the decode callback**, because `get_component_width()` returns full-res dims regardless of `reduce_NL`.
- **One thread count per process** — `ThreadPool::instance()` is a first-call-wins singleton, so `run_bench.sh` sweeps thread counts as separate processes.
- **`-verify`** byte-exact-checks the windowed (col+row) reuse decode against an independent full non-reuse decode. This is the only coverage of the 2D `col_range`+`row_range` combination. Exits 2 on mismatch.

Not registered as a ctest (it is a benchmark tool, like `imgcmp`).

## Example output
```
# full=15852x12392  comps=3  depth=8  mct=1   threads=1  (reuse path)
level  level_dims     window     med_ms   dec_ms   set_ms   regions/s
0      15852x12392    256x256    64.7     60.6     4.1      15.5
2      3963x3098      256x256    29.9     25.7     4.3      33.4
5      496x388        256x256    15.0     10.9     4.1      66.5
# verify summary: PASS (0 failures)
```
(196 MP HTJ2K image, Ryzen 9950X.) Two structural observations the split makes visible: a flat ~4 ms `init`-copy setup, and a decode floor (~11 ms) that doesn't shrink with the window — the reuse path replays the whole codestream's packet headers per call. Both motivate a precinct-indexed / byte-range region-decode path as a follow-up.

## Test
- `cmake --build build --target region_decode_bench`
- `-verify` passes byte-exact on the test image across all reduce levels and window sizes.
- Existing `cr_*` / `rr_*` suites unaffected (new target, no shared files beyond CMakeLists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GasbTWbL9gxerNrPGizXsh