### PR TITLE
Harden JPIP query and chunked-response parsing against malformed input

### DIFF
--- a/source/core/jpip/cache_model.cpp
+++ b/source/core/jpip/cache_model.cpp
@@ -12,6 +12,16 @@
 namespace open_htj2k {
 namespace jpip {
 
+// Upper bound on the number of data-bin operations a single apply() call may
+// perform.  A malformed range such as "P0-18446744073709551615" would
+// otherwise spin ~2^64 iterations, each inserting a map entry — unbounded
+// memory and CPU.  The cache model is advisory: under-applying it only makes
+// the server re-send data the client already holds (correct, just not
+// optimal), so stopping early is always safe.  The cap sits far above the
+// data-bin count of any realistic gigapixel session (~10^5–10^6) while
+// keeping worst-case memory bounded (~40 bytes per map entry).
+static constexpr uint64_t kMaxModelBinOps = 1u << 22;  // 4,194,304
+
 void CacheModel::mark(uint8_t class_id, uint64_t in_class_id) {
   bins_[key(class_id, in_class_id)].complete = true;
 }
@@ -156,6 +166,7 @@ void CacheModel::apply(const std::string &model_str) {
   // (memchr) are clamped to the token.
   const char *p         = model_str.c_str();
   const char *const end = p + model_str.size();
+  uint64_t budget       = kMaxModelBinOps;
   while (p < end) {
     const char *tok_end =
         static_cast<const char *>(std::memchr(p, ',', static_cast<size_t>(end - p)));
@@ -205,6 +216,8 @@ void CacheModel::apply(const std::string &model_str) {
     const bool partial     = (numend < tok_end && *numend == ':');
     if (partial) partial_bytes = std::strtoull(numend + 1, nullptr, 10);
     for (uint64_t id = start; id <= end_id; ++id) {
+      if (budget == 0) return;  // bin-operation budget spent — ignore the rest
+      --budget;
       if (subtractive) m.unmark(cls, id);
       else if (partial) m.mark_partial(cls, id, partial_bytes);
       else m.mark(cls, id);

--- a/source/core/jpip/jpip_request.cpp
+++ b/source/core/jpip/jpip_request.cpp
@@ -10,6 +10,13 @@ namespace jpip {
 
 namespace {
 
+// A codestream has at most 16384 components (Csiz range, ISO/IEC 15444-1
+// Table A.9), so a component selection can never name more than that many.
+// We cap the expanded `comps` list here so a tiny query such as
+// "comps=0-4294967295" (or a long run of repeated ranges) cannot expand
+// into a multi-billion-entry push loop — a memory/CPU DoS on the server.
+constexpr std::size_t kJpipMaxComponents = 16384;
+
 // Split "key=val" pairs from a '&'-delimited query string.  Calls fn
 // with each (key, val) pair; val may be empty.
 template <typename Fn>
@@ -125,6 +132,12 @@ RequestParseStatus parse_jpip_query(const std::string &query_in, JpipRequest *ou
             status = RequestParseStatus::MalformedField; return;
           }
           for (unsigned long v = lo; v <= hi; ++v) {
+            if (out->view_window.comps.size() >= kJpipMaxComponents) {
+              // More components named than can possibly exist — reject
+              // rather than keep expanding an attacker-controlled range.
+              status = RequestParseStatus::MalformedField;
+              return;
+            }
             out->view_window.comps.push_back(static_cast<uint16_t>(v));
           }
         }

--- a/source/core/jpip/jpip_response.cpp
+++ b/source/core/jpip/jpip_response.cpp
@@ -202,6 +202,9 @@ bool decode_chunked_body(const uint8_t *data, std::size_t len,
       else if (c >= 'a' && c <= 'f') v = 10 + (c - 'a');
       else if (c >= 'A' && c <= 'F') v = 10 + (c - 'A');
       else return false;
+      // Reject before the shift can drop high bits — an over-long hex size
+      // would otherwise wrap chunk_size around and defeat the bound check.
+      if (chunk_size > (SIZE_MAX >> 4)) return false;
       chunk_size = (chunk_size << 4) | static_cast<std::size_t>(v);
       any_digit = true;
     }
@@ -218,7 +221,12 @@ bool decode_chunked_body(const uint8_t *data, std::size_t len,
       }
       return false;
     }
-    if (i + chunk_size + 2 > len) return false;
+    // i <= len here (i = line_end + 2, and line_end + 1 < len was checked
+    // above), so `len - i` cannot underflow.  Comparing by subtraction
+    // avoids the `i + chunk_size + 2` overflow that would let a huge chunk
+    // size slip past the bound into an out-of-bounds read.  The `< 2` term
+    // reserves room for the chunk's trailing CRLF.
+    if (chunk_size > len - i || len - i - chunk_size < 2) return false;
     out->insert(out->end(), data + i, data + i + chunk_size);
     i += chunk_size;
     if (data[i] != '\r' || data[i + 1] != '\n') return false;

--- a/tests/tools/jpip_http_check/main.cpp
+++ b/tests/tools/jpip_http_check/main.cpp
@@ -250,6 +250,31 @@ int main() {
     CHECK(empty_out.empty(), "empty body decodes to empty vector");
   }
 
+  // ── decode_chunked_body rejects integer-overflowing chunk sizes ────────
+  {
+    std::vector<uint8_t> out;
+    // Chunk size = SIZE_MAX (sixteen hex F's).  The old `i + chunk_size + 2
+    // > len` bound check wrapped around and admitted a multi-exabyte
+    // out-of-bounds read; it must now be rejected.
+    const char *huge = "ffffffffffffffff\r\nABC\r\n0\r\n\r\n";
+    CHECK(!decode_chunked_body(reinterpret_cast<const uint8_t *>(huge),
+                               std::strlen(huge), &out),
+          "SIZE_MAX chunk size must be rejected, not over-read");
+    // More hex digits than fit in size_t — the accumulator itself would
+    // overflow; reject before the shift drops high bits.
+    const char *acc = "1ffffffffffffffff\r\nABC\r\n0\r\n\r\n";
+    CHECK(!decode_chunked_body(reinterpret_cast<const uint8_t *>(acc),
+                               std::strlen(acc), &out),
+          "over-long hex chunk size must be rejected");
+    // A representable size that simply exceeds the available bytes: says
+    // 0x100 (256) bytes but supplies two.  Still rejected by the new
+    // subtraction-based bound.
+    const char *toobig = "100\r\nAB\r\n0\r\n\r\n";
+    CHECK(!decode_chunked_body(reinterpret_cast<const uint8_t *>(toobig),
+                               std::strlen(toobig), &out),
+          "chunk size exceeding available bytes must be rejected");
+  }
+
   // ── Content-Length path unchanged by chunked additions ─────────────────
   {
     const uint8_t body[] = {0x11, 0x22};

--- a/tests/tools/jpip_session_check/main.cpp
+++ b/tests/tools/jpip_session_check/main.cpp
@@ -169,6 +169,16 @@ int main() {
           "descending range rejected");
     CHECK(parse_jpip_query("comps=x", &req) == RequestParseStatus::MalformedField,
           "non-numeric rejected");
+    // A range wider than the 16384-component maximum must be rejected, not
+    // expanded into a multi-billion-entry push loop (DoS).
+    CHECK(parse_jpip_query("comps=0-4294967295", &req) == RequestParseStatus::MalformedField,
+          "huge comps range rejected");
+    CHECK(parse_jpip_query("comps=0-16383", &req) == RequestParseStatus::Ok,
+          "full 16384-component range still accepted");
+    CHECK(req.view_window.comps.size() == 16384, "full range expands to 16384, got %zu",
+          req.view_window.comps.size());
+    CHECK(parse_jpip_query("comps=0-16384", &req) == RequestParseStatus::MalformedField,
+          "one past the component cap rejected");
   }
 
   // ── CacheModel: partial-bin qualifier + subtractive statements (§C.9.2) ─
@@ -209,6 +219,15 @@ int main() {
     CHECK(!m.has(kMsgClassPrecinct, 1), "apply subtractive");
     CHECK(m.has(kMsgClassPrecinct, 9), "apply additive");
     CHECK(m.has(kMsgClassPrecinct, 0), "prior state kept");
+
+    // A maximal range must not spin ~2^64 iterations: apply() stops at its
+    // bin-operation budget (kMaxModelBinOps = 1<<22) and returns with a
+    // bounded model.  Reaching this CHECK at all proves it terminated.
+    CacheModel big;
+    big.apply("P0-18446744073709551615");
+    CHECK(big.size() == (static_cast<std::size_t>(1) << 22),
+          "huge model range bounded to the budget, got %zu", big.size());
+    CHECK(big.has(kMsgClassPrecinct, 0), "low end of the range still applied");
   }
 
   // ── BinWindow: budget-blocked vs complete (empty metadata bin) ────────


### PR DESCRIPTION
Hardens three untrusted-input paths in the JPIP subsystem (Part 9). All three are reachable from a single small message; the fixes are bounds/overflow checks only — no protocol or wire-format change.

## Findings

### 1. `comps` range expansion — server-side DoS
`parse_jpip_query` expands a view-window component selection `comps=<lo>-<hi>` by pushing one `uint16_t` per index. `hi` is attacker-controlled up to `ULONG_MAX`, so `comps=0-4294967295` (≈20 bytes) drives a multi-billion-iteration push loop → memory/CPU exhaustion on the server. The 64 KB request-size cap does not help (a tiny query produces the huge expansion).

**Fix:** reject the field once the expanded list reaches **16384**, the maximum component count a codestream can have (Csiz, ISO/IEC 15444-1 Table A.9). A valid request never names more. (Also removes a latent `uint16_t` wraparound for indices ≥ 65536.)

### 2. `model` range expansion — server-side DoS
`CacheModel::apply` expands a client cache-model range `model=<class><lo>-<hi>` by marking one data-bin per id in a hash map. `end_id` is attacker-controlled up to `UINT64_MAX`, so `model=P0-18446744073709551615` is an effectively infinite loop, each iteration inserting a map entry.

**Fix:** bound a single `apply()` to **1<<22** data-bin operations. The cache model is advisory — under-applying it only makes the server re-send data the client already holds (correct, just not optimal) — so stopping early is always safe, and the cap sits far above the bin count of any realistic gigapixel session while keeping worst-case memory bounded.

### 3. `decode_chunked_body` integer overflow — client-side OOB read
The JPIP **client** decodes a server's HTTP/1.1 chunked response here. The hex chunk size was accumulated with no overflow guard, then bounded with `i + chunk_size + 2 > len`. A chunk size near `SIZE_MAX` makes that sum wrap to a small value, the check passes, and `out->insert(out->end(), data + i, data + i + chunk_size)` reads ≈`SIZE_MAX` bytes past the buffer — an out-of-bounds read driven by a malicious server.

**Fix:** reject the size before the accumulator shift can drop high bits, and replace the additive bound with an overflow-safe subtraction (`chunk_size > len - i || len - i - chunk_size < 2`; `i <= len` holds there, so `len - i` cannot underflow).

## Tests
- `jpip_session_check`: oversized/at-limit/over-limit `comps` ranges; maximal `model` range bounded to the budget.
- `jpip_http_check`: `SIZE_MAX` chunk size, accumulator-overflowing chunk size, and a representable over-buffer chunk size — all rejected. The `SIZE_MAX` case was verified to abort on the pre-fix code (`std::length_error` from the oversized insert), confirming the regression bites.

Full suite green locally: **460/460**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)