### PR TITLE
fix(decoder): byte-exact sub-range (col_range) IDWT at component boundaries

### DIFF
--- a/source/core/transform/idwt.cpp
+++ b/source/core/transform/idwt.cpp
@@ -28,6 +28,7 @@
 
 #include <cstring>
 #include <cmath>
+#include <cstdint>
 #include <utility>
 #include "dwt.hpp"
 #include "utils.hpp"
@@ -971,15 +972,17 @@ void idwt_1d_row_inplace_range(sprec_t *row, const int32_t left, const int32_t r
   }
   // Translate target row cols [col_lo, col_hi] → buffer positions.
   // X = row - left, so row col k lives at X[k - u0 + left].
-  // Widen by the filter support so the 4-pass (or 2-pass) lifter has valid
-  // neighbors at the target edges.
-  const int32_t widen = (transformation == 1) ? 2 : 4;
-  int32_t row_lo = col_lo - u0 - widen;
-  int32_t row_hi = col_hi - u0 - 1 + widen;  // inclusive row-col upper bound
-  if (row_lo < 0) row_lo = 0;
-  if (row_hi > width - 1) row_hi = width - 1;
-  const int32_t buf_lo = row_lo + left;
-  const int32_t buf_hi = row_hi + left;
+  // An interior window edge gets a finite `widen` margin of real neighbours so
+  // the lifter is byte-exact there.  But when the window edge is within `widen`
+  // of a COMPONENT boundary, the boundary PSE lifting is involved: clamping the
+  // pass to [0, width-1] would drop the PSE-region writes the full-width kernel
+  // makes, leaving the first/last ~2-3 columns wrong.  In that case run the
+  // pass to its natural extent (INT32_MIN/MAX make the kernel's clip resolve to
+  // the natural start/end, which writes into the row's PSE prefix/suffix slack
+  // exactly as the full-width kernel does).
+  const int32_t widen  = (transformation == 1) ? 2 : 4;
+  const int32_t buf_lo = (col_lo - widen < u0) ? INT32_MIN : (col_lo - u0 - widen + left);
+  const int32_t buf_hi = (col_hi + widen > u1) ? INT32_MAX : (col_hi - u0 - 1 + widen + left);
 
   sprec_t *X = row - left;
   if (transformation == 1) {


### PR DESCRIPTION
## Summary

The reuse-path sub-range horizontal IDWT (the column-range / JPIP-zoom decode) was not byte-exact with full-width decode when a window edge fell on a **component boundary** — which surfaced as the scalar build's `cr_ht_06_reuse` conformance failure.

`idwt_1d_row_inplace_range` clamped its lifting-pass range to `[0, width-1]`. At a component boundary (`col_lo == u0` or `col_hi == u1`) that dropped the PSE-region writes the full-width kernel makes, leaving the first/last ~2-3 output columns wrong; the per-level error then **compounded down the streaming-IDWT cascade**. Subsampled chroma was worst hit (its window clamps to the component edge at every level). Interior window edges, which keep a finite real-neighbour margin, were already exact.

**Fix:** at a component boundary, run the lifting pass to its natural extent (writing into the row's PSE prefix/suffix slack exactly as the full-width kernel does) instead of clamping; keep the finite margin only for interior edges. The change is in the shared scalar/interleave fallback that every ISA build uses for coarse DWT levels (`N < 16`), so it covers all ISAs.

## Verification

- **449/449** conformance on AVX2 and scalar (scalar previously failed `cr_ht_06_reuse`).
- Full-image decode is **byte-identical** (the full-width fast path is untouched; the change only affects an actual sub-range window).

## Deferred follow-ups

Two related improvements were prototyped and intentionally left out of this PR. They exposed a separate, **pre-existing** latent fault in the windowed-decode path that reproduces only on certain CI toolchains (GCC 13 / MSVC / AppleClang, non-deterministically) and not under local AddressSanitizer (pooled allocator disabled, so all buffers redzoned — decoder is memory-clean) or valgrind, so they need dedicated investigation:

- Wiring `set_col_range` to actually apply on the **non-reuse** line-based path (it is currently a silent no-op there, because it runs before `init_line_decode` builds the tree).
- Broader edge / narrow-window coverage in `col_range_compare`'s reuse probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaH1Ay9hPfnqfHsJ7wxh8M