### PR TITLE
harden(decoder): fail fast when HT code-block decode reports malformed input

### DIFF
--- a/source/core/coding/subband_row_buf.cpp
+++ b/source/core/coding/subband_row_buf.cpp
@@ -337,10 +337,16 @@ void j2k_subband_row_buf::decode_strip_core(sprec_t *target_buf, int32_t y0, int
           return [blk, this]() {
             blk->dequant_i32 = this->dequant_i32;
             try {
-              if ((blk->Cmodes & HT) >> 6)
-                htj2k_decode(blk, ROIshift);
-              else
+              if ((blk->Cmodes & HT) >> 6) {
+                // htj2k_decode returns false (rather than throwing) when it
+                // rejects malformed input at a bounds/segment guard.  Treat that
+                // like a thrown error so the driver re-throws after the barrier
+                // instead of silently emitting a garbage (or uninitialised) block.
+                if (!htj2k_decode(blk, ROIshift))
+                  par_error.store(true, std::memory_order_relaxed);
+              } else {
                 j2k_decode(blk, ROIshift);
+              }
             } catch (...) {
               // Never let a decode error escape the task: it would std::terminate
               // the pool worker or unwind through try_run_one.  Record it; the
@@ -449,10 +455,17 @@ void j2k_subband_row_buf::decode_strip_core(sprec_t *target_buf, int32_t y0, int
         }
 
         block->dequant_i32 = this->dequant_i32;
-        if ((block->Cmodes & HT) >> 6)
-          htj2k_decode(block, ROIshift);
-        else
+        if ((block->Cmodes & HT) >> 6) {
+          // A false return means htj2k_decode rejected malformed input at a
+          // bounds/segment guard; fail fast like the threaded path (and like
+          // j2k_decode, which throws) rather than continue with a garbage block.
+          if (!htj2k_decode(block, ROIshift)) {
+            printf("ERROR: HT code-block decoding reported failure — malformed input.\n");
+            throw std::exception();
+          }
+        } else {
           j2k_decode(block, ROIshift);
+        }
       }
     }
   }
