### PR TITLE
fix(decoder): drain strip-prefetch tasks at the line-decode frame boundary

### DIFF
--- a/source/core/coding/coding_units.cpp
+++ b/source/core/coding/coding_units.cpp
@@ -3151,12 +3151,40 @@ void j2k_tile_component::pull_strip_advance(uint32_t count) {
 
 void j2k_tile_component::finalize_line_decode() {
   if (line_dec == nullptr) return;
+  j2k_tcomp_line_dec *ld = line_dec.get();
+
+#ifdef OPENHTJ2K_THREAD
+  // Drain all in-flight strip-prefetch tasks at the frame boundary.  Their
+  // htj2k_decode workers modDcup-mutate bytes borrowed directly from the
+  // codestream buffer (subband_row_buf borrow path); the next reuse frame's
+  // init() overwrites that same buffer, so a straggler left running across the
+  // boundary races it — corrupt tiles and nondeterministic "cleanup pass
+  // suffix length 4095 is invalid" warnings at threads >= 3.  The non-reuse
+  // path drains via free_resources() below, but the reuse path early-returns
+  // before that, so this must run for both.  Only ll0_buf and hl_bufs are
+  // initialised at every active level; lh/hh exist only for BIDIR levels
+  // (mirrors the free loop below) and draining an uninitialised buf would
+  // touch an indeterminate par_cnt.
+  {
+    j2k_subband_row_buf *hl = ld->hl_bufs.get();
+    j2k_subband_row_buf *lh = ld->lh_bufs.get();
+    j2k_subband_row_buf *hh = ld->hh_bufs.get();
+    ld->ll0_buf.drain_prefetch();
+    for (int32_t i = 0; i < ld->NL_active; ++i) {
+      hl[i].drain_prefetch();
+      if (access_resolution(static_cast<uint8_t>(i + 1))->transform_direction == DWT_BIDIR) {
+        lh[i].drain_prefetch();
+        hh[i].drain_prefetch();
+      }
+    }
+  }
+#endif
+
   // Single-tile reuse: skip teardown so init_line_decode on the next frame
   // can reuse every allocation.  The j2k_tile_component destructor clears
   // line_dec_persistent_ before calling us, so final cleanup still happens
   // when the tile_component itself is destroyed.
   if (line_dec_persistent_) return;
-  j2k_tcomp_line_dec *ld = line_dec.get();
 
   idwt_2d_state *states        = ld->states.get();
   idwt_level_src_ctx *ctxs     = ld->ctxs.get();

--- a/source/core/coding/subband_row_buf.cpp
+++ b/source/core/coding/subband_row_buf.cpp
@@ -164,11 +164,21 @@ void j2k_subband_row_buf::init(j2k_resolution *resolution, uint8_t b_idx,
 #endif
 }
 
+void j2k_subband_row_buf::drain_prefetch() {
+#ifdef OPENHTJ2K_THREAD
+  // spin_wait drains the queue by running pending tasks on the calling thread,
+  // so the in-flight htj2k_decode workers (which modDcup-mutate the borrowed
+  // codestream bytes) finish before the caller overwrites/frees that memory.
+  // A no-op when par_cnt is already 0.
+  spin_wait(par_cnt);
+  prefetch_y0 = prefetch_y1 = -1;
+#endif
+}
+
 void j2k_subband_row_buf::free_resources() {
 #ifdef OPENHTJ2K_THREAD
   // Drain any in-flight tasks before touching the scratch buffers.
-  spin_wait(par_cnt);
-  prefetch_y0 = prefetch_y1 = -1;
+  drain_prefetch();
   // Free combined allocation via its stable base pointer — ring_buf may have been
   // swapped with prefetch_buf and could be an interior pointer after prefetch hits.
   aligned_mem_free(combined_buf);

--- a/source/core/coding/subband_row_buf.hpp
+++ b/source/core/coding/subband_row_buf.hpp
@@ -152,6 +152,14 @@ struct j2k_subband_row_buf {
   // Release scratch buffers.
   void free_resources();
 
+  // Drain any in-flight strip-prefetch tasks (spin-wait on par_cnt) and clear
+  // the pending-prefetch cursor.  Their htj2k_decode workers modDcup-mutate
+  // bytes borrowed directly from the codestream buffer, so they MUST complete
+  // before that buffer is overwritten or freed.  free_resources() calls this;
+  // the single-tile reuse frame boundary (which bypasses free_resources) must
+  // call it too, or a straggler races the next frame's init() memcpy.
+  void drain_prefetch();
+
   // Return pointer into sb->i_samples for abs_row.
   // Decodes the containing codeblock strip if not yet decoded.
   const sprec_t *row_ptr(int32_t abs_row);


### PR DESCRIPTION
## Summary

Fixes a multi-threaded data race in the single-tile **reuse** decode path. Decoding the same stream repeatedly through the reuse path with **3+ threads** could nondeterministically corrupt tiles and print `WARNING: cleanup pass suffix length 4095 is invalid`.

## Root cause

1. A codeblock's `compressed_data` is a **zero-copy pointer borrowed directly into the codestream buffer** (`create_compressed_buffer`, the single-layer fast path).
2. HT cleanup decode **mutates those bytes in place** — `modDcup` writes `Dcup[Lcup-1]=0xFF; Dcup[Lcup-2]|=0x0F` (`ht_block_decoding.cpp`). `4095 = (0xFF<<4)+0xF` is exactly that post-mutation byte pattern, read back by a *later* decode.
3. The line-decode driver **prefetches the next strip's codeblocks as background pool tasks**. `free_resources()` drains them (`spin_wait(par_cnt)`) before releasing buffers — but the **reuse path skips `free_resources()`** to keep allocations, so it never drained.
4. A strip prefetched-but-not-consumed near the bottom of a coarser-resolution subband (consumed at half/quarter rate by the multi-level IDWT) left its `htj2k_decode` workers in flight **past the end of the frame**. The next frame's `init()` `memcpy` then overwrote the codestream buffer **while those workers were still reading / `modDcup`-mutating it**.

Single-thread (and 2-thread) decode was already clean: prefetch is disabled at `<= 1` thread, and the window only opens with enough workers to leave a straggler.

## Fix

Drain every subband row buffer's in-flight prefetch tasks at the frame boundary — in `finalize_line_decode()`, **before** the reuse early-return (and still via `free_resources()` on real teardown). The existing `spin_wait + cursor reset` is factored into `j2k_subband_row_buf::drain_prefetch()`. Drains `ll0_buf` + `hl_bufs` at every active level and `lh/hh` at BIDIR levels (the set of initialised row buffers, mirroring the teardown loop).

+49 / -3 lines.

## Verification (196 MP HTJ2K image, Ryzen 9950X)

- **ThreadSanitizer A/B:** **10 data races before → 0 after.** The reports pinpoint `init()` `memcpy` (`decoder.cpp`) racing `fwd_buf::read()` inside `ht_cleanup_decode`, dispatched from the prefetch task in `subband_row_buf.cpp`.
- **Functional symptom:** nondeterministic warnings at threads 3/4/8 before → **0 across 6 × (threads=8, iter=60)** stress runs after.
- **449/449** conformance + regression tests pass; region decode byte-exact vs an independent non-reuse decode.

Reproduces both native and WASM (the WASM `mt_simd` build shares this core). Found while benchmarking region decode for the OpenSeadragon evaluation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GasbTWbL9gxerNrPGizXsh