@@ -694,10 +707,14 @@ void j2k_subband_row_buf::trigger_prefetch(int32_t next_y0) {
     return [blk, this]() {
       blk->dequant_i32 = this->dequant_i32;
       try {
-        if ((blk->Cmodes & HT) >> 6)
-          htj2k_decode(blk, ROIshift);
-        else
+        if ((blk->Cmodes & HT) >> 6) {
+          // A false return is htj2k_decode's non-throwing malformed-input signal;
+          // record it like a thrown error so the prefetch-consume barrier re-throws.
+          if (!htj2k_decode(blk, ROIshift))
+            par_error.store(true, std::memory_order_relaxed);
+        } else {
           j2k_decode(blk, ROIshift);
+        }
       } catch (...) {
         // See decode_strip_core: record decode errors instead of throwing out of
         // the task; the prefetch-consume barrier (row_ptr) re-throws on the driver.

--- a/tests/security_regressions.cmake
+++ b/tests/security_regressions.cmake
@@ -25,17 +25,46 @@ set(_SEC_CRASH_RE
 # (SANGMYUNG UNIVERSITY, @5asever40-a11y).
 # SHA-256: da756e7aa7421e1207b92b7651996ed4b328edb820bd30cdb5f4af953d1eb063
 #
-# Assertion model: codeblock-level decode failures are logged as
-# warnings and do NOT propagate to the decoder's top-level exit
-# code, so we can't rely on WILL_FAIL.  Instead, require that the
-# specific guard printf from the patched code path fires (proof the
-# bounds check is in effect) and reject any crash-marker text.
+# The fixture is a grab-bag of several malformed code-blocks, each of which
+# trips a different htj2k_decode bounds/segment guard (the >4-segment stack
+# write among them).  Those guards return false rather than throwing; the
+# streaming decoder used to ignore that return and keep decoding, so a
+# malformed block silently produced a garbage (or uninitialised) plane while
+# the process exited 0.  The decoder now treats a false return like a thrown
+# error and fails fast at the first rejected block: the serial path throws from
+# decode_strip_core and the threaded path records par_error and re-throws at the
+# strip barrier.  These are scalar prologue guards, so the propagation is
+# platform-independent (not arch-gated).
+#
+# Assertion model: the CLI catches the decode exception and still exits 0, so
+# WILL_FAIL is not usable; instead require the fail-fast propagation message
+# (which appears only once the false return is honoured — a reverted fix prints
+# neither) and reject any crash marker.  The FAIL regex is the load-bearing
+# security assertion — the reported PoC must never stack-smash — and it holds
+# because the block is now rejected instead of decoded.
 add_test(NAME security_ht_segments_overflow
          COMMAND open_htj2k_dec
                  -i ${SECURITY_DATA_DIR}/security_ht_segments_overflow.j2k
-                 -o security_ht_segments_overflow.pgx)
+                 -o security_ht_segments_overflow.pgx
+                 -num_threads 1)
 set_tests_properties(security_ht_segments_overflow PROPERTIES
-    PASS_REGULAR_EXPRESSION "too many HT coding-pass segments"
+    PASS_REGULAR_EXPRESSION "HT code-block decoding reported failure"
+    FAIL_REGULAR_EXPRESSION "${_SEC_CRASH_RE}"
+    TIMEOUT 60)
+
+# Threaded counterpart: the same fixture under -num_threads 4 exercises the
+# pool-worker path, where a code-block decode failure is recorded as par_error
+# and re-thrown at the completion barrier (decode_strip_core / trigger_prefetch)
+# rather than thrown inline.  A tiny image may still fall back to the serial
+# decode, so the PASS regex accepts either the barrier message or the inline
+# throw; either way a reverted fix prints neither and the test fails.
+add_test(NAME security_ht_segments_overflow_mt
+         COMMAND open_htj2k_dec
+                 -i ${SECURITY_DATA_DIR}/security_ht_segments_overflow.j2k
+                 -o security_ht_segments_overflow_mt.pgx
+                 -num_threads 4)
+set_tests_properties(security_ht_segments_overflow_mt PROPERTIES
+    PASS_REGULAR_EXPRESSION "code-block decode task failed|HT code-block decoding reported failure"
     FAIL_REGULAR_EXPRESSION "${_SEC_CRASH_RE}"
     TIMEOUT 60)
 


### PR DESCRIPTION
## Summary

The HT block decoder, `htj2k_decode`, returns `false` (rather than throwing) when it rejects malformed input at one of its prologue guards — the `>4`-segment stack-write guard and the `Lcup`/`Lref` code-block-length bounds added by the recent hardening pass among them. The line-based streaming decoder **discarded that return value at all three call sites** in `subband_row_buf.cpp`. So after a guard fired specifically to prevent an out-of-bounds access, the decode simply continued, emitting a garbage (or uninitialised) plane while the process still exited 0.

Only the *throwing* malformed-input paths (e.g. the AVX2 MagSgn over-read) were being propagated to the caller; the *non-throwing* return-`false` paths were not. Half the guards the decoder already has were effectively mute — they stopped the OOB but left the caller none the wiser.

## Fix

Honour the return value, mirroring how a thrown decode error is already handled:

- **Two pool-worker sites** (`decode_strip_core` threaded dispatch and `trigger_prefetch`) record `par_error`, so the driver re-throws at the completion barrier — the same mechanism already used for thrown errors.
- **The serial site** throws inline (`printf` + `throw`), matching the codebase's marker-error convention.

This unifies the two malformed-input signalling paths (throw vs. return-`false`) into one fail-fast behaviour, and gives library API consumers (JPIP, RTP, WASM, OpenSeadragon) a catchable exception instead of silent garbage. `j2k_decode` (the MQ/Part-1 path) already returns `void` and throws, so it is unchanged.

## Why it's safe

- The guards live in the scalar prologue shared by every SIMD variant (scalar/AVX2/NEON/WASM), so the propagation is platform-independent — **not arch-gated**.
- No conforming stream trips a guard: on a valid code-block `Lcup + Lref == block->length` exactly, so the bounds never fire. The full conformance, encoder round-trip, JPIP, WASM and line-based suites are unaffected (463/463 pass; the change touches exactly one pre-existing test — see below).

## Tests

`security_ht_segments_overflow` (the reported HT stack-overflow PoC) is a grab-bag of several malformed code-blocks. It previously passed by matching a warning printed by a *later* block that the continue-on-error behaviour walked to. With fail-fast the decode aborts at the *first* rejected block, so:

- the test now asserts the fail-fast **propagation** message (which appears only once the `false` return is honoured — a reverted fix prints neither message and the test fails), and
- a threaded counterpart (`_mt`) was added to exercise the pool-worker `par_error` path.

Its load-bearing `FAIL` regex — the PoC must never stack-smash — is unchanged and still holds, because the block is now *rejected* rather than *decoded*. Verified by reverting only the source fix (keeping the new tests): both tests fail on the missing propagation message, with no crash marker, i.e. they reproduce exactly the silent-continue behaviour this PR removes.

## Threat model

Not a memory-safety fix in itself — the underlying OOB was already closed by the guards this completes the wiring for. It converts *silently-wrong output on malformed input* into a *clean, catchable decode failure*, which is the robustness contract the rest of the hardening pass established for the decoder's public API.